### PR TITLE
Use ExceptionTracking for now to log errors when polling + add info b…

### DIFF
--- a/lib/app/connector.rb
+++ b/lib/app/connector.rb
@@ -51,8 +51,9 @@ module App
         loop do
           polling_jobs
         rescue StandardError => e
-          Utility::Logger.error("Error happened during sync. error: #{e.message}")
+          Utility::ExceptionTracking.log_exception(e, 'Sync failed due to unexpected error.')
         ensure
+          Utility::Logger.info("Sleeping for #{POLL_IDLING} seconds")
           sleep(POLL_IDLING)
         end
       end


### PR DESCRIPTION
Minor improvement for development process: currently when error happens during `polling_jobs`, sometimes there's no error message, for example I've put wrong config for Elasticsearch connection and got:

```
E, [2022-06-27T17:56:33.769259 #3666] ERROR -- : Error happened during sync. error: 
```

So, there's no error message or stacktrace, I think for development purposes it's nice to log stacktrace too.