### PR TITLE
Separate sinks from batching and fix problem with sink eventually dropping some documents

### DIFF
--- a/lib/utility/sink.rb
+++ b/lib/utility/sink.rb
@@ -30,11 +30,7 @@ module Utility
     end
 
     def add_multiple(elements)
-      elements.each do |element|
-        @queue << element
-      end
-
-      flush if ready_to_flush?
+      elements.each { |element| add(element) }
     end
 
     def flush


### PR DESCRIPTION
Problem that I faced:
ElasticSink relies on a timer to eventually flush the data into Elasticsearch when threshold of flush is not met. What it leads to is that when sync ends, sink does not always (almost never) flush the last batch of data into Elasticsearch, leading to data loss.

What this PR does:

- Introduces a new Batcher class that moves away the batching logic from the sinks. It's definitely not a final solution, but good enough to move forward and provide a way to either ingest data without batching, if needed, or with batching. We'll need to re-visit it later
- Cleans up Sink classes interfaces, moving methods around and removing not-needed statements.
- Adds very basic error handling to ElasticSink - before it was just sending request without checking the response, now it's possible to see errors that appear during ingestion

What this PR does not do:

- Move files around
- Change namespaces


These ^^^ things can be done in a separate PR.