### PR TITLE
Add sync job logs

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -76,6 +76,7 @@ module Core
         body = {
           :connector_id => connector_package_id,
           :status => Connectors::SyncStatus::IN_PROGRESS,
+          :worker_hostname => Socket.gethostname,
           :created_at => Time.now
         }
         job = client.index(:index => JOB_INDEX, :body => body)
@@ -165,6 +166,7 @@ module Core
             :connector_id => { :type => :keyword },
             :status => { :type => :keyword },
             :error => { :type => :text },
+            :worker_hostname => { :type => :keyword },
             :indexed_document_count => { :type => :integer },
             :deleted_document_count => { :type => :integer },
             :created_at => { :type => :date },

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -71,27 +71,46 @@ module Core
           }
         }
 
-        client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
-        Utility::Logger.info("Successfully claimed job for connector #{connector_package_id}")
-      end
+      client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
 
-      def complete_sync(connector_package_id, error)
-        body = {
-          :doc => {
-            :last_sync_status => error.nil? ? Connectors::SyncStatus::COMPLETED : Connectors::SyncStatus::FAILED,
-            :last_sync_error => error,
-            :last_synced => Time.now
-          }
+      body = {
+        :connector_id => connector_package_id,
+        :status => Connectors::SyncStatus::IN_PROGRESS,
+        :created_at => Time.now
+      }
+      job = client.index(:index => JOB_INDEX, :body => body)
+
+      Utility::Logger.info("Successfully claimed job for connector #{connector_package_id}")
+      job['_id']
+    end
+
+    def complete_sync(connector_package_id, job_id, status)
+      sync_status = status[:error] ? Connectors::SyncStatus::FAILED : Connectors::SyncStatus::COMPLETED
+
+      body = {
+        :doc => {
+          :last_sync_status => sync_status,
+          :last_sync_error => status[:error],
+          :last_synced => Time.now
         }
+      }
 
         client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
 
-        if error
-          Utility::Logger.info("Failed to sync for connector #{connector_package_id} with error #{error}")
-        else
-          Utility::Logger.info("Successfully synced for connector #{connector_package_id}")
-        end
+      body = {
+        :doc => {
+            :status => sync_status,
+            :completed_at => Time.now
+        }.merge(status)
+      }
+      client.update(:index => JOB_INDEX, :id => job_id, :body => body)
+
+      if status[:error]
+        Utility::Logger.info("Failed to sync for connector #{connector_package_id} with error #{status[:error]}")
+      else
+        Utility::Logger.info("Successfully synced for connector #{connector_package_id}")
       end
+    end
 
       def client
         @client ||= Utility::EsClient.new

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -6,6 +6,7 @@
 
 # frozen_string_literal: true
 
+require 'app/config'
 require 'concurrent'
 require 'cron_parser'
 require 'connectors/registry'

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -22,8 +22,13 @@ module Core
   class SyncJobRunner
     def initialize(connector_settings, service_type)
       @connector_settings = connector_settings
-      @sink = Core::OutputSink::ElasticSink.new(connector_settings.index_name)
+      @sink = Core::OutputSink::EsSink.new(connector_settings.index_name)
       @connector_instance = Connectors::REGISTRY.connector(service_type)
+      @status = {
+        :indexed_document_count => 0,
+        :deleted_document_count => 0,
+        :error => nil
+      }
     end
 
     def execute
@@ -34,18 +39,17 @@ module Core
       validate_configuration!
       return unless should_sync?
 
-      error = nil
-
       Utility::Logger.info("Starting to sync for connector #{@connector_settings['_id']}")
       job_id = ElasticConnectorActions.claim_job(@connector_settings.id)
 
       @connector_instance.yield_documents(@connector_settings) do |document|
         @sink.ingest(document)
+        @status[:indexed_document_count] += 1
       end
     rescue StandardError => e
-      error = e
+      @status[:error] = e.message
     ensure
-      ElasticConnectorActions.complete_sync(@connector_settings.id, job_id, error)
+      ElasticConnectorActions.complete_sync(@connector_settings.id, job_id, @status.dup)
     end
 
     private

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -36,7 +36,7 @@ module Core
       error = nil
 
       Utility::Logger.info("Starting to sync for connector #{@connector_settings['_id']}")
-      ElasticConnectorActions.claim_job(@connector_settings.id)
+      job_id = ElasticConnectorActions.claim_job(@connector_settings.id)
 
       @connector_instance.yield_documents(@connector_settings) do |document|
         @sink.ingest(document)
@@ -44,7 +44,7 @@ module Core
     rescue StandardError => e
       error = e
     ensure
-      ElasticConnectorActions.complete_sync(@connector_settings.id, error)
+      ElasticConnectorActions.complete_sync(@connector_settings.id, job_id, error)
     end
 
     private


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/2157

This PR
~1. Create index `.elastic-connector-sync-logs` (see schema [here](https://github.com/elastic/enterprise-search-team/issues/2157#issuecomment-1170869941)) at the connector service startup if it does not exist.~
2. Index a new job when claiming the job.
3. Update the job when completing the job.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally