### PR TITLE
Randomize test order 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ config/connectors.yml:
 	cp config/connectors.yml.example config/connectors.yml
 
 test: config/connectors.yml
-	bundle _$(shell cat .bundler-version)_ exec rspec spec
+	bundle _$(shell cat .bundler-version)_ exec rspec spec --order rand
 
 lint: config/connectors.yml
 	bundle _$(shell cat .bundler-version)_ exec rubocop lib spec

--- a/make.bat
+++ b/make.bat
@@ -25,4 +25,4 @@ call rbenv rehash
 echo "Running tests..."
 copy config\connectors.yml.example config\connectors.yml
 
-call %instpath%\versions\%RUBY_VERSION%\bin\bundle exec %instpath%\versions\%RUBY_VERSION%\bin\rspec spec
+call %instpath%\versions\%RUBY_VERSION%\bin\bundle exec %instpath%\versions\%RUBY_VERSION%\bin\rspec spec --order rand


### PR DESCRIPTION
This PR adds randomness to the order of the tests that's executed by rspec. It might help us catch more potential problems with missing/incorrect `require` statements.

See discussion in https://github.com/elastic/connectors/pull/96