### PR TITLE
Add Elasticsearch client

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,6 @@ items that may help during the review.-->
 #### Pre-Review Checklist
 - [ ] Covered the changes with automated tests
 - [ ] Tested the changes locally
-- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
 
 #### Changes Requiring Extra Attention
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'httpclient', '~> 2.8.3'
 gem 'attr_extras', '~> 6.2.5'
 gem 'hashie', '~> 5.0.0'
 gem 'concurrent-ruby', '~> 1.1.9'
+gem 'elasticsearch'
 
 # Dependencies for oauth
 gem 'signet', '~> 0.16.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,14 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.8, >= 1.8.0)
+    elastic-transport (8.0.1)
+      faraday (~> 1)
+      multi_json
+    elasticsearch (8.2.2)
+      elastic-transport (~> 8.0)
+      elasticsearch-api (= 8.2.2)
+    elasticsearch-api (8.2.2)
+      multi_json
     faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -204,6 +212,7 @@ DEPENDENCIES
   concurrent-ruby (~> 1.1.9)
   config (~> 4.0.0)
   debase (= 0.2.5.beta2)
+  elasticsearch
   faraday (~> 1.10.0)
   faraday_middleware (= 1.0.0)
   forwardable (~> 1.3.2)

--- a/config/connectors.yml.example
+++ b/config/connectors.yml.example
@@ -3,6 +3,11 @@ version: "CHANGEME"
 repository: "git@github.com:elastic/connectors.git"
 revision: "main"
 
+elasticsearch:
+  cloud_id: "CHANGEME"
+  hosts: "CHANGEME"
+  api_key: "CHANGEME"
+
 worker:
   max_thread_count: 4
 

--- a/lib/connectors_app/config.rb
+++ b/lib/connectors_app/config.rb
@@ -21,6 +21,12 @@ puts "Parsing #{CONFIG_FILE} configuration file."
     required(:repository).value(:string)
     required(:revision).value(:string)
 
+    required(:elasticsearch).hash do
+      optional(:cloud_id).value(:string)
+      optional(:hosts).value(:string)
+      required(:api_key).value(:string)
+    end
+
     required(:worker).hash do
       required(:max_thread_count).value(:integer)
     end

--- a/lib/connectors_shared/elasticsearch_client.rb
+++ b/lib/connectors_shared/elasticsearch_client.rb
@@ -17,7 +17,8 @@ module ConnectorsShared
         client.cluster.health
       end
 
-    private
+      private
+
       def client
         @client ||= Elasticsearch::Client.new(connection_configs)
       end

--- a/lib/connectors_shared/elasticsearch_client.rb
+++ b/lib/connectors_shared/elasticsearch_client.rb
@@ -1,0 +1,39 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
+# frozen_string_literal: true
+
+require 'elasticsearch'
+require 'connectors_app/config'
+
+module ConnectorsShared
+  class ElasticsearchClient
+    class << self
+
+      def health
+        client.cluster.health
+      end
+
+    private
+      def client
+        @client ||= Elasticsearch::Client.new(connection_configs)
+      end
+
+      def connection_configs
+        es_config = ConnectorsApp::Config['elasticsearch']
+        configs = { :api_key => es_config['api_key'] }
+        if es_config['cloud_id']
+          configs[:cloud_id] = es_config['cloud_id']
+        elsif es_config['hosts']
+          configs[:hosts] = es_config['hosts']
+        else
+          raise 'Either elasitcsearch.cloud_id or elasticsearch.hosts should be configured.'
+        end
+        configs
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/2126

Add a Elasticsearch client (using [elasticsearch-ruby](https://github.com/elastic/elasticsearch-ruby))

## Checklists

#### Pre-Review Checklist
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] ~Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)~ (Removed from template in this PR)
