### PR TITLE
Drop threading from the connector (for now)

### DIFF
--- a/spec/app/connector_spec.rb
+++ b/spec/app/connector_spec.rb
@@ -14,16 +14,4 @@ describe App::Connector do
     allow(Connectors::REGISTRY).to receive(:connector_class).and_return(nil)
     expect { described_class.start! }.to raise_error('foobar is not a supported connector')
   end
-
-  it 'should start only once' do
-    stub_request(:get, 'http://localhost:9200/').to_return(status: 200, body: '', headers: {})
-
-    allow(described_class).to receive(:pre_flight_check)
-    allow(described_class).to receive(:start_polling_jobs)
-    allow(described_class).to receive(:ensure_index_exists)
-
-    described_class.start!
-    expect(described_class.running?).to be_truthy
-    expect { described_class.start! }.to raise_error('The connector app is already running!')
-  end
 end


### PR DESCRIPTION
I think for 8.4 it would make sense to not have any multithreading in the connector (unless we'll have a robust abstraction on top of it).

Problems that can happen now:

- If connector runs for more than 60 seconds and somebody forces a sync, second sync will start
- If connector runs too often (schedule allows for it), then it will run multiple syncs at the same time

I think currently it brings problems, thus maybe let's get rid of it until we have time to dedicate to creating a robust threading abstraction?