### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ We welcome contributors to the project. Before you begin, please read the [Conne
 
 - [Code of Conduct](https://www.elastic.co/community/codeofconduct)
 - [Getting Support](./docs/SUPPORT.md)
-- [Releasing](./docs/RELEASING.mg)
+- [Releasing](./docs/RELEASING.md)
 - [Developer guide](./docs/DEVELOPING.md)
 - [Security Policy](./docs/SECURITY.md)
 - [Elastic-internal guide](./docs/INTERNAL.md)


### PR DESCRIPTION
# Fixing the typo in the `RELEASING.md` link

The link from `README.md` was giving a 404 but the page actually is there. The link was just mistyped.
