### PR TITLE
Add sites prefix to path

### DIFF
--- a/lib/connectors_sdk/share_point/adapter.rb
+++ b/lib/connectors_sdk/share_point/adapter.rb
@@ -29,17 +29,35 @@ module ConnectorsSdk
         def self.convert_id_to_es_id(id)
           ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
         end
+
+        private
+
+        def get_path(item)
+          item.site_name.present? ? "/sites/#{item.site_name}#{super}" : super
+        end
       end
 
       class FolderGraphItem < Office365::Adapter::FolderGraphItem
         def self.convert_id_to_es_id(id)
           ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
         end
+
+        private
+
+        def get_path(item)
+          item.site_name.present? ? "/sites/#{item.site_name}#{super}" : super
+        end
       end
 
       class PackageGraphItem < Office365::Adapter::PackageGraphItem
         def self.convert_id_to_es_id(id)
           ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
+        end
+
+        private
+
+        def get_path(item)
+          item.site_name.present? ? "/sites/#{item.site_name}#{super}" : super
         end
       end
     end

--- a/lib/connectors_sdk/share_point/adapter.rb
+++ b/lib/connectors_sdk/share_point/adapter.rb
@@ -10,6 +10,12 @@ require 'connectors_sdk/office365/adapter'
 
 module ConnectorsSdk
   module SharePoint
+    module SitePrefix
+      def get_path(item)
+        item.site_name.present? ? "/sites/#{item.site_name}#{super}" : super
+      end
+    end
+
     class Adapter < Office365::Adapter
       generate_id_helpers :share_point, 'share_point'
 
@@ -26,38 +32,26 @@ module ConnectorsSdk
       end
 
       class FileGraphItem < Office365::Adapter::FileGraphItem
+        include SitePrefix
+
         def self.convert_id_to_es_id(id)
           ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
-        end
-
-        private
-
-        def get_path(item)
-          item.site_name.present? ? "/sites/#{item.site_name}#{super}" : super
         end
       end
 
       class FolderGraphItem < Office365::Adapter::FolderGraphItem
+        include SitePrefix
+
         def self.convert_id_to_es_id(id)
           ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
-        end
-
-        private
-
-        def get_path(item)
-          item.site_name.present? ? "/sites/#{item.site_name}#{super}" : super
         end
       end
 
       class PackageGraphItem < Office365::Adapter::PackageGraphItem
+        include SitePrefix
+
         def self.convert_id_to_es_id(id)
           ConnectorsSdk::SharePoint::Adapter.share_point_id_to_es_id(id)
-        end
-
-        private
-
-        def get_path(item)
-          item.site_name.present? ? "/sites/#{item.site_name}#{super}" : super
         end
       end
     end

--- a/spec/connectors_sdk/base/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/base/http_call_wrapper_spec.rb
@@ -49,9 +49,9 @@ describe ConnectorsSdk::Base::HttpCallWrapper do
         ]
       }
 
-      mock_endpoint('sites/?$select=id&search=&top=10', sites)
+      mock_endpoint('sites/?$select=id,name&search=&top=10', sites)
       mock_endpoint('groups/?$select=id,createdDateTime', groups)
-      mock_endpoint('groups/1234/sites/root?$select=id', sites)
+      mock_endpoint('groups/1234/sites/root?$select=id,name', sites)
       mock_endpoint('sites/4567/drives/?$select=id,owner,name,driveType', drives)
       # ??
       mock_endpoint('sites//drives/?$select=id,owner,name,driveType', drives)

--- a/spec/connectors_sdk/office365/custom_client_spec.rb
+++ b/spec/connectors_sdk/office365/custom_client_spec.rb
@@ -129,7 +129,7 @@ describe ConnectorsSdk::Office365::CustomClient do
       stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'groups/?$select=id,createdDateTime')
         .to_return(:status => status, :body => groups_mapped_body)
 
-      stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'groups/ed5f8403-cc9b-40bf-9adc-5642238447ab/sites/root?$select=id')
+      stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'groups/ed5f8403-cc9b-40bf-9adc-5642238447ab/sites/root?$select=id,name')
         .to_return(:status => status, :body => private_group_site_id_body)
 
       stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'sites/enterprisesearch.sharepoint.com,afb9d6f1-1ae4-422a-aea6-ea1965f7b854,91dd91fc-e210-4be2-b41f-7f1dbedb969c/drives/')
@@ -143,7 +143,7 @@ describe ConnectorsSdk::Office365::CustomClient do
       let(:site_ids_body) { connectors_fixture_raw(directory + 'sites_select_ids_before_permission_sync.json') }
 
       before(:each) do
-        stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'sites/?$select=id&search=&top=10')
+        stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'sites/?$select=id,name&search=&top=10')
           .to_return(:status => status, :body => site_ids_body)
       end
 
@@ -162,7 +162,7 @@ describe ConnectorsSdk::Office365::CustomClient do
       let(:site_ids_body) { connectors_fixture_raw(directory + 'sites_select_ids_after_permission_sync.json') }
 
       before(:each) do
-        stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'sites/?$select=id&search=&top=10')
+        stub_request(:get, ConnectorsSdk::Office365::CustomClient::BASE_URL + 'sites/?$select=id,name&search=&top=10')
           .to_return(:status => status, :body => site_ids_body)
       end
 

--- a/spec/connectors_sdk/sharepoint/adapter_spec.rb
+++ b/spec/connectors_sdk/sharepoint/adapter_spec.rb
@@ -28,6 +28,7 @@ describe ConnectorsSdk::SharePoint::Adapter do
     let(:drive_owner_name) { 'drive owner' }
     let(:parent_folder) { 'parent_folder' }
     let(:parent_path) { "/drives/eac871c1371902ee/root:/#{parent_folder}" }
+    let(:site_name) { 'test_site' }
 
     shared_examples_for(:graph_item) do
       let(:item_in_response) do
@@ -63,7 +64,8 @@ describe ConnectorsSdk::SharePoint::Adapter do
             'path' => parent_path
           },
           'size' => 10_880,
-          'drive_owner_name' => drive_owner_name
+          'drive_owner_name' => drive_owner_name,
+          'site_name' => site_name
         )
       end
 
@@ -71,7 +73,7 @@ describe ConnectorsSdk::SharePoint::Adapter do
         {
           :_fields_to_preserve => described_class.fields_to_preserve,
           :id => 'share_point_01E4DADQ55RSOGGR4HDJA2R2VN6LQRFAUK',
-          :path => "/#{parent_folder}/#{title}",
+          :path => "/sites/#{site_name}/#{parent_folder}/#{title}",
           :url => url,
           :type => type,
           :created_by => created_by,
@@ -94,7 +96,7 @@ describe ConnectorsSdk::SharePoint::Adapter do
         let(:parent_path) { '/drives/eac871c1371902ee/root:' }
 
         it 'should correctly handle when the parent is the root' do
-          expect(document[:path]).to eq("/#{title}")
+          expect(document[:path]).to eq("/sites/#{site_name}/#{title}")
         end
       end
     end
@@ -158,7 +160,8 @@ describe ConnectorsSdk::SharePoint::Adapter do
             'path' => parent_path
           },
           'size' => 5519,
-          'drive_owner_name' => drive_owner_name
+          'drive_owner_name' => drive_owner_name,
+          'site_name' => site_name
         )
       end
 
@@ -166,7 +169,7 @@ describe ConnectorsSdk::SharePoint::Adapter do
         {
           :_fields_to_preserve => described_class.fields_to_preserve,
           :id => 'share_point_01Q7HJRADY5KQSPST46REJQUOXTXHNYTE5',
-          :path => "/#{parent_folder}/#{title}",
+          :path => "/sites/#{site_name}/#{parent_folder}/#{title}",
           :title => title,
           :url => url,
           :type => 'onenote',

--- a/spec/connectors_sdk/sharepoint/extractor_spec.rb
+++ b/spec/connectors_sdk/sharepoint/extractor_spec.rb
@@ -58,7 +58,7 @@ describe ConnectorsSdk::SharePoint::Extractor do
     end
     let(:drive_ids) { share_point_site_drive_ids }
     let(:groups_url) { "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}groups/?$select=id,createdDateTime" }
-    let(:sites_url) { "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}sites/?$select=id&search=&top=10" }
+    let(:sites_url) { "#{ConnectorsSdk::Office365::CustomClient::BASE_URL}sites/?$select=id,name&search=&top=10" }
     let(:sites_body) { connectors_fixture_raw('office365/sites.json') }
     let(:site_1_id) { 'enterprisesearch.sharepoint.com,f62543c6-b329-4e0a-96c1-c1a065f5be3f,23ed25a9-4dee-4750-afb0-acb21475a499' }
     let(:site_2_id) { 'enterprisesearch.sharepoint.com,79e9ffcd-05d4-49b5-8d7c-eb0c111f218c,f19c4f31-428a-4627-89e1-72355835e8eb' }
@@ -290,7 +290,7 @@ describe ConnectorsSdk::SharePoint::Extractor do
       subject { super().yield_document_changes(:break_after_page => true, &block) }
 
       before(:each) do
-        expect_sites([:id => site_id])
+        expect_sites([:id => site_id, :name => random_string])
         expect_groups([])
         expect_site_drives(site_id, drives)
         allow(extractor).to receive(:retrieve_latest_cursors).and_return({ described_class::DRIVE_IDS_CURSOR_KEY => {} })
@@ -338,7 +338,7 @@ describe ConnectorsSdk::SharePoint::Extractor do
   end
 
   def expect_sites(sites)
-    stub_request(:get, "#{graph_base_url}sites/?$select=id&search=&top=10")
+    stub_request(:get, "#{graph_base_url}sites/?$select=id,name&search=&top=10")
       .to_return(graph_response({ value: sites }))
 
     sites

--- a/spec/connectors_sdk/sharepoint/extractor_spec.rb
+++ b/spec/connectors_sdk/sharepoint/extractor_spec.rb
@@ -170,6 +170,17 @@ describe ConnectorsSdk::SharePoint::Extractor do
         expect(subject.monitor.total_error_count).to eq(0)
       end
 
+      it 'has sites prefix in path' do
+        site = expect_sites([random_site]).first
+        drive = expect_site_drives(site[:id], [random_drive]).first
+        root = expect_root_item(drive[:id], random_item)
+        expect_item_children(drive[:id], root[:id], [random_document])
+
+        subject.yield_document_changes do |_action, document, _subextractors|
+          expect(document[:path]).to start_with("/sites/#{site[:name]}/")
+        end
+      end
+
       context 'documents fail' do
         before(:each) do
           subject.monitor = ConnectorsShared::Monitor.new(:connector => subject, :max_error_ratio => 1)


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/1982

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## For Elastic Internal Use Only
- [x] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [x] [Manual test steps](https://github.com/elastic/connectors/blob/main/docs/INTERNAL.md#minimal-manual-tests)  are successful
- [x] Enterprise Search builds successfully with a gem built from this PR's branch.
  - https://github.com/elastic/ent-search/pull/6521
