### PR TITLE
Add ConnectorNotAvailable Error - used by External Connector Framework

### DIFF
--- a/connectors-api/src/main/ruby/connectors_errors.rb
+++ b/connectors-api/src/main/ruby/connectors_errors.rb
@@ -92,4 +92,4 @@ class JobCannotBeUpdatedError < StandardError; end
 class SecretInvalidError < StandardError; end
 class InvalidIndexingConfigurationError < StandardError; end
 class TokenRefreshFailedError < StandardError; end
-class ThirdPartyNotAvailableError < StandardError; end
+class ConnectorNotAvailableError < StandardError; end

--- a/connectors-api/src/main/ruby/connectors_errors.rb
+++ b/connectors-api/src/main/ruby/connectors_errors.rb
@@ -92,3 +92,4 @@ class JobCannotBeUpdatedError < StandardError; end
 class SecretInvalidError < StandardError; end
 class InvalidIndexingConfigurationError < StandardError; end
 class TokenRefreshFailedError < StandardError; end
+class ThirdPartyNotAvailableError < StandardError; end


### PR DESCRIPTION
Issue for discussion.

The error added in this PR is the error that is specific to the Enterprise Search handling of connectors - it does not get thrown by any connector.

However, `connectors_errors` file contains some errors that are framework specific, as I saw.

Question: should these errors (such as `JobClaimingError`, `JobCannotBeUpdatedError`) be moved back to Enterprise Search along with ConnectorNotAvailableError?