### PR TITLE
Add proper logging into JobRunner

### DIFF
--- a/lib/connectors_async/job_runner.rb
+++ b/lib/connectors_async/job_runner.rb
@@ -9,6 +9,7 @@ require 'concurrent'
 require 'connectors_app/config'
 require 'connectors_async/job_store'
 require 'connectors_shared/job_status'
+require 'connectors_shared/exception_tracking'
 require 'connectors_shared/logger'
 
 module ConnectorsAsync
@@ -26,7 +27,7 @@ module ConnectorsAsync
         cursors = params[:cursors] ||= {}
         cursors[:modified_since] = params.delete(:modified_since) if params[:modified_since]
 
-        log_with_thread_id("Running the job #{job.id}")
+        log_with_thread_id(:info, "Running the job #{job.id}")
 
         job.update_status(ConnectorsShared::JobStatus::RUNNING)
 
@@ -37,15 +38,16 @@ module ConnectorsAsync
         job.update_status(ConnectorsShared::JobStatus::FINISHED)
         job.update_cursors(new_cursors)
 
-        log_with_thread_id("Job #{job.id} has finished successfully")
+        log_with_thread_id(:info, "Job #{job.id} has finished successfully")
       rescue StandardError => e
         job.fail(e)
-        log_with_thread_id("Job #{job.id} failed: #{e.message}")
+        log_with_thread_id(:error, "Job #{job.id} failed.")
+        ConnectorsShared::ExceptionTracking.log_exception(e)
       end
     end
 
-    def log_with_thread_id(str)
-      ConnectorsShared::Logger.debug("[#{Time.now.to_i}] [Thread #{Thread.current.object_id}] #{str}")
+    def log_with_thread_id(level, str)
+      ConnectorsShared::Logger.public_send(level, "[Thread #{Thread.current.name}] #{str}")
     end
 
     private

--- a/lib/connectors_async/job_runner.rb
+++ b/lib/connectors_async/job_runner.rb
@@ -26,7 +26,7 @@ module ConnectorsAsync
         cursors = params[:cursors] ||= {}
         cursors[:modified_since] = params.delete(:modified_since) if params[:modified_since]
 
-        log("Running the job #{job.id}")
+        log_with_thread_id("Running the job #{job.id}")
 
         job.update_status(ConnectorsShared::JobStatus::RUNNING)
 
@@ -37,15 +37,14 @@ module ConnectorsAsync
         job.update_status(ConnectorsShared::JobStatus::FINISHED)
         job.update_cursors(new_cursors)
 
-        log("Job #{job.id} has finished successfully")
+        log_with_thread_id("Job #{job.id} has finished successfully")
       rescue StandardError => e
         job.fail(e)
-        log("Job #{job.id} failed: #{e.message}")
+        log_with_thread_id("Job #{job.id} failed: #{e.message}")
       end
     end
 
-    def log(str)
-      # TODO: use proper logging
+    def log_with_thread_id(str)
       ConnectorsShared::Logger.debug("[#{Time.now.to_i}] [Thread #{Thread.current.object_id}] #{str}")
     end
 

--- a/lib/connectors_async/job_runner.rb
+++ b/lib/connectors_async/job_runner.rb
@@ -46,7 +46,7 @@ module ConnectorsAsync
 
     def log(str)
       # TODO: use proper logging
-      puts("[#{Time.now.to_i}] [Thread #{Thread.current.object_id}] #{str}")
+      ConnectorsShared::Logger.debug("[#{Time.now.to_i}] [Thread #{Thread.current.object_id}] #{str}")
     end
 
     private


### PR DESCRIPTION
Just cleaning up some tech debt - before I was using `puts` to output logging info, this PR changes it to use `ConnectorsShared::Logger` instead.

Ideally, the method `log_with_thread_id` should go away and we should log thread ids when running jobs natively for all code running within threads, but that's work for later.