### PR TITLE
Update/correct example `repository` value

### DIFF
--- a/config/connectors.yml.example
+++ b/config/connectors.yml.example
@@ -1,6 +1,6 @@
 # general metadata
 version: "CHANGEME"
-repository: "https://github.com/elastic/connectors"
+repository: "git@github.com:elastic/connectors.git"
 revision: "main"
 
 # web service


### PR DESCRIPTION
This just updates and corrects the `repository` value present in the example config file.