### PR TITLE
Return cursors at the end of extraction

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -90,21 +90,14 @@ class ConnectorsWebApp < Sinatra::Base
   end
 
   post '/documents' do
-    original_cursors = (body_params.fetch(:cursors, {}) || {}).as_json
-
     connector = settings.connector
 
     results = connector.document_batch(body_params)
 
-    new_cursors = if connector.cursors.as_json != original_cursors
-                    connector.cursors
-                  else
-                    {}
-                  end
-
     json(
       :results => results,
-      :cursors => new_cursors
+      :cursors => connector.cursors,
+      :completed => connector.completed?
     )
   end
 

--- a/lib/connectors_sdk/base/extractor.rb
+++ b/lib/connectors_sdk/base/extractor.rb
@@ -30,7 +30,7 @@ module ConnectorsSdk
         ]
       )
 
-      attr_reader :content_source_id, :config, :features, :original_cursors, :service_type
+      attr_reader :content_source_id, :config, :features, :original_cursors, :service_type, :completed
       attr_accessor :monitor, :client_proc
 
       def initialize(content_source_id:,
@@ -48,6 +48,7 @@ module ConnectorsSdk
         @authorization_data_proc = authorization_data_proc
         @original_cursors = config.cursors.deep_dup
         @monitor = monitor
+        @completed = false
       end
 
       def authorization_data!

--- a/lib/connectors_sdk/office365/config.rb
+++ b/lib/connectors_sdk/office365/config.rb
@@ -17,6 +17,7 @@ module ConnectorsSdk
 
       def initialize(drive_ids:, cursors:, index_permissions: false)
         super(:cursors => cursors)
+        @cursors[ConnectorsSdk::Office365::Extractor::DRIVE_IDS_CURSOR_KEY] ||= {}
         @drive_ids = drive_ids
         @index_permissions = index_permissions
       end

--- a/lib/connectors_sdk/office365/custom_client.rb
+++ b/lib/connectors_sdk/office365/custom_client.rb
@@ -134,7 +134,7 @@ module ConnectorsSdk
             yielded += 1
           end
 
-          if break_after_page && yielded >= 100
+          if break_after_page && yielded >= 100 && stack.any?
             cursors['page_cursor'] = stack.dup
             break
           end

--- a/lib/connectors_sdk/office365/custom_client.rb
+++ b/lib/connectors_sdk/office365/custom_client.rb
@@ -50,6 +50,7 @@ module ConnectorsSdk
       def initialize(access_token:, cursors: {}, ensure_fresh_auth: nil)
         @access_token = access_token
         @cursors = cursors || {}
+        @cursors[ConnectorsSdk::Office365::Extractor::DRIVE_IDS_CURSOR_KEY] ||= {}
         super(:ensure_fresh_auth => ensure_fresh_auth)
       end
 
@@ -178,11 +179,11 @@ module ConnectorsSdk
           response = request_json(:url => response['@odata.nextLink'])
         end
 
-        cursors[drive_id] = response['@odata.deltaLink']
+        cursors[ConnectorsSdk::Office365::Extractor::DRIVE_IDS_CURSOR_KEY][drive_id] = response['@odata.deltaLink']
       end
 
       def get_latest_delta_link(drive_id)
-        cursors[drive_id] || exhaustively_get_delta_link(drive_id)
+        cursors[ConnectorsSdk::Office365::Extractor::DRIVE_IDS_CURSOR_KEY][drive_id] || exhaustively_get_delta_link(drive_id)
       end
 
       def exhaustively_get_delta_link(drive_id)

--- a/lib/connectors_sdk/office365/extractor.rb
+++ b/lib/connectors_sdk/office365/extractor.rb
@@ -20,19 +20,9 @@ module ConnectorsSdk
 
           if break_after_page
             current_drive_id = config.cursors['current_drive_id']
-            last_drive_id = config.cursors['last_drive_id']
-
             if current_drive_id.present? && current_drive_id > drive_id # they come alpha sorted
               next
             end
-
-            if last_drive_id.present? && last_drive_id >= drive_id # they come alpha sorted
-              if last_drive_id == drive_id
-                config.cursors.delete('last_drive_id')
-              end
-              next
-            end
-
             config.cursors['current_drive_id'] = drive_id
           end
 
@@ -61,12 +51,15 @@ module ConnectorsSdk
             capture_exception(e)
           end
 
-          if break_after_page
-            if config.cursors['page_cursor'].blank?
-              config.cursors['last_drive_id'] = config.cursors.delete('current_drive_id')
-            end
+          if break_after_page && config.cursors['page_cursor'].present?
             break
           end
+        end
+
+        if break_after_page && config.cursors['page_cursor'].blank?
+          @completed = true
+          config.overwrite_cursors!(retrieve_latest_cursors)
+          log_info("Completed #{modified_since.nil? ? 'full' : 'incremental'} extraction")
         end
 
         nil
@@ -107,12 +100,6 @@ module ConnectorsSdk
           yield []
         else
           raise
-        end
-      end
-
-      def client
-        @client ||= super.tap do |client|
-          client.cursors = config.cursors&.fetch(DRIVE_IDS_CURSOR_KEY, {}) || {}
         end
       end
 

--- a/lib/connectors_sdk/office365/extractor.rb
+++ b/lib/connectors_sdk/office365/extractor.rb
@@ -59,7 +59,7 @@ module ConnectorsSdk
         if break_after_page && config.cursors['page_cursor'].blank?
           @completed = true
           config.overwrite_cursors!(retrieve_latest_cursors)
-          log_info("Completed #{modified_since.nil? ? 'full' : 'incremental'} extraction")
+          log_debug("Completed #{modified_since.nil? ? 'full' : 'incremental'} extraction")
         end
 
         nil

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -63,6 +63,10 @@ module ConnectorsSdk
         @extractor.config.cursors
       end
 
+      def completed?
+        @extractor.completed
+      end
+
       def deleted(params)
         results = []
         extractor(params).yield_deleted_ids(params[:ids]) do |id|

--- a/spec/connectors_sdk/office365/custom_client_spec.rb
+++ b/spec/connectors_sdk/office365/custom_client_spec.rb
@@ -212,7 +212,7 @@ describe ConnectorsSdk::Office365::CustomClient do
       end
 
       it 'should clear page_cursor' do
-        expect { subject }.to change { client.cursors }.to({})
+        expect { subject }.to change { client.cursors }.to({ 'drive_ids' => {} })
       end
 
       it 'should break after first folder returns over 100 items' do
@@ -221,7 +221,7 @@ describe ConnectorsSdk::Office365::CustomClient do
         end
         stub_request(:get, "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}drives/#{drive_id}/items/#{folder_ids.last}/children").to_return(:status => 200, :body => { 'value' => value }.to_json)
 
-        expect { subject }.to change { client.cursors }.to({ 'page_cursor' => Array.wrap(folder_ids.first) })
+        expect { subject }.to change { client.cursors }.to({ 'drive_ids' => {}, 'page_cursor' => Array.wrap(folder_ids.first) })
       end
     end
 

--- a/spec/connectors_sdk/sharepoint/extractor_spec.rb
+++ b/spec/connectors_sdk/sharepoint/extractor_spec.rb
@@ -309,6 +309,13 @@ describe ConnectorsSdk::SharePoint::Extractor do
 
         expect { subject }.to change { cursors }.from({ 'current_drive_id' => drive_id, 'drive_ids' => {} }).to({ 'current_drive_id' => drive_id, 'page_cursor' => '_', 'drive_ids' => {} })
       end
+
+      it 'sets completed to true in the absence of a page_cursor' do
+        cursors['current_drive_id'] = drive_id
+        allow(extractor).to receive(:yield_drive_items)
+
+        expect { subject }.to change { extractor.completed }.from(false).to(true)
+      end
     end
   end
 

--- a/spec/connectors_sdk/sharepoint/extractor_spec.rb
+++ b/spec/connectors_sdk/sharepoint/extractor_spec.rb
@@ -293,33 +293,12 @@ describe ConnectorsSdk::SharePoint::Extractor do
         expect_sites([:id => site_id])
         expect_groups([])
         expect_site_drives(site_id, drives)
+        allow(extractor).to receive(:retrieve_latest_cursors).and_return({ described_class::DRIVE_IDS_CURSOR_KEY => {} })
       end
 
       it 'does not error' do
         cursors['current_drive_id'] = ('z' * 100) # sorts after any real id
         expect { subject }.not_to raise_error
-      end
-
-      it 'understands how to skip to just after last_drive_id' do
-        cursors['last_drive_id'] = ('z' * 100)
-        expect { subject }.not_to raise_error
-      end
-
-      it 'understands how to skip to just after last_drive_id' do
-        cursors['last_drive_id'] = drive_id
-        expect { subject }.not_to raise_error
-      end
-
-      it 'clears cursor on final last_drive_id' do
-        cursors['last_drive_id'] = drive_id
-        expect { subject }.to change { cursors }.to({})
-      end
-
-      it 'sets last_drive_id from current_drive_id' do
-        cursors['current_drive_id'] = drive_id
-        allow(extractor).to receive(:yield_drive_items)
-
-        expect { subject }.to change { cursors }.from({ 'current_drive_id' => drive_id }).to({ 'last_drive_id' => drive_id })
       end
 
       it 'preserves current_drive_id in the presence of a page_cursor' do
@@ -328,7 +307,7 @@ describe ConnectorsSdk::SharePoint::Extractor do
           config.cursors['page_cursor'] = '_'
         end
 
-        expect { subject }.to change { cursors }.from({ 'current_drive_id' => drive_id }).to({ 'current_drive_id' => drive_id, 'page_cursor' => '_' })
+        expect { subject }.to change { cursors }.from({ 'current_drive_id' => drive_id, 'drive_ids' => {} }).to({ 'current_drive_id' => drive_id, 'page_cursor' => '_', 'drive_ids' => {} })
       end
     end
   end


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/1774

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

* https://github.com/elastic/ent-search/pull/6441
