### PR TITLE
Remove Enterprise Search gem steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,6 +43,4 @@ author(s) can easily look it up.-->
 ## For Elastic Internal Use Only
 - [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
 - [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
-- [ ] [Manual test steps](https://github.com/elastic/connectors/blob/main/docs/INTERNAL.md#minimal-manual-tests)  are successful
-- [ ] Enterprise Search builds successfully with a gem built from this PR's branch.
-  - _Link the ent-search PR here_
+- [ ] [Manual test steps](https://github.com/elastic/connectors/blob/main/docs/INTERNAL.md#minimal-manual-tests) are successful

--- a/docs/INTERNAL.md
+++ b/docs/INTERNAL.md
@@ -1,16 +1,5 @@
 # Elastic Internal Documentation
 
-### Copying artifacts to Enterprise Search
-
-Any time that changes are made to the connectors repo, that would impact the `connectors_sdk` gem, the ent-search repo should be updated to vendor the new changes. Follow the below steps to do so.
-
-1. run `make build_gem`
-1. cd to your ent-search checkout
-1. run  `gem uninstall connectors_sdk`
-1. copy the artifacts in the `.gems` directory to the `vendor/cache` directory in Enterprise Search repository.
-1. update the ent-search `Gemfile` with the new `connectors_sdk` gem build version.
-1. run `script/bundle install`
-
 ### Testing locally with Enterprise Search and Kibana
 
 ##### Setup
@@ -61,5 +50,4 @@ Any time that changes are made to the connectors repo, that would impact the `co
 - [ ] run `make run`, ensure it doesn't crash
 - [ ] run `curl -u elastic:changeme http://localhost:9292 | jq` and validate API key error
 - [ ] run `curl -u elastic:$CONNECTOR_API_KEY http://localhost:9292 | jq` and validate 200 OK
-- [ ] run `make build_gem` and copy the resulting gemfile to ent-search using the process defined in [the above section](#copying-artifacts-to-enterprise-search).
 - [ ] create a new content source using the external connector. Validate that it syncs, and that there are no errors in the ent-search or connectors logs.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,7 +1,5 @@
 # Releasing the Connectors project
 
-The Connectors project contains logic that is also packaged as a Gem to be included in the Enterprise Search distribution ([example](https://github.com/elastic/ent-search/blob/9e87bf1c293df97f3a550ed1e2a7efac18c9d8f2/Gemfile#L262)).
-
 The version scheme we use is **MAJOR.MINOR.PATCH.BUILD** and stored in the [VERSION](https://github.com/elastic/connectors/blob/main/VERSION) file
 at the root of this repository.
 
@@ -27,13 +25,6 @@ To release Connectors:
 
 A Gem will be published to RubyGems: https://rubygems.org/gems/connectors_sdk.
 
-Then immediately update ent-search's gem dependency with the released version:
-
-- Update Gemfile if necessary
-- Run `./script/bundle update --conservative connectors_sdk`
-- Verify bundler picked up the version you expected it to update to
-- PR these changes to the appropriate Enterprise Search release branch ([example](https://github.com/elastic/ent-search/pull/6476))
-
 Take care of the branching (minor releases only):
 
 - Increment the VERSION on main to match the next minor release
@@ -50,7 +41,7 @@ For instance, if someone wants to use the project as an HTTP Service and we have
 bug fix we want them to have as soon as possible.
 
 In that case, we increment the **BUILD** number, and follow the same release
-process than for the unified release, except that this gem won't ship with Enterprise Search.
+process than for the unified release.
 
 So `8.1.2.1`, `8.1.2.2` etc. On the next unified release, the version will be bumped to
 the next **PATCH** value, and **BUILD** set to `0`


### PR DESCRIPTION
In pursuit of: https://github.com/elastic/enterprise-search-team/issues/2036.

Removes some documentation references to bundling the `connectors_sdk` gem into Enterprise Search.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [X] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->

## For Elastic Internal Use Only
- [X] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [X] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [X] [Manual test steps](https://github.com/elastic/connectors/blob/main/docs/INTERNAL.md#minimal-manual-tests)  are successful
- [ ] Enterprise Search builds successfully with a gem built from this PR's branch.
  - _Link the ent-search PR here_
