### PR TITLE
[8.2][Backport] Paginate over the contents of a single SharePoint Online folder node (#69)

### DIFF
--- a/lib/connectors_sdk/office365/extractor.rb
+++ b/lib/connectors_sdk/office365/extractor.rb
@@ -51,12 +51,12 @@ module ConnectorsSdk
             capture_exception(e)
           end
 
-          if break_after_page && config.cursors['page_cursor'].present?
+          if break_after_page && (config.cursors['page_cursor'].present? || config.cursors['item_children_next_link'].present?)
             break
           end
         end
 
-        if break_after_page && config.cursors['page_cursor'].blank?
+        if break_after_page && config.cursors['page_cursor'].blank? && config.cursors['item_children_next_link'].blank?
           @completed = true
           config.overwrite_cursors!(retrieve_latest_cursors)
           log_debug("Completed #{modified_since.nil? ? 'full' : 'incremental'} extraction")

--- a/spec/connectors_sdk/office365/custom_client_spec.rb
+++ b/spec/connectors_sdk/office365/custom_client_spec.rb
@@ -223,6 +223,15 @@ describe ConnectorsSdk::Office365::CustomClient do
 
         expect { subject }.to change { client.cursors }.to({ 'drive_ids' => {}, 'page_cursor' => Array.wrap(folder_ids.first) })
       end
+
+      it 'will save current folder for next request in presence of item_children_next_link' do
+        value = (1..100).to_a.map do |i|
+          Hashie::Mash.new(:id => i, :folder => false)
+        end
+        stub_request(:get, "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}drives/#{drive_id}/items/#{folder_ids.last}/children").to_return(:status => 200, :body => { 'value' => value, '@odata.nextLink' => '_' }.to_json)
+
+        expect { subject }.to change { client.cursors }.to({ 'drive_ids' => {}, 'page_cursor' => folder_ids, 'item_children_next_link' => '_' })
+      end
     end
 
     describe '#list_changes' do


### PR DESCRIPTION
Backport of #69.


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] [Manual test steps](../docs/INTERNAL.md#minimal-manual-tests)  are successful
- [ ] Enterprise Search builds successfully with a gem built from this PR's branch.
  - _Link the ent-search PR here_
