### PR TITLE
[Connector Package] - API token support #1836

### DIFF
--- a/lib/connectors_sdk/confluence_cloud/connector.rb
+++ b/lib/connectors_sdk/confluence_cloud/connector.rb
@@ -29,10 +29,6 @@ module ConnectorsSdk
         'Confluence Cloud'
       end
 
-      def connection_requires_redirect
-        true
-      end
-
       def configurable_fields
         [
           {
@@ -40,12 +36,8 @@ module ConnectorsSdk
             'label' => 'Base URL'
           },
           {
-            'key' => 'client_id',
-            'label' => 'Client ID'
-          },
-          {
-            'key' => 'client_secret',
-            'label' => 'Client Secret'
+            'key' => 'basic_auth_token',
+            'label' => 'basic_auth_token'
           },
         ]
       end
@@ -61,7 +53,10 @@ module ConnectorsSdk
       end
 
       def client(params)
-        ConnectorsSdk::ConfluenceCloud::CustomClient.new(:base_url => base_url(params[:cloud_id]), :access_token => params[:access_token])
+        ConnectorsSdk::ConfluenceCloud::CustomClient.new(
+          :base_url => base_url(params[:cloud_id]),
+          :basic_auth_token => params[:basic_auth_token]
+        )
       end
 
       def custom_client_error
@@ -69,7 +64,11 @@ module ConnectorsSdk
       end
 
       def config(params)
-        ConnectorsSdk::Atlassian::Config.new(:base_url => "#{params[:external_connector_base_url]}/wiki", :cursors => params.fetch(:cursors, {}) || {})
+        ConnectorsSdk::Atlassian::Config.new(
+          :base_url => "#{params[:external_connector_base_url]}/wiki",
+          :cursors => params.fetch(:cursors, {}) || {},
+          :index_permissions => params[:index_permissions] || false
+        )
       end
 
       def health_check(params)

--- a/spec/connectors_sdk/confluence/custom_client_spec.rb
+++ b/spec/connectors_sdk/confluence/custom_client_spec.rb
@@ -10,11 +10,21 @@ require 'connectors_sdk/confluence/custom_client'
 
 describe ConnectorsSdk::Confluence::CustomClient do
   let(:auth_token) { 'auth_token' }
+  let(:basic_auth_token) { 'confluence_is_basic' }
   let(:base_url) { 'http://localhost' }
   let(:client) do
     described_class.new(
       :base_url => base_url,
-      :access_token => 'access_token'
+      :access_token => 'access_token',
+      :basic_auth_token => nil
+    )
+  end
+
+  let(:basic_client) do
+    described_class.new(
+      :base_url => base_url,
+      :access_token => nil,
+      :basic_auth_token => basic_auth_token
     )
   end
 
@@ -91,6 +101,37 @@ describe ConnectorsSdk::Confluence::CustomClient do
     client.content_search('CQL', :expand => [], :limit => 25)
     expect(content_search_request).to have_been_requested
   end
+
+  it 'applies correct middleware for token auth' do
+    client.additional_middleware.find do |item|
+      item.is_a?(Array) && item[0].is_a?(ConnectorsShared::Middleware::BearerAuth)
+    end
+  end
+
+  it 'applies correct middleware for token auth' do
+    expect(client.additional_middleware.find do |item|
+      item.is_a?(Array) && item[0] == ConnectorsShared::Middleware::BearerAuth
+    end).to be_present
+  end
+
+  it 'does not apply incorrect middleware for token auth' do
+    expect(client.additional_middleware.find do |item|
+      item.is_a?(Array) && item[0] == ConnectorsShared::Middleware::BasicAuth
+    end).to be_nil
+  end
+
+  it 'applies correct middleware for basic auth' do
+    expect(basic_client.additional_middleware.find do |item|
+      item.is_a?(Array) && item[0] == ConnectorsShared::Middleware::BasicAuth
+    end).to be_present
+  end
+
+  it 'does not apply incorrect middleware for basic auth' do
+    expect(basic_client.additional_middleware.find do |item|
+      item.is_a?(Array) && item[0] == ConnectorsShared::Middleware::BearerAuth
+    end).to be_nil
+  end
+
 
   describe '#content' do
     let(:next_value) { '/a-provided-endpoint?with=a_param' }

--- a/spec/connectors_sdk/confluence_cloud/extractor_spec.rb
+++ b/spec/connectors_sdk/confluence_cloud/extractor_spec.rb
@@ -21,12 +21,12 @@ describe ConnectorsSdk::ConfluenceCloud::Extractor do
   let(:api_base_url) { 'https://api.atlassian.com/ex/confluence/abc123' }
   let(:content_source_id) { BSON::ObjectId.new }
   let(:oauth_config) { { :client_id => 'client_id', :client_secret => 'client_secret', :base_url => base_url } }
-  let(:access_token) { 'access_token' }
+  let(:basic_auth_token) { 'basic_auth_token' }
   let(:headers) { { 'Content-Type' => 'application/json' } }
 
   let(:authorization_data) do
     {
-      'access_token' => access_token,
+      'basic_auth_token' => basic_auth_token,
       'base_url' => base_url,
       'cloud_id' => cloud_id
     }
@@ -45,7 +45,7 @@ describe ConnectorsSdk::ConfluenceCloud::Extractor do
     proc do
       ConnectorsSdk::ConfluenceCloud::CustomClient.new(
         :base_url => api_base_url,
-        :access_token => access_token
+        :basic_auth_token => basic_auth_token
       )
     end
   end


### PR DESCRIPTION
Replacing oauth with basic auth in confluence cloud

## Closes https://github.com/elastic/enterprise-search-team/issues/1836

Implement the changes needed for a developer building a new https://github.com/elastic/enterprise-search-team/issues/1833 to be able to use API token auth in their connector
 Implement the changes to demo how a customer might clone https://github.com/elastic/enterprise-search-team/issues/1828 and register a new version of the connector using API token support

### Demo:

Show API token support in shippable form for a forked connector


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->

## For Elastic Internal Use Only
- [ ] Considered corresponding documentation changes to [contribute separately](https://github.com/elastic/enterprise-search-pubs#contribute-docs-changes-for-product-changes)
- [ ] New configuration settings added in this PR follow the [official guidelines](https://github.com/elastic/ent-search/blob/main/doc/enterprise-search-config.md)
- [ ] [Manual test steps](https://github.com/elastic/connectors/blob/main/docs/INTERNAL.md#minimal-manual-tests) are successful
