### PR TITLE
Refactor outdated naming

### DIFF
--- a/lib/connectors_sdk/base/adapter.rb
+++ b/lib/connectors_sdk/base/adapter.rb
@@ -25,19 +25,19 @@ module ConnectorsSdk
       end
 
       def self.generate_id_helpers(method_prefix, id_prefix)
-        define_singleton_method("#{method_prefix}_id_to_fp_id") do |id|
+        define_singleton_method("#{method_prefix}_id_to_es_id") do |id|
           "#{id_prefix}_#{id}"
         end
 
-        define_singleton_method("fp_id_is_#{method_prefix}_id?") do |fp_id|
-          regex_match = /#{id_prefix}_(.+)$/.match(fp_id)
+        define_singleton_method("es_id_is_#{method_prefix}_id?") do |es_id|
+          regex_match = /#{id_prefix}_(.+)$/.match(es_id)
           regex_match.present? && regex_match.size == 2
         end
 
-        define_singleton_method("fp_id_to_#{method_prefix}_id") do |fp_id|
-          regex_match = /#{id_prefix}_(.+)$/.match(fp_id)
+        define_singleton_method("es_id_to_#{method_prefix}_id") do |es_id|
+          regex_match = /#{id_prefix}_(.+)$/.match(es_id)
 
-          raise ArgumentError, "Invalid id #{fp_id} for source with method prefix #{method_prefix}." if regex_match.nil? || regex_match.length != 2
+          raise ArgumentError, "Invalid id #{es_id} for source with method prefix #{method_prefix}." if regex_match.nil? || regex_match.length != 2
           regex_match[1]
         end
       end
@@ -92,7 +92,7 @@ module ConnectorsSdk
         nil
       end
 
-      def self.swiftype_document_from_configured_object_base(object_type:, object:, fields:)
+      def self.es_document_from_configured_object_base(object_type:, object:, fields:)
         object_as_json = object.as_json
 
         adapted_object = {

--- a/lib/connectors_sdk/confluence/adapter.rb
+++ b/lib/connectors_sdk/confluence/adapter.rb
@@ -21,16 +21,16 @@ module ConnectorsSdk
       generate_id_helpers :confluence_content, 'confluence_content'
       generate_id_helpers :confluence_attachment, 'confluence_attachment'
 
-      def self.swiftype_document_from_confluence_space(space, base_url, permissions = [])
-        SpaceNode.new(:node => space, :base_url => base_url, :permissions => permissions).to_swiftype_document
+      def self.es_document_from_confluence_space(space, base_url, permissions = [])
+        SpaceNode.new(:node => space, :base_url => base_url, :permissions => permissions).to_es_document
       end
 
-      def self.swiftype_document_from_confluence_content(content, base_url, restrictions = [])
-        ContentNode.new(:node => content, :base_url => base_url, :permissions => restrictions).to_swiftype_document
+      def self.es_document_from_confluence_content(content, base_url, restrictions = [])
+        ContentNode.new(:node => content, :base_url => base_url, :permissions => restrictions).to_es_document
       end
 
-      def self.swiftype_document_from_confluence_attachment(attachment, base_url, restrictions = [])
-        AttachmentNode.new(:node => attachment, :base_url => base_url, :permissions => restrictions).to_swiftype_document
+      def self.es_document_from_confluence_attachment(attachment, base_url, restrictions = [])
+        AttachmentNode.new(:node => attachment, :base_url => base_url, :permissions => restrictions).to_es_document
       end
 
       class Node
@@ -43,7 +43,7 @@ module ConnectorsSdk
           @permissions = permissions
         end
 
-        def to_swiftype_document
+        def to_es_document
           {
             :id => id,
             :title => title,
@@ -207,7 +207,7 @@ module ConnectorsSdk
           end
         end
 
-        def to_swiftype_document
+        def to_es_document
           super.merge(:_fields_to_preserve => ConnectorsSdk::Confluence::Adapter.fields_to_preserve)
         end
       end

--- a/lib/connectors_sdk/confluence/adapter.rb
+++ b/lib/connectors_sdk/confluence/adapter.rb
@@ -81,7 +81,7 @@ module ConnectorsSdk
 
       class SpaceNode < Node
         def id
-          Confluence::Adapter.confluence_space_id_to_fp_id(node.fetch('key'))
+          Confluence::Adapter.confluence_space_id_to_es_id(node.fetch('key'))
         end
 
         def type
@@ -107,7 +107,7 @@ module ConnectorsSdk
 
       class ContentNode < Node
         def id
-          Confluence::Adapter.confluence_content_id_to_fp_id(node.id)
+          Confluence::Adapter.confluence_content_id_to_es_id(node.id)
         end
 
         def type
@@ -176,7 +176,7 @@ module ConnectorsSdk
 
       class AttachmentNode < ContentNode
         def id
-          Confluence::Adapter.confluence_attachment_id_to_fp_id(node.id)
+          Confluence::Adapter.confluence_attachment_id_to_es_id(node.id)
         end
 
         def type

--- a/lib/connectors_sdk/confluence/extractor.rb
+++ b/lib/connectors_sdk/confluence/extractor.rb
@@ -26,7 +26,7 @@ module ConnectorsSdk
         yield_spaces do |space|
           yield_single_document_change(:identifier => "Confluence Space: #{space&.fetch(:key)} (#{space&.webui})") do
             permissions = config.index_permissions ? get_space_permissions(space) : []
-            yield :create_or_update, Confluence::Adapter.swiftype_document_from_confluence_space(space, content_base_url, permissions)
+            yield :create_or_update, Confluence::Adapter.es_document_from_confluence_space(space, content_base_url, permissions)
           end
 
           yield_content_for_space(
@@ -36,7 +36,7 @@ module ConnectorsSdk
           ) do |content|
             restrictions = config.index_permissions ? get_content_restrictions(content) : []
             if content.type == 'attachment'
-              document = Confluence::Adapter.swiftype_document_from_confluence_attachment(content, content_base_url, restrictions)
+              document = Confluence::Adapter.es_document_from_confluence_attachment(content, content_base_url, restrictions)
               download_args = download_args_and_proc(
                 id: document.fetch(:id),
                 name: content.title,
@@ -47,7 +47,7 @@ module ConnectorsSdk
               end
               yield :create_or_update, document, download_args
             else
-              yield :create_or_update, Confluence::Adapter.swiftype_document_from_confluence_content(content, content_base_url, restrictions)
+              yield :create_or_update, Confluence::Adapter.es_document_from_confluence_content(content, content_base_url, restrictions)
             end
           end
 

--- a/lib/connectors_sdk/confluence/extractor.rb
+++ b/lib/connectors_sdk/confluence/extractor.rb
@@ -60,11 +60,11 @@ module ConnectorsSdk
 
       def yield_deleted_ids(ids)
         id_groups = ids.group_by do |id|
-          if Confluence::Adapter.fp_id_is_confluence_space_id?(id)
+          if Confluence::Adapter.es_id_is_confluence_space_id?(id)
             :space
-          elsif Confluence::Adapter.fp_id_is_confluence_content_id?(id)
+          elsif Confluence::Adapter.es_id_is_confluence_content_id?(id)
             :content
-          elsif Confluence::Adapter.fp_id_is_confluence_attachment_id?(id)
+          elsif Confluence::Adapter.es_id_is_confluence_attachment_id?(id)
             :attachment
           else
             :unknown
@@ -72,9 +72,9 @@ module ConnectorsSdk
         end
 
         %i(space content attachment).each do |group|
-          confluence_ids = Array(id_groups[group]).map { |id| Confluence::Adapter.public_send("fp_id_to_confluence_#{group}_id", id) }
+          confluence_ids = Array(id_groups[group]).map { |id| Confluence::Adapter.public_send("es_id_to_confluence_#{group}_id", id) }
           get_ids_for_deleted(confluence_ids, group).each do |deleted_id|
-            yield Confluence::Adapter.public_send("confluence_#{group}_id_to_fp_id", deleted_id)
+            yield Confluence::Adapter.public_send("confluence_#{group}_id_to_es_id", deleted_id)
           end
         end
       end

--- a/lib/connectors_sdk/office365/adapter.rb
+++ b/lib/connectors_sdk/office365/adapter.rb
@@ -26,7 +26,7 @@ module ConnectorsSdk
           @item = item
         end
 
-        def self.convert_id_to_fp_id(_id)
+        def self.convert_id_to_es_id(_id)
           raise NotImplementedError
         end
 
@@ -44,7 +44,7 @@ module ConnectorsSdk
         def to_swiftype_document
           {
             :_fields_to_preserve => ConnectorsSdk::Office365::Adapter.fields_to_preserve,
-            :id => self.class.convert_id_to_fp_id(item.id),
+            :id => self.class.convert_id_to_es_id(item.id),
             :path => get_path(item),
             :title => item.name,
             :url => item.webUrl,
@@ -96,7 +96,7 @@ module ConnectorsSdk
       end
 
       class FileGraphItem < GraphItem
-        def self.convert_id_to_fp_id(_id)
+        def self.convert_id_to_es_id(_id)
           raise NotImplementedError
         end
 
@@ -132,7 +132,7 @@ module ConnectorsSdk
       end
 
       class PackageGraphItem < GraphItem
-        def self.convert_id_to_fp_id(id)
+        def self.convert_id_to_es_id(id)
           raise NotImplementedError
         end
 

--- a/lib/connectors_sdk/office365/adapter.rb
+++ b/lib/connectors_sdk/office365/adapter.rb
@@ -11,11 +11,11 @@ require 'connectors_sdk/base/adapter'
 module ConnectorsSdk
   module Office365
     class Adapter < ConnectorsSdk::Base::Adapter
-      def self.swiftype_document_from_file(_file)
+      def self.es_document_from_file(_file)
         raise NotImplementedError
       end
 
-      def self.swiftype_document_from_folder(_folder)
+      def self.es_document_from_folder(_folder)
         raise NotImplementedError
       end
 
@@ -41,7 +41,7 @@ module ConnectorsSdk
           ConnectorsSdk::Office365::Adapter.normalize_path("#{parent_folder_path}/#{item.name}")
         end
 
-        def to_swiftype_document
+        def to_es_document
           {
             :_fields_to_preserve => ConnectorsSdk::Office365::Adapter.fields_to_preserve,
             :id => self.class.convert_id_to_es_id(item.id),

--- a/lib/connectors_sdk/office365/extractor.rb
+++ b/lib/connectors_sdk/office365/extractor.rb
@@ -132,7 +132,7 @@ module ConnectorsSdk
         @existing_drive_item_ids ||= Set.new.tap do |ids|
           drives_to_index.each do |drive|
             client.list_items(drive.id) do |item|
-              ids << convert_id_to_fp_id(item.id)
+              ids << convert_id_to_es_id(item.id)
             end
           end
         end
@@ -142,7 +142,7 @@ module ConnectorsSdk
         raise NotImplementedError
       end
 
-      def convert_id_to_fp_id(_id)
+      def convert_id_to_es_id(_id)
         raise NotImplementedError
       end
 
@@ -170,7 +170,7 @@ module ConnectorsSdk
         if item.deleted.nil?
           yield_create_or_update(drive_id, item, &block)
         else
-          yield :delete, convert_id_to_fp_id(item.id)
+          yield :delete, convert_id_to_es_id(item.id)
         end
       end
 

--- a/lib/connectors_sdk/office365/extractor.rb
+++ b/lib/connectors_sdk/office365/extractor.rb
@@ -210,11 +210,11 @@ module ConnectorsSdk
 
       def generate_document(item)
         if item.file
-          adapter.swiftype_document_from_file(item)
+          adapter.es_document_from_file(item)
         elsif item.folder
-          adapter.swiftype_document_from_folder(item)
+          adapter.es_document_from_folder(item)
         elsif item.package
-          adapter.swiftype_document_from_package(item)
+          adapter.es_document_from_package(item)
         else
           raise "Unexpected Office 365 item type for item #{item}"
         end

--- a/lib/connectors_sdk/share_point/adapter.rb
+++ b/lib/connectors_sdk/share_point/adapter.rb
@@ -26,20 +26,20 @@ module ConnectorsSdk
       end
 
       class FileGraphItem < Office365::Adapter::FileGraphItem
-        def self.convert_id_to_fp_id(id)
-          ConnectorsSdk::SharePoint::Adapter.share_point_id_to_fp_id(id)
+        def self.convert_id_to_es_id(id)
+          ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
         end
       end
 
       class FolderGraphItem < Office365::Adapter::FolderGraphItem
-        def self.convert_id_to_fp_id(id)
-          ConnectorsSdk::SharePoint::Adapter.share_point_id_to_fp_id(id)
+        def self.convert_id_to_es_id(id)
+          ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
         end
       end
 
       class PackageGraphItem < Office365::Adapter::PackageGraphItem
-        def self.convert_id_to_fp_id(id)
-          ConnectorsSdk::SharePoint::Adapter.share_point_id_to_fp_id(id)
+        def self.convert_id_to_es_id(id)
+          ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
         end
       end
     end

--- a/lib/connectors_sdk/share_point/adapter.rb
+++ b/lib/connectors_sdk/share_point/adapter.rb
@@ -13,16 +13,16 @@ module ConnectorsSdk
     class Adapter < Office365::Adapter
       generate_id_helpers :share_point, 'share_point'
 
-      def self.swiftype_document_from_file(file)
-        FileGraphItem.new(file).to_swiftype_document
+      def self.es_document_from_file(file)
+        FileGraphItem.new(file).to_es_document
       end
 
-      def self.swiftype_document_from_folder(folder)
-        FolderGraphItem.new(folder).to_swiftype_document
+      def self.es_document_from_folder(folder)
+        FolderGraphItem.new(folder).to_es_document
       end
 
-      def self.swiftype_document_from_package(package)
-        PackageGraphItem.new(package).to_swiftype_document
+      def self.es_document_from_package(package)
+        PackageGraphItem.new(package).to_es_document
       end
 
       class FileGraphItem < Office365::Adapter::FileGraphItem

--- a/lib/connectors_sdk/share_point/extractor.rb
+++ b/lib/connectors_sdk/share_point/extractor.rb
@@ -15,8 +15,8 @@ module ConnectorsSdk
 
       private
 
-      def convert_id_to_fp_id(id)
-        ConnectorsSdk::SharePoint::Adapter.share_point_id_to_fp_id(id)
+      def convert_id_to_es_id(id)
+        ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
       end
 
       def adapter

--- a/lib/connectors_shared/exception_tracking.rb
+++ b/lib/connectors_shared/exception_tracking.rb
@@ -6,7 +6,7 @@
 
 # frozen_string_literal: true
 
-require 'stubs/swiftype/exception_tracking' unless defined?(Rails)
+require 'stubs/enterprise_search/exception_tracking' unless defined?(Rails)
 require 'bson'
 require 'connectors_shared/logger'
 
@@ -14,15 +14,15 @@ module ConnectorsShared
   class ExceptionTracking
     class << self
       def capture_message(message, context = {})
-        Swiftype::ExceptionTracking.capture_message(message, context)
+        EnterpriseSearch::ExceptionTracking.capture_message(message, context)
       end
 
       def capture_exception(exception, context = {})
-        Swiftype::ExceptionTracking.log_exception(exception, :context => context)
+        EnterpriseSearch::ExceptionTracking.log_exception(exception, :context => context)
       end
 
       def log_exception(exception, message = nil)
-        Swiftype::ExceptionTracking.log_exception(exception, message, :logger => ConnectorsShared::Logger.logger)
+        EnterpriseSearch::ExceptionTracking.log_exception(exception, message, :logger => ConnectorsShared::Logger.logger)
       end
 
       def augment_exception(exception)

--- a/lib/connectors_shared/monitor.rb
+++ b/lib/connectors_shared/monitor.rb
@@ -8,7 +8,7 @@
 
 require 'connectors_shared/errors'
 require 'stubs/app_config' unless defined?(Rails)
-require 'stubs/swiftype/exception_tracking' unless defined?(Rails)
+require 'stubs/enterprise_search/exception_tracking' unless defined?(Rails)
 
 module ConnectorsShared
   class Monitor
@@ -44,8 +44,8 @@ module ConnectorsShared
     end
 
     def note_error(error, id: Time.now.to_i)
-      stack_trace = Swiftype::ExceptionTracking.generate_stack_trace(error)
-      error_message = Swiftype::ExceptionTracking.generate_error_message(error, nil, nil)
+      stack_trace = EnterpriseSearch::ExceptionTracking.generate_stack_trace(error)
+      error_message = EnterpriseSearch::ExceptionTracking.generate_error_message(error, nil, nil)
       @connector.log_debug("Message id: #{id} - #{error_message}\n#{stack_trace}")
       @total_error_count += 1
       @consecutive_error_count += 1

--- a/lib/stubs/enterprise_search/exception_tracking.rb
+++ b/lib/stubs/enterprise_search/exception_tracking.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License.
 #
 
-module Swiftype
+module EnterpriseSearch
   class ExceptionTracking
     def self.capture_message(message, context = {})
       AppConfig.connectors_logger.error { "Error: #{message}. Context: #{context.inspect}" }

--- a/spec/connectors_sdk/base/adapter_spec.rb
+++ b/spec/connectors_sdk/base/adapter_spec.rb
@@ -18,24 +18,24 @@ describe ConnectorsSdk::Base::Adapter do
 
     context 'inherited class methods based on class name' do
       it 'should convert id to fp id' do
-        expect(Dummy.dummy_id_to_fp_id('1')).to eq('dummy_1')
+        expect(Dummy.dummy_id_to_es_id('1')).to eq('dummy_1')
       end
 
       it 'should convert an fp id to a dummy id' do
-        expect(Dummy.fp_id_to_dummy_id('dummy_1')).to eq('1')
+        expect(Dummy.es_id_to_dummy_id('dummy_1')).to eq('1')
       end
 
       it 'should have predicate method' do
-        expect(Dummy.fp_id_is_dummy_id?('dummy_1')).to eq(true)
+        expect(Dummy.es_id_is_dummy_id?('dummy_1')).to eq(true)
       end
     end
 
     it 'should throw an error if the fp id is invalid' do
-      expect { Dummy.fp_id_to_dummy_id('invalid_id') }.to raise_error(ArgumentError)
+      expect { Dummy.es_id_to_dummy_id('invalid_id') }.to raise_error(ArgumentError)
     end
 
     it 'should throw an error if the fp id does not match the expected format' do
-      expect { Dummy.fp_id_to_dummy_id('dummy_') }.to raise_error(ArgumentError)
+      expect { Dummy.es_id_to_dummy_id('dummy_') }.to raise_error(ArgumentError)
     end
   end
 
@@ -108,7 +108,7 @@ describe ConnectorsSdk::Base::Adapter do
       ]
     end
 
-    subject { described_class.swiftype_document_from_configured_object_base(:object_type => object_type, :object => object, :fields => fields) }
+    subject { described_class.es_document_from_configured_object_base(:object_type => object_type, :object => object, :fields => fields) }
 
     it 'sets the object type' do
       expect(subject).to match(hash_including(:type => 'animal'))

--- a/spec/connectors_sdk/base/adapter_spec.rb
+++ b/spec/connectors_sdk/base/adapter_spec.rb
@@ -73,7 +73,7 @@ describe ConnectorsSdk::Base::Adapter do
     end
   end
 
-  describe 'swiftype_document_from_configured_object_base' do
+  describe 'es_document_from_configured_object_base' do
     let(:object_type) { 'animal' }
     let(:field_remote) { 'RemoteFieldName' }
     let(:field_target) { 'target_field_name' }

--- a/spec/connectors_sdk/confluence/adapter_spec.rb
+++ b/spec/connectors_sdk/confluence/adapter_spec.rb
@@ -13,9 +13,9 @@ describe ConnectorsSdk::Confluence::Adapter do
 
   let(:base_url) { 'https://swiftypedevelopment.atlassian.net/wiki' }
 
-  describe '.swiftype_document_from_confluence_space' do
+  describe '.es_document_from_confluence_space' do
     let(:json) { Hashie::Mash.new(expanded_space_response) }
-    let(:document) { described_class.swiftype_document_from_confluence_space(json, base_url) }
+    let(:document) { described_class.es_document_from_confluence_space(json, base_url) }
 
     it 'should work' do
       expect(document[:url]).to eq('https://swiftypedevelopment.atlassian.net/wiki/spaces/SWPRJ')
@@ -28,9 +28,9 @@ describe ConnectorsSdk::Confluence::Adapter do
     it_behaves_like 'does not populate updated_at'
   end
 
-  describe '.swiftype_document_from_confluence_content' do
+  describe '.es_document_from_confluence_content' do
     let(:json) { Hashie::Mash.new(expanded_content_response) }
-    let(:document) { described_class.swiftype_document_from_confluence_content(json, base_url) }
+    let(:document) { described_class.es_document_from_confluence_content(json, base_url) }
 
     it 'should work' do
       expect(document[:url]).to eq('https://swiftypedevelopment.atlassian.net/wiki/display/eng/Backups+Playbook')
@@ -43,9 +43,9 @@ describe ConnectorsSdk::Confluence::Adapter do
     it_behaves_like 'does not populate updated_at'
   end
 
-  describe '.swiftype_document_from_confluence_attachment' do
+  describe '.es_document_from_confluence_attachment' do
     let(:json) { Hashie::Mash.new(expanded_attachment_response) }
-    let(:document) { described_class.swiftype_document_from_confluence_attachment(json, base_url) }
+    let(:document) { described_class.es_document_from_confluence_attachment(json, base_url) }
 
     it 'should work' do
       expect(document[:url]).to eq('https://swiftypedevelopment.atlassian.net/wiki/spaces/TS/pages/32989/This+my+first+page?preview=%2F32989%2F33012%2Fcake.jpg')

--- a/spec/connectors_sdk/confluence/extractor_spec.rb
+++ b/spec/connectors_sdk/confluence/extractor_spec.rb
@@ -175,13 +175,13 @@ describe ConnectorsSdk::Confluence::Extractor do
 
   describe '#yield_deleted_ids' do
     let(:fp_space_ids) { ['confluence_space_1234_delete_me', 'confluence_space_1234_keep_me'] }
-    let(:space_ids) { fp_space_ids.map { |id| ConnectorsSdk::Confluence::Adapter.fp_id_to_confluence_space_id(id) } }
+    let(:space_ids) { fp_space_ids.map { |id| ConnectorsSdk::Confluence::Adapter.es_id_to_confluence_space_id(id) } }
     let(:fp_content_ids) { ['confluence_content_1234_delete_me', 'confluence_content_1234_keep_me'] }
-    let(:content_ids) { fp_content_ids.map { |id| ConnectorsSdk::Confluence::Adapter.fp_id_to_confluence_content_id(id) } }
+    let(:content_ids) { fp_content_ids.map { |id| ConnectorsSdk::Confluence::Adapter.es_id_to_confluence_content_id(id) } }
     let(:fp_attachment_ids) { ['confluence_attachment_1234_delete_me', 'confluence_attachment_1234_keep_me'] }
-    let(:attachment_ids) { fp_attachment_ids.map { |id| ConnectorsSdk::Confluence::Adapter.fp_id_to_confluence_attachment_id(id) } }
+    let(:attachment_ids) { fp_attachment_ids.map { |id| ConnectorsSdk::Confluence::Adapter.es_id_to_confluence_attachment_id(id) } }
 
-    let(:fp_ids) { fp_space_ids + fp_content_ids + fp_attachment_ids }
+    let(:es_ids) { fp_space_ids + fp_content_ids + fp_attachment_ids }
 
     before do
       allow(subject).to receive(:get_ids_for_deleted).with([], anything).and_return([])
@@ -204,7 +204,7 @@ describe ConnectorsSdk::Confluence::Extractor do
     end
 
     it 'yields a mix of ids' do
-      expect { |blk| subject.yield_deleted_ids(fp_ids, &blk) }.to yield_successive_args(fp_space_ids.first, fp_content_ids.first, fp_attachment_ids.first)
+      expect { |blk| subject.yield_deleted_ids(es_ids, &blk) }.to yield_successive_args(fp_space_ids.first, fp_content_ids.first, fp_attachment_ids.first)
     end
   end
 end

--- a/spec/connectors_sdk/office365/adapter_spec.rb
+++ b/spec/connectors_sdk/office365/adapter_spec.rb
@@ -10,6 +10,6 @@ require 'connectors_sdk/office365/adapter'
 
 describe ConnectorsSdk::Office365::Adapter do
   it 'is not a concrete class' do
-    expect { described_class.swiftype_document_from_folder(nil) }.to raise_error(NotImplementedError)
+    expect { described_class.es_document_from_folder(nil) }.to raise_error(NotImplementedError)
   end
 end

--- a/spec/connectors_sdk/sharepoint/adapter_spec.rb
+++ b/spec/connectors_sdk/sharepoint/adapter_spec.rb
@@ -11,8 +11,8 @@ require 'support/shared_examples'
 
 describe ConnectorsSdk::SharePoint::Adapter do
   it 'should have id conversion functions set by generate_id_helpers' do
-    expect(described_class.singleton_methods).to include(:share_point_id_to_fp_id)
-    expect(described_class.singleton_methods).to include(:fp_id_to_share_point_id)
+    expect(described_class.singleton_methods).to include(:share_point_id_to_es_id)
+    expect(described_class.singleton_methods).to include(:es_id_to_share_point_id)
   end
 
   describe 'conversions to swiftype documents' do

--- a/spec/connectors_sdk/sharepoint/adapter_spec.rb
+++ b/spec/connectors_sdk/sharepoint/adapter_spec.rb
@@ -15,7 +15,7 @@ describe ConnectorsSdk::SharePoint::Adapter do
     expect(described_class.singleton_methods).to include(:es_id_to_share_point_id)
   end
 
-  describe 'conversions to swiftype documents' do
+  describe 'conversions to es documents' do
     let(:created_by) { 'creator' }
     let(:created_at) { '2017-01-20T22:27:28Z' }
     let(:created_at_rfc3339) { ConnectorsSdk::Base::Adapter.normalize_date(created_at) }
@@ -81,7 +81,7 @@ describe ConnectorsSdk::SharePoint::Adapter do
         }.merge(expected_fields).compact
       end
 
-      let(:document) { described_class.public_send(swiftype_document_method, item_in_response) }
+      let(:document) { described_class.public_send(es_document_method, item_in_response) }
 
       it 'should have the correct fields' do
         expect(document).to eq(expected_converted_hash)
@@ -98,8 +98,8 @@ describe ConnectorsSdk::SharePoint::Adapter do
       end
     end
 
-    describe '.swiftype_document_from_file' do
-      let(:swiftype_document_method) { :swiftype_document_from_file }
+    describe '.es_document_from_file' do
+      let(:es_document_method) { :es_document_from_file }
       let(:type) { 'file' }
       let(:expected_fields) do
         {
@@ -112,8 +112,8 @@ describe ConnectorsSdk::SharePoint::Adapter do
       it_behaves_like(:graph_item)
     end
 
-    describe '.swiftype_document_from_folder' do
-      let(:swiftype_document_method) { :swiftype_document_from_folder }
+    describe '.es_document_from_folder' do
+      let(:es_document_method) { :es_document_from_folder }
       let(:type) { 'folder' }
       let(:expected_fields) do
         {
@@ -124,8 +124,8 @@ describe ConnectorsSdk::SharePoint::Adapter do
       it_behaves_like(:graph_item)
     end
 
-    describe '.swiftype_document_from_package' do
-      let(:swiftype_document_method) { :swiftype_document_from_package }
+    describe '.es_document_from_package' do
+      let(:es_document_method) { :es_document_from_package }
       let(:type) { 'oneNote' }
       let(:item_in_response) do
         Hashie::Mash.new(
@@ -177,7 +177,7 @@ describe ConnectorsSdk::SharePoint::Adapter do
         }.compact
       end
 
-      let(:document) { described_class.public_send(swiftype_document_method, item_in_response) }
+      let(:document) { described_class.public_send(es_document_method, item_in_response) }
 
       it 'should have the correct fields and correctly convert type from oneNote to onenote' do
         expect(document).to eq(expected_converted_hash)

--- a/spec/connectors_sdk/sharepoint/extractor_spec.rb
+++ b/spec/connectors_sdk/sharepoint/extractor_spec.rb
@@ -259,7 +259,7 @@ describe ConnectorsSdk::SharePoint::Extractor do
     end
 
     context 'with removed item' do
-      let(:ids) { [subject.send(:convert_id_to_fp_id, 'removed_id')] }
+      let(:ids) { [subject.send(:convert_id_to_es_id, 'removed_id')] }
 
       it 'yields the deleted item id' do
         expect { |blk| subject.yield_deleted_ids(ids, &blk) }.to yield_successive_args(ids.first)
@@ -267,7 +267,7 @@ describe ConnectorsSdk::SharePoint::Extractor do
     end
 
     context 'with no item removed' do
-      let(:ids) { [subject.send(:convert_id_to_fp_id, document_id)] }
+      let(:ids) { [subject.send(:convert_id_to_es_id, document_id)] }
 
       it 'yields nothing' do
         expect { |blk| subject.yield_deleted_ids(ids, &blk) }.to yield_successive_args


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/1918

I am writing an article about BYOC and I stumbled upon some outdated namings. I understand that they've been moved from ent-search code as is, and they've been there because of historical reasons. But I think the method names having `fp_` (as in, `FritoPie`)  and `swiftype`  are really foreign to `connectors` project. 

This PR contains the code for renaming them, for example, make `convert_id_to_fp_id`  => `convert_id_to_es_id`  and `swiftype_document_from_folder`  =>  `es_document_from_folder`  etc (es  representing Enterprise Search in this context). 

I am open to other suggestions, but I do think it's important to not bring these outdated naming conventions into the new - and open-sourced project, because the external developers coming to the project won't have the historical context and it might be just a source of confusion.

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

* https://github.com/elastic/connectors/pull/89 - this PR needs to use the code changes from here.