### PR TITLE
Stop caching the instance of HttpCallWrapper, which caused it to behave like a singleton class

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing the Connectors project
 
-The Connectors project is packaged as a Gem that is added in the Enterprise Search distribution.
+The Connectors project contains logic that is also packaged as a Gem to be included in the Enterprise Search distribution ([example](https://github.com/elastic/ent-search/blob/9e87bf1c293df97f3a550ed1e2a7efac18c9d8f2/Gemfile#L262)).
 
-The version scheme we use is **MAJOR.MINOR.PATCH.BUILD** and stored in the [VERSION](VERSION) file
+The version scheme we use is **MAJOR.MINOR.PATCH.BUILD** and stored in the [VERSION](https://github.com/elastic/connectors/blob/main/VERSION) file
 at the root of this repository.
 
 ## RubyGem Account
@@ -10,33 +10,38 @@ at the root of this repository.
 When releasing Gems, you will be asked for an Email and Password.
 Look into the Vault in the `ent-search-team/rubygem` secret.
 
-
 ## Unified release
 
 **MAJOR.MINOR.PATCH** should match the Elastic and Enterprise Search version it targets 
-and the *BUILD* number should be set to **0** the day the release is created
+and the *BUILD* number should be set to **0** the day the Connectors release is created
 to be included with the Enterprise Search distribution.
 
 For example, when shipping for `8.1.2`, the version is `8.1.2.0`.
 
 To release Connectors:
 
-- set the VERSION file to the right version
-- make sure all tests and linter pass with `make lint test`
-- run `make release`
+- Set the VERSION file to the new/incremented version on the release branch
+- Make sure all tests and linter pass with `make lint test`
+- PR these changes to the appropriate Connectors release branch
+- Run `make release`
 
-A Gem file will be created in the `.gem` directory, that needs to be embed in Enterprise Search.
+A Gem will be published to RubyGems: https://rubygems.org/gems/connectors_sdk.
 
-Immediately update ent-search's gem dependency with the released version:
+Then immediately update ent-search's gem dependency with the released version:
 
-- update the Gem in vendor/cache
-- update Gemfile
+- Update Gemfile if necessary
+- Run `./script/bundle update connectors_sdk`
+- Verify bundler picked up the version you expected it to update to
+- PR these changes to the appropriate Enterprise Search release branch ([example](https://github.com/elastic/ent-search/pull/6476))
 
 Last, take care of the branching:
 
 - Increment the VERSION on main to match the next release
-- create a new maintenance branch if it's a new MINOR
+- Create a new maintenance branch if it's a new MINOR
 
+After the Elastic unified release is complete
+
+- Update the **BUILD** version ([example PR](https://github.com/elastic/connectors/pull/81)). Note that the Connectors project does not immediately bump to the next **PATCH** version. That wont happen until that patch release's FF date.
 
 ## In-Between releases
 

--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -54,6 +54,8 @@ class ConnectorsWebApp < Sinatra::Base
   end
 
   before do
+    @connector = settings.connector_class.new
+
     Time.zone = ActiveSupport::TimeZone.new('UTC')
     # XXX to be removed
     return if settings.deactivate_auth
@@ -81,16 +83,15 @@ class ConnectorsWebApp < Sinatra::Base
   end
 
   post '/status' do
-    connector = settings.connector_class.new
-    source_status = connector.source_status(body_params)
+    source_status = @connector.source_status(body_params)
     json(
-      :extractor => { :name => connector.name },
+      :extractor => { :name => @connector.name },
       :contentProvider => source_status
     )
   end
 
   post '/documents' do
-    results, cursors, completed = settings.connector_class.new.document_batch(body_params)
+    results, cursors, completed = @connector.document_batch(body_params)
 
     json(
       :results => results,
@@ -100,22 +101,22 @@ class ConnectorsWebApp < Sinatra::Base
   end
 
   post '/download' do
-    settings.connector_class.new.download(body_params)
+    @connector.download(body_params)
   end
 
   post '/deleted' do
-    json :results => settings.connector_class.new.deleted(body_params)
+    json :results => @connector.deleted(body_params)
   end
 
   post '/permissions' do
-    json :results => settings.connector_class.new.permissions(body_params)
+    json :results => @connector.permissions(body_params)
   end
 
   # XXX remove `oauth2` from the name
   post '/oauth2/init' do
     logger.info "Received client ID: #{body_params[:client_id]} and client secret: #{body_params[:client_secret]}"
     logger.info "Received redirect URL: #{body_params[:redirect_uri]}"
-    authorization_uri = settings.connector_class.new.authorization_uri(body_params)
+    authorization_uri = @connector.authorization_uri(body_params)
 
     json :oauth2redirect => authorization_uri
   end
@@ -123,12 +124,12 @@ class ConnectorsWebApp < Sinatra::Base
   # XXX remove `oauth2` from the name
   post '/oauth2/exchange' do
     logger.info "Received payload: #{body_params}"
-    json settings.connector_class.new.access_token(body_params)
+    json @connector.access_token(body_params)
   end
 
   post '/oauth2/refresh' do
     logger.info "Received payload: #{body_params}"
-    json settings.connector_class.new.refresh(body_params)
+    json @connector.refresh(body_params)
   end
 
   def body_params

--- a/lib/connectors_sdk/base/registry.rb
+++ b/lib/connectors_sdk/base/registry.rb
@@ -17,8 +17,8 @@ module ConnectorsSdk
         @connectors[name] = klass
       end
 
-      def connector(name)
-        @connectors[name].new
+      def connector_class(name)
+        @connectors[name]
       end
     end
 

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -34,9 +34,9 @@ module ConnectorsSdk
       def document_batch(params)
         results = []
 
-        @extractor = extractor(params)
+        extractor = extractor(params)
 
-        @extractor.yield_document_changes(:break_after_page => true, :modified_since => @extractor.config.cursors['modified_since']) do |action, doc, download_args_and_proc|
+        extractor.yield_document_changes(:break_after_page => true, :modified_since => extractor.config.cursors['modified_since']) do |action, doc, download_args_and_proc|
           download_obj = nil
           if download_args_and_proc
             download_obj = {
@@ -54,17 +54,9 @@ module ConnectorsSdk
           }
         end
 
-        results
+        return results, extractor.config.cursors, extractor.completed
       rescue ConnectorsSdk::Office365::CustomClient::ClientError => e
         raise e.status_code == 401 ? ConnectorsShared::InvalidTokenError : e
-      end
-
-      def cursors
-        @extractor.config.cursors
-      end
-
-      def completed?
-        @extractor.completed
       end
 
       def deleted(params)

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -54,7 +54,7 @@ module ConnectorsSdk
           }
         end
 
-        return results, extractor.config.cursors, extractor.completed
+        [results, extractor.config.cursors, extractor.completed]
       rescue ConnectorsSdk::Office365::CustomClient::ClientError => e
         raise e.status_code == 401 ? ConnectorsShared::InvalidTokenError : e
       end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe ConnectorsWebApp do
 
   let(:app) { ConnectorsWebApp }
   let(:api_key) { 'api_key' }
-  let(:connector) { ConnectorsSdk::SharePoint::HttpCallWrapper.new }
+  let(:connector_class) { ConnectorsSdk::SharePoint::HttpCallWrapper }
+  let(:connector) { connector_class.new }
 
   def expect_json(response, json)
     expect(json(response)).to eq json
@@ -21,7 +22,8 @@ RSpec.describe ConnectorsWebApp do
   before(:each) do
     allow(ConnectorsWebApp.settings).to receive(:deactivate_auth).and_return(false)
     allow(ConnectorsWebApp.settings).to receive(:api_key).and_return(api_key)
-    allow(ConnectorsWebApp.settings).to receive(:connector).and_return(connector)
+    allow(ConnectorsWebApp.settings).to receive(:connector_class).and_return(connector_class)
+    allow(connector_class).to receive(:new).and_return(connector)
   end
 
   describe 'Catch all' do

--- a/spec/connectors_sdk/base/registry_spec.rb
+++ b/spec/connectors_sdk/base/registry_spec.rb
@@ -21,7 +21,7 @@ describe ConnectorsSdk::Base::Factory do
     end
 
     factory.register('sharepoint', MyConnector)
-    instance = factory.connector('sharepoint')
-    expect(instance.works).to eq 'works'
+    connector_class = factory.connector_class('sharepoint')
+    expect(connector_class.new.works).to eq 'works'
   end
 end

--- a/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ConnectorsSdk::SharePoint::HttpCallWrapper do
       mock_endpoint('drives/4567/items/1111/permissions', permissions)
 
       extractor = backend.extractor(params)
-      results, cursors, completed = backend.document_batch(params)
+      results, _cursors, _completed = backend.document_batch(params)
 
       expect(results.size).to eq 100
       expect(extractor.config.index_permissions).to be_truthy

--- a/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
@@ -62,8 +62,11 @@ RSpec.describe ConnectorsSdk::SharePoint::HttpCallWrapper do
       mock_endpoint('drives/4567/items/1111/children', children)
       mock_endpoint('drives/4567/items/1111/permissions', permissions)
 
-      expect(backend.document_batch(params).size).to eq 100
-      expect(backend.extractor(params).config.index_permissions).to be_truthy
+      extractor = backend.extractor(params)
+      results, cursors, completed = backend.document_batch(params)
+
+      expect(results.size).to eq 100
+      expect(extractor.config.index_permissions).to be_truthy
     end
   end
 


### PR DESCRIPTION
We discovered that the HttpCallWrapper instance was being shared between requests. These changes ensure it is used as a normal class/object, rather than what is effectively a singleton class. I expect this would resolve some thread-unsafe behavior.

These changes also remove the thread-unsafe behavior, but I think it's still a good idea to remove the singleton class behavior as well.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [X] Covered the changes with automated tests
- [X] Tested the changes locally
- [X] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Fixed an issue where two requests to the `/documents` endpoint could interfere with each other in a thread-unsafe manner.

## For Elastic Internal Use Only
- [X] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [X] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [X] [Manual test steps](https://github.com/elastic/connectors/blob/main/docs/INTERNAL.md#minimal-manual-tests)  are successful
- [ ] Enterprise Search builds successfully with a gem built from this PR's branch.
  - _Link the ent-search PR here_
