### PR TITLE
[8.2] Stop caching the instance of HttpCallWrapper, which caused it to behave like a singleton class (#83)

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -34,7 +34,7 @@ class ConnectorsWebApp < Sinatra::Base
     set :api_key, settings.http['api_key']
     set :deactivate_auth, settings.http['deactivate_auth']
     set :connector_name, settings.http['connector']
-    set :connector, ConnectorsSdk::Base::REGISTRY.connector(settings.http['connector'])
+    set :connector_class, ConnectorsSdk::Base::REGISTRY.connector_class(settings.http['connector'])
   end
 
   error do
@@ -54,6 +54,8 @@ class ConnectorsWebApp < Sinatra::Base
   end
 
   before do
+    @connector = settings.connector_class.new
+
     Time.zone = ActiveSupport::TimeZone.new('UTC')
     # XXX to be removed
     return if settings.deactivate_auth
@@ -81,43 +83,40 @@ class ConnectorsWebApp < Sinatra::Base
   end
 
   post '/status' do
-    connector = settings.connector
-    source_status = connector.source_status(body_params)
+    source_status = @connector.source_status(body_params)
     json(
-      :extractor => { :name => connector.name },
+      :extractor => { :name => @connector.name },
       :contentProvider => source_status
     )
   end
 
   post '/documents' do
-    connector = settings.connector
-
-    results = connector.document_batch(body_params)
+    results, cursors, completed = @connector.document_batch(body_params)
 
     json(
       :results => results,
-      :cursors => connector.cursors,
-      :completed => connector.completed?
+      :cursors => cursors,
+      :completed => completed
     )
   end
 
   post '/download' do
-    settings.connector.download(body_params)
+    @connector.download(body_params)
   end
 
   post '/deleted' do
-    json :results => settings.connector.deleted(body_params)
+    json :results => @connector.deleted(body_params)
   end
 
   post '/permissions' do
-    json :results => settings.connector.permissions(body_params)
+    json :results => @connector.permissions(body_params)
   end
 
   # XXX remove `oauth2` from the name
   post '/oauth2/init' do
     logger.info "Received client ID: #{body_params[:client_id]} and client secret: #{body_params[:client_secret]}"
     logger.info "Received redirect URL: #{body_params[:redirect_uri]}"
-    authorization_uri = settings.connector.authorization_uri(body_params)
+    authorization_uri = @connector.authorization_uri(body_params)
 
     json :oauth2redirect => authorization_uri
   end
@@ -125,12 +124,12 @@ class ConnectorsWebApp < Sinatra::Base
   # XXX remove `oauth2` from the name
   post '/oauth2/exchange' do
     logger.info "Received payload: #{body_params}"
-    json settings.connector.access_token(body_params)
+    json @connector.access_token(body_params)
   end
 
   post '/oauth2/refresh' do
     logger.info "Received payload: #{body_params}"
-    json settings.connector.refresh(body_params)
+    json @connector.refresh(body_params)
   end
 
   def body_params

--- a/lib/connectors_sdk/base/registry.rb
+++ b/lib/connectors_sdk/base/registry.rb
@@ -17,8 +17,8 @@ module ConnectorsSdk
         @connectors[name] = klass
       end
 
-      def connector(name)
-        @connectors[name].new
+      def connector_class(name)
+        @connectors[name]
       end
     end
 

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -34,9 +34,9 @@ module ConnectorsSdk
       def document_batch(params)
         results = []
 
-        @extractor = extractor(params)
+        extractor = extractor(params)
 
-        @extractor.yield_document_changes(:break_after_page => true, :modified_since => @extractor.config.cursors['modified_since']) do |action, doc, download_args_and_proc|
+        extractor.yield_document_changes(:break_after_page => true, :modified_since => extractor.config.cursors['modified_since']) do |action, doc, download_args_and_proc|
           download_obj = nil
           if download_args_and_proc
             download_obj = {
@@ -54,17 +54,9 @@ module ConnectorsSdk
           }
         end
 
-        results
+        [results, extractor.config.cursors, extractor.completed]
       rescue ConnectorsSdk::Office365::CustomClient::ClientError => e
         raise e.status_code == 401 ? ConnectorsShared::InvalidTokenError : e
-      end
-
-      def cursors
-        @extractor.config.cursors
-      end
-
-      def completed?
-        @extractor.completed
       end
 
       def deleted(params)

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe ConnectorsWebApp do
 
   let(:app) { ConnectorsWebApp }
   let(:api_key) { 'api_key' }
-  let(:connector) { ConnectorsSdk::SharePoint::HttpCallWrapper.new }
+  let(:connector_class) { ConnectorsSdk::SharePoint::HttpCallWrapper }
+  let(:connector) { connector_class.new }
 
   def expect_json(response, json)
     expect(json(response)).to eq json
@@ -21,7 +22,8 @@ RSpec.describe ConnectorsWebApp do
   before(:each) do
     allow(ConnectorsWebApp.settings).to receive(:deactivate_auth).and_return(false)
     allow(ConnectorsWebApp.settings).to receive(:api_key).and_return(api_key)
-    allow(ConnectorsWebApp.settings).to receive(:connector).and_return(connector)
+    allow(ConnectorsWebApp.settings).to receive(:connector_class).and_return(connector_class)
+    allow(connector_class).to receive(:new).and_return(connector)
   end
 
   describe 'Catch all' do

--- a/spec/connectors_sdk/base/registry_spec.rb
+++ b/spec/connectors_sdk/base/registry_spec.rb
@@ -21,7 +21,7 @@ describe ConnectorsSdk::Base::Factory do
     end
 
     factory.register('sharepoint', MyConnector)
-    instance = factory.connector('sharepoint')
-    expect(instance.works).to eq 'works'
+    connector_class = factory.connector_class('sharepoint')
+    expect(connector_class.new.works).to eq 'works'
   end
 end

--- a/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
@@ -62,8 +62,11 @@ RSpec.describe ConnectorsSdk::SharePoint::HttpCallWrapper do
       mock_endpoint('drives/4567/items/1111/children', children)
       mock_endpoint('drives/4567/items/1111/permissions', permissions)
 
-      expect(backend.document_batch(params).size).to eq 100
-      expect(backend.extractor(params).config.index_permissions).to be_truthy
+      extractor = backend.extractor(params)
+      results, _cursors, _completed = backend.document_batch(params)
+
+      expect(results.size).to eq 100
+      expect(extractor.config.index_permissions).to be_truthy
     end
   end
 


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Stop caching the instance of HttpCallWrapper, which caused it to behave like a singleton class (#83)