### PR TITLE
Disabling windows specs for now

### DIFF
--- a/.ci/pipelines/connectors.groovy
+++ b/.ci/pipelines/connectors.groovy
@@ -34,7 +34,7 @@ eshPipeline(
                     reportName: 'Coverage Report'
                 ])
             },
-            nodes: ['linux', 'windows'],
+            // nodes: ['linux', 'windows'], // disabled pending https://github.com/elastic/ent-search-jenkins-lib/pull/36
             match_on_all_branches: true,
        ],
        [

--- a/lib/connectors_shared/middleware/restrict_hostnames.rb
+++ b/lib/connectors_shared/middleware/restrict_hostnames.rb
@@ -36,7 +36,7 @@ module ConnectorsShared
       def ips_from_hosts(hosts)
         hosts&.flat_map do |host|
           if URL_PATTERN.match(host)
-            lookup_ips(URI.parse(host).host)
+            lookup_ips(Addressable::URI.parse(host).hostname)
           elsif Resolv::IPv4::Regex.match(host) || Resolv::IPv6::Regex.match(host)
             IPAddr.new(host)
           else
@@ -46,7 +46,7 @@ module ConnectorsShared
       end
 
       def denied?(env)
-        requested_ips = lookup_ips(env[:url].hostname.to_s)
+        requested_ips = lookup_ips(env[:url].hostname)
         no_match = requested_ips.all? { |ip| !@allowed_ips.include?(ip) }
         return false unless no_match
         ConnectorsShared::Logger.warn("Requested url #{env[:url]} with resolved ip addresses #{requested_ips} does not match " \

--- a/lib/connectors_shared/middleware/restrict_hostnames.rb
+++ b/lib/connectors_shared/middleware/restrict_hostnames.rb
@@ -46,7 +46,7 @@ module ConnectorsShared
       end
 
       def denied?(env)
-        requested_ips = lookup_ips(env[:url].hostname)
+        requested_ips = lookup_ips(env[:url].hostname.to_s)
         no_match = requested_ips.all? { |ip| !@allowed_ips.include?(ip) }
         return false unless no_match
         ConnectorsShared::Logger.warn("Requested url #{env[:url]} with resolved ip addresses #{requested_ips} does not match " \


### PR DESCRIPTION
@tarekziade pointed out that windows tests don't really matter at the moment, and they're causing issues with surfacing CI failures (and making CI take too long) so we can disable them for now. This lets us use the "default nodes" which is `nil`, and causes us to pick up `linux && immutable`. 

This also (successfully and intentionally) exposed a bug that was present on main, causing CI to fail. So fixing that too, so that this can merge.