### PR TITLE
move connectors exceptionhandling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'bundler', '2.2.29'
 
 gem 'activesupport', '5.2.6'
+gem 'bson', '~> 4.2.2'
 
 group :test do
   gem 'rspec-core', '~> 3.10.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    bson (4.2.2-java)
     concurrent-ruby (1.1.9)
     diff-lcs (1.5.0)
     i18n (0.9.5)
@@ -30,6 +31,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (= 5.2.6)
+  bson (~> 4.2.2)
   bundler (= 2.2.29)
   rspec-collection_matchers (~> 1.2.0)
   rspec-core (~> 3.10.1)

--- a/connectors-api/src/main/ruby/connectors_exception_tracking.rb
+++ b/connectors-api/src/main/ruby/connectors_exception_tracking.rb
@@ -1,0 +1,41 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+
+# frozen_string_literal: true
+
+require 'swiftype_exception_tracking' unless defined?(Rails)
+require 'bson'
+require_relative './connectors_logger'
+
+java_package 'co.elastic.connectors.api'
+
+class ConnectorsExceptionTracking
+  class << self
+    def capture_message(message, context = {})
+      Swiftype::ExceptionTracking.capture_message(message, context)
+    end
+
+    def capture_exception(exception, context = {})
+      Swiftype::ExceptionTracking.log_exception(exception, :context => context)
+    end
+
+    def log_exception(exception, message = nil)
+      Swiftype::ExceptionTracking.log_exception(exception, message, :logger => ConnectorsLogger.logger)
+    end
+
+    def augment_exception(exception)
+      unless exception.respond_to?(:id)
+        exception.instance_eval do
+          def id
+            @error_id ||= BSON::ObjectId.new.to_s
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/connectors-api/src/test/ruby/connectors_exception_tracking_test.rb
+++ b/connectors-api/src/test/ruby/connectors_exception_tracking_test.rb
@@ -1,0 +1,16 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+require_relative '../../main/ruby/connectors_exception_tracking'
+
+RSpec.describe ConnectorsExceptionTracking do
+  let(:message) { 'this is a test message' }
+  let(:exception) { StandardError.new(message) }
+
+  it "can log an exception" do
+    expect { ConnectorsExceptionTracking.log_exception(exception) }.to output(/#{message}/).to_stdout_from_any_process
+  end
+end

--- a/connectors-stubs/NOTICE.txt
+++ b/connectors-stubs/NOTICE.txt
@@ -6,4 +6,11 @@ This product includes software developed by The Apache Software Foundation (http
 Third party libraries used by connectors-stubs:
 ===============================================
 
+  A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. under MIT License
+  Daylight savings aware timezone library under MIT License
+  minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking under MIT License
+  Modern concurrency tools for Ruby. Inspired by Erlang, Clojure, Scala, Haskell, F#, C#, Java, and classic concurrency patterns. under MIT License
+  New wave Internationalization support for Ruby under MIT License
+  Ruby Implementation of the BSON specification under Apache License Version 2.0
+  Thread-safe collections and utilities for Ruby under Apache-2.0
 

--- a/connectors-stubs/pom.xml
+++ b/connectors-stubs/pom.xml
@@ -18,6 +18,16 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>rubygems</groupId>
+            <artifactId>bson</artifactId>
+            <type>gem</type>
+        </dependency>
+        <dependency>
+            <groupId>rubygems</groupId>
+            <artifactId>activesupport</artifactId>
+            <type>gem</type>
+        </dependency>
 
         <!-- provided dependencies -->
         <dependency>

--- a/connectors-stubs/src/main/resources/META-INF/NOTICE.txt
+++ b/connectors-stubs/src/main/resources/META-INF/NOTICE.txt
@@ -6,4 +6,11 @@ This product includes software developed by The Apache Software Foundation (http
 Third party libraries used by connectors-stubs:
 ===============================================
 
+  A toolkit of support libraries and Ruby core extensions extracted from the Rails framework. under MIT License
+  Daylight savings aware timezone library under MIT License
+  minitest provides a complete suite of testing facilities supporting TDD, BDD, mocking, and benchmarking under MIT License
+  Modern concurrency tools for Ruby. Inspired by Erlang, Clojure, Scala, Haskell, F#, C#, Java, and classic concurrency patterns. under MIT License
+  New wave Internationalization support for Ruby under MIT License
+  Ruby Implementation of the BSON specification under Apache License Version 2.0
+  Thread-safe collections and utilities for Ruby under Apache-2.0
 

--- a/connectors-stubs/src/main/ruby/swiftype_exception_tracking.rb
+++ b/connectors-stubs/src/main/ruby/swiftype_exception_tracking.rb
@@ -1,0 +1,35 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+module Swiftype
+  # empty
+end
+class Swiftype::ExceptionTracking
+
+  def self.capture_message(message, context = {})
+    AppConfig.connectors_logger.error { "Error: #{message}. Context: #{context.inspect}" }
+
+    # When the method is called from a rescue block, our return value may leak outside of its
+    # intended scope, so let's explicitly return nil here to be safe.
+    nil
+  end
+
+  def self.log_exception(exception, message = nil, context: nil, logger: AppConfig.connectors_logger)
+    logger.error { message } if message
+    logger.error { generate_stack_trace(exception) }
+    logger.error { "Context: #{context.inspect}" } if context
+  end
+
+  def self.generate_stack_trace(exception)
+    full_message = exception.full_message
+
+    cause = exception
+    while cause.cause != cause && (cause = cause.cause)
+      full_message << "Cause:\n#{cause.full_message}"
+    end
+
+    full_message.dup.force_encoding('UTF-8')
+  end
+end

--- a/connectors-stubs/src/test/ruby/swiftype_exception_tracking_test.rb
+++ b/connectors-stubs/src/test/ruby/swiftype_exception_tracking_test.rb
@@ -1,0 +1,20 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+require_relative '../../main/ruby/swiftype_exception_tracking'
+
+RSpec.describe Swiftype::ExceptionTracking do
+  let(:message) { 'this is a test message' }
+  let(:exception) { StandardError.new(message) }
+
+  it "can capture messages" do
+    expect { Swiftype::ExceptionTracking.capture_message(message) }.to output(/#{message}/).to_stdout_from_any_process
+  end
+
+  it "can can log exceptions" do
+    expect { Swiftype::ExceptionTracking.log_exception(exception, message) }.to output(/StandardError/).to_stdout_from_any_process
+  end
+end

--- a/example-consumer/pom.xml
+++ b/example-consumer/pom.xml
@@ -28,6 +28,12 @@
             <groupId>org.jruby</groupId>
             <artifactId>jruby-complete</artifactId>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.connectors</groupId>
+            <artifactId>connectors-stubs</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/example-consumer/src/test/java/co/elastic/connectors/example/consumer/ExampleConsumerTest.groovy
+++ b/example-consumer/src/test/java/co/elastic/connectors/example/consumer/ExampleConsumerTest.groovy
@@ -33,11 +33,11 @@ class ExampleConsumerTest extends Specification {
         then:
         1==1
 
-        when: "active_support"
-        runtime.executeScript("require 'active_support'", 'foo.rb') // not transitively included
+        when: "nokogiri"
+        runtime.executeScript("require 'nokogiri'", 'foo.rb') // not transitively included
 
         then:
         LoadError e = thrown(LoadError)
-        e.message.contains("no such file to load -- active_support")
+        e.message.contains("no such file to load -- nokogiri")
     }
 }

--- a/hello-world-connector/pom.xml
+++ b/hello-world-connector/pom.xml
@@ -33,6 +33,12 @@
             <groupId>org.jruby</groupId>
             <artifactId>jruby-complete</artifactId>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.connectors</groupId>
+            <artifactId>connectors-stubs</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/hello-world-connector/src/main/ruby/hello_world.rb
+++ b/hello-world-connector/src/main/ruby/hello_world.rb
@@ -8,6 +8,7 @@ require 'java'
 require 'awesome_print'
 java_import 'co.elastic.connectors.api.Connector'
 java_import 'java.util.List'
+require 'connectors_exception_tracking'
 
 java_package 'co.elastic.connectors.hello.world'
 class HelloWorld
@@ -28,6 +29,9 @@ class HelloWorld
 
   def do_risky_thing
     do_risky_thing_helper
+  rescue StandardError => e
+    ConnectorsExceptionTracking.log_exception(e)
+    raise
   end
 
   def do_risky_thing_helper

--- a/hello-world-connector/src/test/java/co/elastic/connectors/hello/world/HelloWorldTest.groovy
+++ b/hello-world-connector/src/test/java/co/elastic/connectors/hello/world/HelloWorldTest.groovy
@@ -31,6 +31,7 @@ class HelloWorldTest extends Specification {
 
         then:
         Exception e = thrown()
+        e.message.contains("Oh dear, an error")
         e.printStackTrace()
     }
 

--- a/license-mappings.xml
+++ b/license-mappings.xml
@@ -7,4 +7,34 @@
         <version>1.8.0</version>
         <license>MIT License</license>
     </artifact>
+    <artifact>
+        <groupId>rubygems</groupId>
+        <artifactId>activesupport</artifactId>
+        <version>5.2.6</version>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>rubygems</groupId>
+        <artifactId>concurrent-ruby</artifactId>
+        <version>1.1.9</version>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>rubygems</groupId>
+        <artifactId>i18n</artifactId>
+        <version>1.10.0</version>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>rubygems</groupId>
+        <artifactId>minitest</artifactId>
+        <version>5.15.0</version>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>rubygems</groupId>
+        <artifactId>tzinfo</artifactId>
+        <version>1.2.9</version>
+        <license>MIT License</license>
+    </artifact>
 </license-lookup>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
                                 <environmentVariables>
                                     <RSPEC_JAVA_CLASSPATH>${maven.compile.classpath}</RSPEC_JAVA_CLASSPATH>
                                 </environmentVariables>
+                                <skip>${skipTests}</skip>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,18 @@
                 <version>1.8.0</version>
                 <type>gem</type>
             </dependency>
+            <dependency>
+                <groupId>rubygems</groupId>
+                <artifactId>bson</artifactId>
+                <version>4.2.2</version>
+                <type>gem</type>
+            </dependency>
+            <dependency>
+                <groupId>rubygems</groupId>
+                <artifactId>activesupport</artifactId>
+                <version>5.2.6</version>
+                <type>gem</type>
+            </dependency>
 
             <!-- provided -->
             <dependency>


### PR DESCRIPTION
## part of https://github.com/elastic/enterprise-search-team/issues/1294

- moves Connectors::ConnectorsAPI::ExceptionTracking to ConnectorsExceptiontracking
- ensures that multiple layers of dependencies resolve correctly