### PR TITLE
Add InvalidTokenError

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -41,7 +41,7 @@ class ConnectorsWebApp < Sinatra::Base
     err = case e
           when ConnectorsShared::ClientError
             ConnectorsShared::Error.new(400, 'BAD_REQUEST', e.message)
-          when ConnectorsShared::SecretInvalidError
+          when ConnectorsShared::InvalidTokenError
             ConnectorsShared::INVALID_ACCESS_TOKEN
           when ConnectorsShared::TokenRefreshFailedError
             ConnectorsShared::TOKEN_REFRESH_ERROR

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -56,7 +56,7 @@ module ConnectorsSdk
 
         results
       rescue ConnectorsSdk::Office365::CustomClient::ClientError => e
-        raise e.status_code == 401 ? ConnectorsShared::SecretInvalidError : e
+        raise e.status_code == 401 ? ConnectorsShared::InvalidTokenError : e
       end
 
       def cursors
@@ -70,7 +70,7 @@ module ConnectorsSdk
         end
         results
       rescue ConnectorsSdk::Office365::CustomClient::ClientError => e
-        raise e.status_code == 401 ? ConnectorsShared::SecretInvalidError : e
+        raise e.status_code == 401 ? ConnectorsShared::InvalidTokenError : e
       end
 
       def permissions(params)
@@ -78,7 +78,7 @@ module ConnectorsSdk
           return permissions
         end
       rescue ConnectorsSdk::Office365::CustomClient::ClientError => e
-        raise e.status_code == 401 ? ConnectorsShared::SecretInvalidError : e
+        raise e.status_code == 401 ? ConnectorsShared::InvalidTokenError : e
       end
 
       def authorization_uri(body)

--- a/lib/connectors_shared/errors.rb
+++ b/lib/connectors_shared/errors.rb
@@ -86,6 +86,7 @@ module ConnectorsShared
   class JobCannotBeUpdatedError < StandardError; end
   class SecretInvalidError < StandardError; end
   class InvalidIndexingConfigurationError < StandardError; end
+  class InvalidTokenError < StandardError; end
   class TokenRefreshFailedError < StandardError; end
   class ConnectorNotAvailableError < StandardError; end
 


### PR DESCRIPTION
Introduce a new error class `ConnectorsShared::InvalidTokenError`. The error `ConnectorsShared::SecretInvalidError` was introduced by GitHub Apps and should only be used by GitHub Apps.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
