### PR TITLE
Minor copyedit to `readme`: add missing word to heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make run
 Consumers will need to use the `api_key` string as the password in
 the basic Authorization header.
 
-### Running a with Docker
+### Running a webserver with Docker
 You can run the web server using our Dockerfile.
 
 First, build the Docker image with:


### PR DESCRIPTION
There isn't much to explain here 🙂.