### PR TITLE
[8.2] Return cursors at the end of extraction (#70)

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -90,21 +90,14 @@ class ConnectorsWebApp < Sinatra::Base
   end
 
   post '/documents' do
-    original_cursors = (body_params.fetch(:cursors, {}) || {}).as_json
-
     connector = settings.connector
 
     results = connector.document_batch(body_params)
 
-    new_cursors = if connector.cursors.as_json != original_cursors
-                    connector.cursors
-                  else
-                    {}
-                  end
-
     json(
       :results => results,
-      :cursors => new_cursors
+      :cursors => connector.cursors,
+      :completed => connector.completed?
     )
   end
 

--- a/lib/connectors_sdk/base/extractor.rb
+++ b/lib/connectors_sdk/base/extractor.rb
@@ -30,7 +30,7 @@ module ConnectorsSdk
         ]
       )
 
-      attr_reader :content_source_id, :config, :features, :original_cursors, :service_type
+      attr_reader :content_source_id, :config, :features, :original_cursors, :service_type, :completed
       attr_accessor :monitor, :client_proc
 
       def initialize(content_source_id:,
@@ -48,6 +48,7 @@ module ConnectorsSdk
         @authorization_data_proc = authorization_data_proc
         @original_cursors = config.cursors.deep_dup
         @monitor = monitor
+        @completed = false
       end
 
       def authorization_data!

--- a/lib/connectors_sdk/office365/config.rb
+++ b/lib/connectors_sdk/office365/config.rb
@@ -17,6 +17,7 @@ module ConnectorsSdk
 
       def initialize(drive_ids:, cursors:, index_permissions: false)
         super(:cursors => cursors)
+        @cursors[ConnectorsSdk::Office365::Extractor::DRIVE_IDS_CURSOR_KEY] ||= {}
         @drive_ids = drive_ids
         @index_permissions = index_permissions
       end

--- a/lib/connectors_sdk/office365/custom_client.rb
+++ b/lib/connectors_sdk/office365/custom_client.rb
@@ -50,6 +50,7 @@ module ConnectorsSdk
       def initialize(access_token:, cursors: {}, ensure_fresh_auth: nil)
         @access_token = access_token
         @cursors = cursors || {}
+        @cursors[ConnectorsSdk::Office365::Extractor::DRIVE_IDS_CURSOR_KEY] ||= {}
         super(:ensure_fresh_auth => ensure_fresh_auth)
       end
 
@@ -133,7 +134,7 @@ module ConnectorsSdk
             yielded += 1
           end
 
-          if break_after_page && yielded >= 100
+          if break_after_page && yielded >= 100 && stack.any?
             cursors['page_cursor'] = stack.dup
             break
           end
@@ -178,11 +179,11 @@ module ConnectorsSdk
           response = request_json(:url => response['@odata.nextLink'])
         end
 
-        cursors[drive_id] = response['@odata.deltaLink']
+        cursors[ConnectorsSdk::Office365::Extractor::DRIVE_IDS_CURSOR_KEY][drive_id] = response['@odata.deltaLink']
       end
 
       def get_latest_delta_link(drive_id)
-        cursors[drive_id] || exhaustively_get_delta_link(drive_id)
+        cursors[ConnectorsSdk::Office365::Extractor::DRIVE_IDS_CURSOR_KEY][drive_id] || exhaustively_get_delta_link(drive_id)
       end
 
       def exhaustively_get_delta_link(drive_id)

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -63,6 +63,10 @@ module ConnectorsSdk
         @extractor.config.cursors
       end
 
+      def completed?
+        @extractor.completed
+      end
+
       def deleted(params)
         results = []
         extractor(params).yield_deleted_ids(params[:ids]) do |id|

--- a/spec/connectors_sdk/office365/custom_client_spec.rb
+++ b/spec/connectors_sdk/office365/custom_client_spec.rb
@@ -212,7 +212,7 @@ describe ConnectorsSdk::Office365::CustomClient do
       end
 
       it 'should clear page_cursor' do
-        expect { subject }.to change { client.cursors }.to({})
+        expect { subject }.to change { client.cursors }.to({ 'drive_ids' => {} })
       end
 
       it 'should break after first folder returns over 100 items' do
@@ -221,7 +221,7 @@ describe ConnectorsSdk::Office365::CustomClient do
         end
         stub_request(:get, "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}drives/#{drive_id}/items/#{folder_ids.last}/children").to_return(:status => 200, :body => { 'value' => value }.to_json)
 
-        expect { subject }.to change { client.cursors }.to({ 'page_cursor' => Array.wrap(folder_ids.first) })
+        expect { subject }.to change { client.cursors }.to({ 'drive_ids' => {}, 'page_cursor' => Array.wrap(folder_ids.first) })
       end
     end
 


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Return cursors at the end of extraction (#70)