### PR TITLE
Declare a singleton of EsClient + fix usages of it

### DIFF
--- a/lib/app/connector.rb
+++ b/lib/app/connector.rb
@@ -17,8 +17,6 @@ module App
     QUERY_SIZE = 20
     POLL_IDLING = 60
 
-    @client = Utility::EsClient.new
-
     class << self
 
       def start!

--- a/lib/connectors/stub_connector/connector.rb
+++ b/lib/connectors/stub_connector/connector.rb
@@ -36,7 +36,7 @@ module Connectors
         body = [
           { index: { _index: connector['_source']['index_name'], _id: 1, data: { name: 'stub connector' } } }
         ]
-        Utility::EsClient.bulk(:body => body)
+        Utility::EsClient.instance.bulk(:body => body)
       rescue StandardError => e
         Utility.Logger.error("Error happened when syncing #{display_name}. Error: #{e.message}")
         error = e.message

--- a/lib/utility/es_client.rb
+++ b/lib/utility/es_client.rb
@@ -11,6 +11,10 @@ require 'app/config'
 
 module Utility
   class EsClient < Elasticsearch::Client
+    def self.instance
+      @client ||= new
+    end
+
     def initialize
       super(connection_configs)
     end

--- a/lib/utility/sink.rb
+++ b/lib/utility/sink.rb
@@ -54,7 +54,7 @@ module Utility
 
       def initialize(_index_name, flush_threshold = 50, flush_interval = 1.minutes)
         super()
-        @client = Utility::EsClient
+        @client = Utility::EsClient.instance
         @queue = []
         @flush_threshold = flush_threshold
         @last_flush = Time.now


### PR DESCRIPTION
After a recent commit EsClient became a regular, non-static class that inherits from `ElasticSearch::Client`.

This PR aims to fix the problem that arose from the refactoring - calls to EsClient.get and such fail because they are not proxied to a singleton.

For now I'm also not sure if we want to have EsClient a singleton in future - I'm against it just for the sake of simplicity, better testability and potentially less problems with multithreading (I'm not 100% sure if Elasticsearch::Client is thread safe)