### PR TITLE
Move connectors logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 # Pin the version of bundle we support
 gem 'bundler', '2.2.29'
 
+gem 'activesupport', '5.2.6'
+
 group :test do
   gem 'rspec-core', '~> 3.10.1'
   gem 'rspec-collection_matchers', '~> 1.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.1.9)
     diff-lcs (1.5.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    minitest (5.15.0)
     rspec-collection_matchers (1.2.0)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.10.2)
@@ -12,11 +21,15 @@ GEM
     rspec-support (3.10.3)
     rspec_junit_formatter (0.5.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    thread_safe (0.3.6-java)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   universal-java-11
 
 DEPENDENCIES
+  activesupport (= 5.2.6)
   bundler (= 2.2.29)
   rspec-collection_matchers (~> 1.2.0)
   rspec-core (~> 3.10.1)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Connectors
 The new home of Elastic Connectors
 
+### System Requirements
+- java 11
+- jruby (see [.ruby-version](.ruby-version))
+- bundler 2.2.29
+
+### Setup
+1. `bundle install`
 
 ### Building
 run `./mvnw clean install`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sometimes, you may care less about testing all of the pieces of the project, or 
 and its tests. In these instances, you can run just rspec tests for your ruby files.
 
 ```shell
-./mvnw clean exec:exec@test-ruby -pl hello-world-connector
+./mvnw dependency:build-classpath@mvn-classpath exec:exec@test-ruby -pl hello-world-connector
 ```
 
 ### Project Structure

--- a/connectors-api/pom.xml
+++ b/connectors-api/pom.xml
@@ -24,6 +24,12 @@
             <groupId>org.jruby</groupId>
             <artifactId>jruby-complete</artifactId>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.connectors</groupId>
+            <artifactId>connectors-stubs</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/connectors-api/src/main/ruby/connectors_logger.rb
+++ b/connectors-api/src/main/ruby/connectors_logger.rb
@@ -5,10 +5,11 @@
 #
 
 require 'java'
+require 'app_config' unless defined?(Rails)
 
 java_package 'co.elastic.connectors.api'
 
-class Logger
+class ConnectorsLogger
   SUPPORTED_LOG_LEVELS = %i[fatal error warn info debug].freeze
 
   class << self

--- a/connectors-api/src/main/ruby/connectors_logger.rb
+++ b/connectors-api/src/main/ruby/connectors_logger.rb
@@ -1,0 +1,32 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+require 'java'
+
+java_package 'co.elastic.connectors.api'
+
+class Logger
+  SUPPORTED_LOG_LEVELS = %i[fatal error warn info debug].freeze
+
+  class << self
+
+    delegate :formatter, :formatter=, :to => :logger
+
+    def setup!(logger)
+      @logger = logger
+    end
+
+    def logger
+      @logger ||= AppConfig.connectors_logger
+    end
+
+    SUPPORTED_LOG_LEVELS.each do |level|
+      define_method(level) do |message|
+        @logger.public_send(level, message)
+      end
+    end
+  end
+end

--- a/connectors-api/src/main/ruby/connectors_logger.rb
+++ b/connectors-api/src/main/ruby/connectors_logger.rb
@@ -6,6 +6,7 @@
 
 require 'java'
 require 'app_config' unless defined?(Rails)
+require 'active_support/core_ext/module'
 
 java_package 'co.elastic.connectors.api'
 
@@ -26,7 +27,7 @@ class ConnectorsLogger
 
     SUPPORTED_LOG_LEVELS.each do |level|
       define_method(level) do |message|
-        @logger.public_send(level, message)
+        logger.public_send(level, message)
       end
     end
   end

--- a/connectors-api/src/test/ruby/connectors_logger_test.rb
+++ b/connectors-api/src/test/ruby/connectors_logger_test.rb
@@ -1,0 +1,15 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+require_relative '../../main/ruby/connectors_logger'
+
+RSpec.describe ConnectorsLogger do
+  let(:message) { 'this is a test message' }
+
+  it "can give the connectors logger" do
+    expect { ConnectorsLogger.info(message) }.to output(/#{message}/).to_stdout_from_any_process
+  end
+end

--- a/connectors-stubs/NOTICE.txt
+++ b/connectors-stubs/NOTICE.txt
@@ -1,0 +1,9 @@
+connectors-stubs
+Copyright 2012-2018 Elasticsearch B.V.
+This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
+
+===============================================
+Third party libraries used by connectors-stubs:
+===============================================
+
+

--- a/connectors-stubs/NOTICE.txt.template
+++ b/connectors-stubs/NOTICE.txt.template
@@ -1,0 +1,9 @@
+connectors-stubs
+Copyright 2012-2018 Elasticsearch B.V.
+This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
+
+===============================================
+Third party libraries used by connectors-stubs:
+===============================================
+
+#GENERATED_NOTICES#

--- a/connectors-stubs/pom.xml
+++ b/connectors-stubs/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>connectors</artifactId>
+        <groupId>co.elastic.connectors</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>connectors-stubs</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <top.basedir>${project.parent.basedir}</top.basedir>
+    </properties>
+
+    <dependencies>
+
+        <!-- provided dependencies -->
+        <dependency>
+            <groupId>org.jruby</groupId>
+            <artifactId>jruby-complete</artifactId>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>de.saumya.mojo</groupId>
+                <artifactId>gem-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/connectors-stubs/src/main/resources/META-INF/NOTICE.txt
+++ b/connectors-stubs/src/main/resources/META-INF/NOTICE.txt
@@ -1,0 +1,9 @@
+connectors-stubs
+Copyright 2012-2018 Elasticsearch B.V.
+This product includes software developed by The Apache Software Foundation (http://www.apache.org/).
+
+===============================================
+Third party libraries used by connectors-stubs:
+===============================================
+
+

--- a/connectors-stubs/src/main/ruby/app_config.rb
+++ b/connectors-stubs/src/main/ruby/app_config.rb
@@ -1,0 +1,13 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+require 'logger'
+
+class AppConfig
+  def connectors_logger
+    Logger.new(STDOUT)
+  end
+end

--- a/connectors-stubs/src/main/ruby/app_config.rb
+++ b/connectors-stubs/src/main/ruby/app_config.rb
@@ -5,9 +5,11 @@
 #
 
 require 'logger'
+require 'java'
 
+java_package 'co.elastic.connectors.stubs'
 class AppConfig
-  def connectors_logger
+  def self.connectors_logger
     Logger.new(STDOUT)
   end
 end

--- a/connectors-stubs/src/test/ruby/app_config_test.rb
+++ b/connectors-stubs/src/test/ruby/app_config_test.rb
@@ -1,0 +1,15 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+require_relative '../../main/ruby/app_config'
+
+RSpec.describe AppConfig do
+  let(:message) { 'this is a test message' }
+
+  it "can give the connectors logger" do
+    expect { AppConfig.connectors_logger.info { message } }.to output(/#{message}/).to_stdout_from_any_process
+  end
+end

--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,6 @@
                 <version>1.8.0</version>
                 <type>gem</type>
             </dependency>
-            <dependency>
-                <groupId>rubygems</groupId>
-                <artifactId>activesupport</artifactId>
-                <version>5.2.6</version>
-                <type>gem</type>
-            </dependency>
 
             <!-- provided -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <version>1.0.0-SNAPSHOT</version>
     <modules>
         <module>hello-world-connector</module>
+        <module>connectors-stubs</module>
         <module>connectors-api</module>
         <module>example-consumer</module>
     </modules>
@@ -71,6 +72,12 @@
                 <groupId>rubygems</groupId>
                 <artifactId>awesome_print</artifactId>
                 <version>1.8.0</version>
+                <type>gem</type>
+            </dependency>
+            <dependency>
+                <groupId>rubygems</groupId>
+                <artifactId>activesupport</artifactId>
+                <version>5.2.6</version>
                 <type>gem</type>
             </dependency>
 
@@ -148,6 +155,9 @@
                                     <argument>--out</argument>
                                     <argument>${project.build.directory}/surefire-reports/rspec.xml</argument>
                                 </arguments>
+                                <environmentVariables>
+                                    <RSPEC_JAVA_CLASSPATH>${maven.compile.classpath}</RSPEC_JAVA_CLASSPATH>
+                                </environmentVariables>
                             </configuration>
                         </execution>
                     </executions>
@@ -227,6 +237,24 @@
                                         </includes>
                                     </resource>
                                 </resources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <executions>
+                        <execution>
+                            <id>mvn-classpath</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>build-classpath</goal>
+                            </goals>
+                            <configuration>
+                                <outputProperty>maven.compile.classpath</outputProperty>
+                                <pathSeparator>;</pathSeparator>
                             </configuration>
                         </execution>
                     </executions>
@@ -356,6 +384,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>

--- a/script/rspec
+++ b/script/rspec
@@ -8,6 +8,12 @@
 # The application 'rspec' is installed as part of a gem, and
 # this file is here to facilitate running it.
 #
+include Java
+if ENV['RSPEC_JAVA_CLASSPATH']
+  classpath = ENV['RSPEC_JAVA_CLASSPATH'].split(';').map { |path| "file:#{path}" }
+  classpath.each { |path| $CLASSPATH << path }
+end
+
 require 'pathname'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
                                            Pathname.new(__FILE__).realpath)


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/1294

This adds the main connectors logger class to our connectors-api module.
It also adds a stub `AppConfig` class