### PR TITLE
Mock :getaddrinfo in restrict_hostnames_spec.rb for failing test

### DIFF
--- a/spec/connectors_shared/middleware/restrict_hostnames_spec.rb
+++ b/spec/connectors_shared/middleware/restrict_hostnames_spec.rb
@@ -165,6 +165,14 @@ describe ConnectorsShared::Middleware::RestrictHostnames do
 
     context 'external domain' do
       let(:env) { external_url }
+
+      before(:each) do
+        allow(subject).to receive(:lookup_ips).and_return([
+          IPAddr.new('2a00:1450:400e:802::200e'),
+          IPAddr.new('142.251.36.46')
+        ])
+      end
+
       it_behaves_like 'an allowed call'
 
       context 'when DNS lookup changes between initialization and request' do

--- a/spec/connectors_shared/middleware/restrict_hostnames_spec.rb
+++ b/spec/connectors_shared/middleware/restrict_hostnames_spec.rb
@@ -164,13 +164,14 @@ describe ConnectorsShared::Middleware::RestrictHostnames do
     end
 
     context 'external domain' do
+      let(:actual_ip) { double('good ip', :ip_address => '203.0.113.1') }
       let(:env) { external_url }
 
       before(:each) do
-        allow(subject).to receive(:lookup_ips).and_return([
-          IPAddr.new('2a00:1450:400e:802::200e'),
-          IPAddr.new('142.251.36.46')
-        ])
+        allow(Addrinfo).to receive(:getaddrinfo).with(external_url[:url].host, nil, :UNSPEC, :STREAM).and_return(
+          [actual_ip],
+          [actual_ip]
+        )
       end
 
       it_behaves_like 'an allowed call'


### PR DESCRIPTION
Attempt to solve problem that happens in CI pipelines:
```
[2022-05-23T13:08:42.230Z]   1) ConnectorsShared::Middleware::RestrictHostnames when external URLs are allowed by URL external domain behaves like an allowed call 
[2022-05-23T13:08:42.230Z]      Failure/Error: raise AddressNotAllowed.new("Address not allowed for #{env[:url]}") if denied?(env)
[2022-05-23T13:08:42.230Z] 
[2022-05-23T13:08:42.230Z]      ConnectorsShared::Middleware::RestrictHostnames::AddressNotAllowed:
[2022-05-23T13:08:42.230Z]        Address not allowed for https://google.com/
[2022-05-23T13:08:42.230Z]      Shared Example Group: "an allowed call" called from ./spec/connectors_shared/middleware/restrict_hostnames_spec.rb:168
[2022-05-23T13:08:42.230Z]      # ./lib/connectors_shared/middleware/restrict_hostnames.rb:30:in `call'
[2022-05-23T13:08:42.230Z]      # ./spec/connectors_shared/middleware/restrict_hostnames_spec.rb:45:in `block (3 levels) in <top (required)>'
```

Example pipeline:
https://swiftype-ci.elastic.co/blue/organizations/jenkins/connectors%2Fconnectors/detail/artem%2Fadd-idle-logic-to-connector/9/pipeline

Seems like DNS resolution produces unexpected results, thus trying to solve the problem with mocking 3rd-party system calls.