### PR TITLE
Add equivalent endpoint

### DIFF
--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -175,6 +175,10 @@ class ConnectorsWebApp < Sinatra::Base
     json connector.refresh(body_params)
   end
 
+  post '/secrets' do
+    json @connector.secrets(body_params)
+  end
+
   def body_params
     @body_params ||= JSON.parse(request.body.read, symbolize_names: true).with_indifferent_access
   end

--- a/lib/app/app.rb
+++ b/lib/app/app.rb
@@ -175,8 +175,10 @@ class ConnectorsWebApp < Sinatra::Base
     json connector.refresh(body_params)
   end
 
-  post '/secrets' do
-    json @connector.secrets(body_params)
+  post '/secrets/compare' do
+    connector = settings.connector_class.new
+
+    json connector.compare_secrets(body_params)
   end
 
   def body_params

--- a/lib/connectors_sdk/base/http_call_wrapper.rb
+++ b/lib/connectors_sdk/base/http_call_wrapper.rb
@@ -91,6 +91,10 @@ module ConnectorsSdk
         { :status => 'FAILURE', :statusCode => e.is_a?(custom_client_error) ? e.status_code : 500, :message => e.message }
       end
 
+      def secrets(*)
+        raise 'Not implemented for this connector'
+      end
+
       def display_name
         raise 'Not implemented for this connector'
       end
@@ -137,6 +141,13 @@ module ConnectorsSdk
 
       def health_check(*)
         raise 'Not implemented for this connector'
+      end
+
+      def missing_secrets?(params)
+        missing = %w[secret other_secret].select { |field| params[field.to_sym].nil? }
+        unless missing.blank?
+          raise ConnectorsShared::ClientError.new("Missing required fields: #{missing.join(', ')}")
+        end
       end
     end
   end

--- a/lib/connectors_sdk/base/http_call_wrapper.rb
+++ b/lib/connectors_sdk/base/http_call_wrapper.rb
@@ -91,7 +91,7 @@ module ConnectorsSdk
         { :status => 'FAILURE', :statusCode => e.is_a?(custom_client_error) ? e.status_code : 500, :message => e.message }
       end
 
-      def secrets(*)
+      def compare_secrets(*)
         raise 'Not implemented for this connector'
       end
 

--- a/lib/connectors_sdk/confluence_cloud/http_call_wrapper.rb
+++ b/lib/connectors_sdk/confluence_cloud/http_call_wrapper.rb
@@ -17,7 +17,7 @@ module ConnectorsSdk
     class HttpCallWrapper < ConnectorsSdk::Base::HttpCallWrapper
       SERVICE_TYPE = 'confluence_cloud'
 
-      def secrets(params)
+      def compare_secrets(params)
         missing_secrets?(params)
 
         {

--- a/lib/connectors_sdk/confluence_cloud/http_call_wrapper.rb
+++ b/lib/connectors_sdk/confluence_cloud/http_call_wrapper.rb
@@ -17,6 +17,14 @@ module ConnectorsSdk
     class HttpCallWrapper < ConnectorsSdk::Base::HttpCallWrapper
       SERVICE_TYPE = 'confluence_cloud'
 
+      def secrets(params)
+        missing_secrets?(params)
+
+        {
+          :equivalent => params[:secret] == params[:other_secret]
+        }
+      end
+
       def display_name
         'Confluence Cloud'
       end

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -16,6 +16,17 @@ module ConnectorsSdk
     class HttpCallWrapper < ConnectorsSdk::Base::HttpCallWrapper
       SERVICE_TYPE = 'share_point'
 
+      def secrets(params)
+        missing_secrets?(params)
+
+        previous_user = client(:access_token => params[:other_secret][:access_token]).me
+        equivalent = previous_user.nil? ? false : previous_user.id == client(:access_token => params[:secret][:access_token]).me&.id
+
+        {
+          :equivalent => equivalent
+        }
+      end
+
       def display_name
         'SharePoint Online'
       end

--- a/lib/connectors_sdk/share_point/http_call_wrapper.rb
+++ b/lib/connectors_sdk/share_point/http_call_wrapper.rb
@@ -16,7 +16,7 @@ module ConnectorsSdk
     class HttpCallWrapper < ConnectorsSdk::Base::HttpCallWrapper
       SERVICE_TYPE = 'share_point'
 
-      def secrets(params)
+      def compare_secrets(params)
         missing_secrets?(params)
 
         previous_user = client(:access_token => params[:other_secret][:access_token]).me

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -312,15 +312,15 @@ RSpec.describe ConnectorsWebApp do
     end
   end
 
-  describe 'POST /secrets' do
+  describe 'POST /secrets/compare' do
     let(:equivalent) { true }
     before(:each) do
       basic_authorize 'ent-search', api_key
-      allow(connector).to receive(:secrets).and_return({ :equivalent => equivalent })
+      allow(connector).to receive(:compare_secrets).and_return({ :equivalent => equivalent })
     end
 
-    it 'compares secret' do
-      response = post('/secrets', '{}', { 'CONTENT_TYPE' => 'application/json' })
+    it 'compares secrets' do
+      response = post('/secrets/compare', '{}', { 'CONTENT_TYPE' => 'application/json' })
       expect(response).to be_successful
       expect(json(response).equivalent).to be_truthy
     end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -311,4 +311,18 @@ RSpec.describe ConnectorsWebApp do
       end
     end
   end
+
+  describe 'POST /secrets' do
+    let(:equivalent) { true }
+    before(:each) do
+      basic_authorize 'ent-search', api_key
+      allow(connector).to receive(:secrets).and_return({ :equivalent => equivalent })
+    end
+
+    it 'compares secret' do
+      response = post('/secrets', '{}', { 'CONTENT_TYPE' => 'application/json' })
+      expect(response).to be_successful
+      expect(json(response).equivalent).to be_truthy
+    end
+  end
 end

--- a/spec/connectors_sdk/base/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/base/http_call_wrapper_spec.rb
@@ -184,4 +184,30 @@ describe ConnectorsSdk::Base::HttpCallWrapper do
       end
     end
   end
+
+  context '.secrets' do
+    context 'when secret is missing' do
+      let(:params) { { :other_secret => 'other_secret' } }
+
+      it 'raises ClientError' do
+        expect { backend.secrets(params) }.to raise_error(ConnectorsShared::ClientError)
+      end
+    end
+
+    context 'when other_secret is missing' do
+      let(:params) { { :secret => 'secret' } }
+
+      it 'raises ClientError' do
+        expect { backend.secrets(params) }.to raise_error(ConnectorsShared::ClientError)
+      end
+    end
+
+    context 'when params is empty' do
+      let(:params) { {} }
+
+      it 'raises ClientError' do
+        expect { backend.secrets(params) }.to raise_error(ConnectorsShared::ClientError)
+      end
+    end
+  end
 end

--- a/spec/connectors_sdk/base/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/base/http_call_wrapper_spec.rb
@@ -185,12 +185,12 @@ describe ConnectorsSdk::Base::HttpCallWrapper do
     end
   end
 
-  context '.secrets' do
+  context '.compare_secrets' do
     context 'when secret is missing' do
       let(:params) { { :other_secret => 'other_secret' } }
 
       it 'raises ClientError' do
-        expect { backend.secrets(params) }.to raise_error(ConnectorsShared::ClientError)
+        expect { backend.compare_secrets(params) }.to raise_error(ConnectorsShared::ClientError)
       end
     end
 
@@ -198,7 +198,7 @@ describe ConnectorsSdk::Base::HttpCallWrapper do
       let(:params) { { :secret => 'secret' } }
 
       it 'raises ClientError' do
-        expect { backend.secrets(params) }.to raise_error(ConnectorsShared::ClientError)
+        expect { backend.compare_secrets(params) }.to raise_error(ConnectorsShared::ClientError)
       end
     end
 
@@ -206,7 +206,7 @@ describe ConnectorsSdk::Base::HttpCallWrapper do
       let(:params) { {} }
 
       it 'raises ClientError' do
-        expect { backend.secrets(params) }.to raise_error(ConnectorsShared::ClientError)
+        expect { backend.compare_secrets(params) }.to raise_error(ConnectorsShared::ClientError)
       end
     end
   end

--- a/spec/connectors_sdk/confluence_cloud/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/confluence_cloud/http_call_wrapper_spec.rb
@@ -9,7 +9,7 @@
 require 'connectors_sdk/confluence_cloud/http_call_wrapper'
 
 describe ConnectorsSdk::ConfluenceCloud::HttpCallWrapper do
-  describe '.secrets' do
+  describe '.compare_secrets' do
     context 'when secrets are equivalent' do
       let(:params) do
         {
@@ -19,7 +19,7 @@ describe ConnectorsSdk::ConfluenceCloud::HttpCallWrapper do
       end
 
       it 'returns true' do
-        expect(subject.secrets(params)[:equivalent]).to be_truthy
+        expect(subject.compare_secrets(params)[:equivalent]).to be_truthy
       end
     end
 
@@ -32,7 +32,7 @@ describe ConnectorsSdk::ConfluenceCloud::HttpCallWrapper do
       end
 
       it 'returns false' do
-        expect(subject.secrets(params)[:equivalent]).to be_falsey
+        expect(subject.compare_secrets(params)[:equivalent]).to be_falsey
       end
     end
   end

--- a/spec/connectors_sdk/confluence_cloud/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/confluence_cloud/http_call_wrapper_spec.rb
@@ -1,0 +1,39 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+require 'connectors_sdk/confluence_cloud/http_call_wrapper'
+
+describe ConnectorsSdk::ConfluenceCloud::HttpCallWrapper do
+  describe '.secrets' do
+    context 'when secrets are equivalent' do
+      let(:params) do
+        {
+          :secret => 'secret',
+          :other_secret => 'secret'
+        }
+      end
+
+      it 'returns true' do
+        expect(subject.secrets(params)[:equivalent]).to be_truthy
+      end
+    end
+
+    context 'when secrets are not equivalent' do
+      let(:params) do
+        {
+            :secret => 'secret',
+            :other_secret => 'other_secret'
+        }
+      end
+
+      it 'returns false' do
+        expect(subject.secrets(params)[:equivalent]).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
@@ -9,7 +9,7 @@
 require 'connectors_sdk/share_point/http_call_wrapper'
 
 describe ConnectorsSdk::SharePoint::HttpCallWrapper do
-  describe '.secrets' do
+  describe '.compare_secrets' do
     let(:params) do
       {
         :secret => { :access_token => 'secret' },
@@ -29,7 +29,7 @@ describe ConnectorsSdk::SharePoint::HttpCallWrapper do
       end
 
       it 'returns true' do
-        expect(subject.secrets(params)[:equivalent]).to be_truthy
+        expect(subject.compare_secrets(params)[:equivalent]).to be_truthy
       end
     end
 
@@ -41,7 +41,7 @@ describe ConnectorsSdk::SharePoint::HttpCallWrapper do
       end
 
       it 'returns false' do
-        expect(subject.secrets(params)[:equivalent]).to be_falsey
+        expect(subject.compare_secrets(params)[:equivalent]).to be_falsey
       end
     end
   end

--- a/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
+++ b/spec/connectors_sdk/sharepoint/http_call_wrapper_spec.rb
@@ -1,0 +1,48 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+require 'connectors_sdk/share_point/http_call_wrapper'
+
+describe ConnectorsSdk::SharePoint::HttpCallWrapper do
+  describe '.secrets' do
+    let(:params) do
+      {
+        :secret => { :access_token => 'secret' },
+        :other_secret => { :access_token => 'other_secret' }
+      }
+    end
+    let(:client) { double }
+    let(:user) { Hashie::Mash.new(:id => 1) }
+
+    before(:each) do
+      allow(subject).to receive(:client).and_return(client)
+    end
+
+    context 'when secrets are equivalent' do
+      before(:each) do
+        allow(client).to receive(:me).and_return(user)
+      end
+
+      it 'returns true' do
+        expect(subject.secrets(params)[:equivalent]).to be_truthy
+      end
+    end
+
+    context 'when secrets are not equivalent' do
+      let(:other_user) { Hashie::Mash.new(:id => 2) }
+
+      before(:each) do
+        allow(client).to receive(:me).and_return(user, other_user)
+      end
+
+      it 'returns false' do
+        expect(subject.secrets(params)[:equivalent]).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/1886

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

* https://github.com/elastic/ent-search/pull/6527

## For Elastic Internal Use Only
- [x] [Manual test steps](https://github.com/elastic/connectors/blob/main/docs/INTERNAL.md#minimal-manual-tests)  are successful
- [ ] Enterprise Search builds successfully with a gem built from this PR's branch.
  - _Link the ent-search PR here_
