### PR TITLE
handle non-zero cp code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install:
 	rbenv install -s
 	- gem install bundler -v 2.2.33
 	bundle install --jobs 1
-	cp -n config/connectors.yml.example config/connectors.yml
+	cp -n config/connectors.yml.example config/connectors.yml || true
 
 run:
 	${YQ} e ".revision = \"$(shell git rev-parse HEAD)\"" -i config/connectors.yml


### PR DESCRIPTION
Tiny fix. Turns out `cp -n` ("no clobber") will return a `1` exit code if there was a file there that would have otherwise been clobbered 🤨