### PR TITLE
Create system indices if absent

### DIFF
--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -42,6 +42,7 @@ module App
       connector_id = App::Config[:connector_package_id]
       config_settings = Core::ConnectorSettings.fetch(connector_id)
       Core::ElasticConnectorActions.ensure_index_exists(config_settings[:index_name])
+      Core::ElasticConnectorActions.ensure_job_index_exists
       App::Connector.start!
     end
 
@@ -52,6 +53,7 @@ module App
       connector_id = App::Config[:connector_package_id]
       config_settings = Core::ConnectorSettings.fetch(connector_id)
       Core::ElasticConnectorActions.ensure_index_exists(config_settings[:index_name])
+      Core::ElasticConnectorActions.ensure_job_index_exists
       Core::ElasticConnectorActions.force_sync(connector_id)
       App::Worker.start!
     end

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -28,6 +28,8 @@ module App
 
       def pre_flight_check
         raise "#{App::Config['service_type']} is not a supported connector" unless Connectors::REGISTRY.registered?(App::Config['service_type'])
+        Framework::ElasticConnectorActions.ensure_connectors_index_exists
+        Framework::ElasticConnectorActions.ensure_job_index_exists
       end
 
       def start_polling_jobs

--- a/lib/app/worker.rb
+++ b/lib/app/worker.rb
@@ -28,8 +28,8 @@ module App
 
       def pre_flight_check
         raise "#{App::Config['service_type']} is not a supported connector" unless Connectors::REGISTRY.registered?(App::Config['service_type'])
-        Framework::ElasticConnectorActions.ensure_connectors_index_exists
-        Framework::ElasticConnectorActions.ensure_job_index_exists
+        Core::ElasticConnectorActions.ensure_connectors_index_exists
+        Core::ElasticConnectorActions.ensure_job_index_exists
       end
 
       def start_polling_jobs

--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -32,7 +32,12 @@ module Connectors
         yield error
       end
 
-      def sync(connector); end
+      def sync(connector)
+        @sink = Utility::Sink::CombinedSink.new(
+          [Utility::Sink::ConsoleSink.new,
+           Utility::Sink::ElasticSink.new(connector['index_name'])]
+        )
+      end
 
       def source_status(params = {})
         health_check(params)

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -46,10 +46,7 @@ module Connectors
       end
 
       def sync(connector_settings)
-        @sink = Utility::Sink::CombinedSink.new(
-          [Utility::Sink::ConsoleSink.new,
-           Utility::Sink::ElasticSink.new(connector_settings[:index_name])]
-        )
+        super
         extract_projects
       end
 

--- a/lib/connectors/stub_connector/connector.rb
+++ b/lib/connectors/stub_connector/connector.rb
@@ -32,10 +32,8 @@ module Connectors
       end
 
       def sync(connector)
-        body = [
-          { index: { _index: connector['index_name'], _id: 1, data: { name: 'stub connector' } } }
-        ]
-        Utility::EsClient.bulk(:body => body)
+        super
+        @sink.ingest({ :id => 1, :name => 'stub connector' })
       end
     end
   end

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -12,7 +12,7 @@ require 'utility'
 module Core
   class ElasticConnectorActions
     CONNECTORS_INDEX = '.elastic-connectors'
-    JOB_INDEX = '.elastic-connectors-sync-logs'
+    JOB_INDEX = '.elastic-connectors-sync-jobs'
 
     class << self
 
@@ -97,6 +97,11 @@ module Core
         client.indices.create(:index => index_name, :body => body) unless client.indices.exists?(:index => index_name)
       end
 
+      def ensure_alias_exists(alias_name, body = {})
+        body[:aliases] = { alias_name => { :is_write_index => true } }
+        client.indices.create(:index => "#{alias_name}_v1", :body => body) unless client.indices.exists?(:index => alias_name)
+      end
+
       # should only be used in CLI
       def ensure_connectors_index_exists
         body = {
@@ -122,7 +127,7 @@ module Core
             }
           }
         }
-        ensure_index_exists(CONNECTORS_INDEX, body)
+        ensure_alias_exists(CONNECTORS_INDEX, body)
       end
 
       def ensure_job_index_exists
@@ -139,7 +144,7 @@ module Core
             }
           }
         }
-        ensure_index_exists(JOB_INDEX, body)
+        ensure_alias_exists(JOB_INDEX, body)
       end
     end
 

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -12,49 +12,52 @@ require 'utility'
 module Core
   class ElasticConnectorActions
     CONNECTORS_INDEX = '.elastic-connectors'
+    JOB_INDEX = '.elastic-connectors-sync-logs'
 
-    def self.force_sync(connector_package_id)
-      body = {
-        :doc => {
-          :scheduling => { :enabled => true },
-          :sync_now => true
+    class << self
+
+      def force_sync(connector_package_id)
+        body = {
+          :doc => {
+            :scheduling => { :enabled => true },
+            :sync_now => true
+          }
         }
-      }
-      client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
-      Utility::Logger.info("Successfully pushed sync_now flag for connector #{connector_package_id}")
-    end
+        client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
+        Utility::Logger.info("Successfully pushed sync_now flag for connector #{connector_package_id}")
+      end
 
-    def self.create_connector(index_name, service_type)
-      body = {
-        :scheduling => { :enabled => true },
-        :index_name => index_name,
-        :service_type => service_type
-      }
-      response = client.index(:index => CONNECTORS_INDEX, :body => body)
-      created_id = response['_id']
-      Utility::Logger.info("Successfully registered connector #{index_name} with ID #{created_id}")
-      created_id
-    end
+      def create_connector(index_name, service_type)
+        body = {
+          :scheduling => { :enabled => true },
+          :index_name => index_name,
+          :service_type => service_type
+        }
+        response = client.index(:index => CONNECTORS_INDEX, :body => body)
+        created_id = response['_id']
+        Utility::Logger.info("Successfully registered connector #{index_name} with ID #{created_id}")
+        created_id
+      end
 
-    def self.load_connector_settings(connector_package_id)
-      client.get(:index => CONNECTORS_INDEX, :id => connector_package_id, :ignore => 404).with_indifferent_access
-    end
+      def load_connector_settings(connector_package_id)
+        client.get(:index => CONNECTORS_INDEX, :id => connector_package_id, :ignore => 404).with_indifferent_access
+      end
 
-    def self.update_connector_configuration(connector_package_id, configuration)
+    def update_connector_configuration(connector_package_id, configuration)
       update_connector_field(connector_package_id, :configuration, configuration)
     end
 
-    def self.enable_connector_scheduling(connector_package_id, cron_expression)
+    def enable_connector_scheduling(connector_package_id, cron_expression)
       payload = { :enabled => true, :interval => cron_expression }
       update_connector_field(connector_package_id, :scheduling, payload)
     end
 
-    def self.disable_connector_scheduling(connector_package_id)
+    def disable_connector_scheduling(connector_package_id)
       payload = { :enabled => false }
       update_connector_field(connector_package_id, :scheduling, payload)
     end
 
-    def self.claim_job(connector_package_id)
+    def claim_job(connector_package_id)
       body = {
         :doc => {
           :sync_now => false,
@@ -67,7 +70,7 @@ module Core
       Utility::Logger.info("Successfully claimed job for connector #{connector_package_id}")
     end
 
-    def self.complete_sync(connector_package_id, error)
+    def complete_sync(connector_package_id, error)
       body = {
         :doc => {
           :last_sync_status => error.nil? ? Connectors::SyncStatus::COMPLETED : Connectors::SyncStatus::FAILED,
@@ -85,21 +88,62 @@ module Core
       end
     end
 
-    def self.client
-      @client ||= Utility::EsClient.new
+      def client
+        @client ||= Utility::EsClient.new
+      end
+
+      # should only be used in CLI
+      def ensure_index_exists(index_name, body = {})
+        client.indices.create(:index => index_name, :body => body) unless client.indices.exists?(:index => index_name)
+      end
+
+      # should only be used in CLI
+      def ensure_connectors_index_exists
+        body = {
+          :mappings => {
+            :properties => {
+              :api_key_id => { :type => :keyword },
+              :configuration => { :type => :object },
+              :error => { :type => :text },
+              :index_name => { :type => :keyword },
+              :last_seen => { :type => :date },
+              :last_synced => { :type => :date },
+              :scheduling => {
+                :properties => {
+                  :enabled => { :type => :boolean },
+                  :interval => { :type => :text }
+                }
+              },
+              :service_type => { :type => :keyword },
+              :status => { :type => :keyword },
+              :sync_error => { :type => :text },
+              :sync_now => { :type => :boolean },
+              :sync_status => { :type => :keyword }
+            }
+          }
+        }
+        ensure_index_exists(CONNECTORS_INDEX, body)
+      end
+
+      def ensure_job_index_exists
+        body = {
+          :mappings => {
+            :properties => {
+              :connector_id => { :type => :keyword },
+              :status => { :type => :keyword },
+              :error => { :type => :text },
+              :indexed_document_count => { :type => :integer },
+              :deleted_document_count => { :type => :integer },
+              :created_at => { :type => :date },
+              :completed_at => { :type => :date }
+            }
+          }
+        }
+        ensure_index_exists(JOB_INDEX, body)
+      end
     end
 
-    # should only be used in CLI
-    def self.ensure_index_exists(index_name)
-      client.indices.create(:index => index_name) unless client.indices.exists?(:index => index_name)
-    end
-
-    # should only be used in CLI
-    def self.ensure_connectors_index_exists
-      ensure_index_exists(CONNECTORS_INDEX)
-    end
-
-    def self.update_connector_field(connector_package_id, field_name, value)
+    def update_connector_field(connector_package_id, field_name, value)
       body = {
         :doc => {
           field_name => value

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -43,50 +43,50 @@ module Core
         client.get(:index => CONNECTORS_INDEX, :id => connector_package_id, :ignore => 404).with_indifferent_access
       end
 
-    def update_connector_configuration(connector_package_id, configuration)
-      update_connector_field(connector_package_id, :configuration, configuration)
-    end
-
-    def enable_connector_scheduling(connector_package_id, cron_expression)
-      payload = { :enabled => true, :interval => cron_expression }
-      update_connector_field(connector_package_id, :scheduling, payload)
-    end
-
-    def disable_connector_scheduling(connector_package_id)
-      payload = { :enabled => false }
-      update_connector_field(connector_package_id, :scheduling, payload)
-    end
-
-    def claim_job(connector_package_id)
-      body = {
-        :doc => {
-          :sync_now => false,
-          :last_sync_status => Connectors::SyncStatus::IN_PROGRESS,
-          :last_synced => Time.now
-        }
-      }
-
-      client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
-      Utility::Logger.info("Successfully claimed job for connector #{connector_package_id}")
-    end
-
-    def complete_sync(connector_package_id, error)
-      body = {
-        :doc => {
-          :last_sync_status => error.nil? ? Connectors::SyncStatus::COMPLETED : Connectors::SyncStatus::FAILED,
-          :last_sync_error => error,
-          :last_synced => Time.now
-        }
-      }
-
-      client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
-
-      if error
-        Utility::Logger.info("Failed to sync for connector #{connector_package_id} with error #{error}")
-      else
-        Utility::Logger.info("Successfully synced for connector #{connector_package_id}")
+      def update_connector_configuration(connector_package_id, configuration)
+        update_connector_field(connector_package_id, :configuration, configuration)
       end
-    end
+
+      def enable_connector_scheduling(connector_package_id, cron_expression)
+        payload = { :enabled => true, :interval => cron_expression }
+        update_connector_field(connector_package_id, :scheduling, payload)
+      end
+
+      def disable_connector_scheduling(connector_package_id)
+        payload = { :enabled => false }
+        update_connector_field(connector_package_id, :scheduling, payload)
+      end
+
+      def claim_job(connector_package_id)
+        body = {
+          :doc => {
+            :sync_now => false,
+            :last_sync_status => Connectors::SyncStatus::IN_PROGRESS,
+            :last_synced => Time.now
+          }
+        }
+
+        client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
+        Utility::Logger.info("Successfully claimed job for connector #{connector_package_id}")
+      end
+
+      def complete_sync(connector_package_id, error)
+        body = {
+          :doc => {
+            :last_sync_status => error.nil? ? Connectors::SyncStatus::COMPLETED : Connectors::SyncStatus::FAILED,
+            :last_sync_error => error,
+            :last_synced => Time.now
+          }
+        }
+
+        client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
+
+        if error
+          Utility::Logger.info("Failed to sync for connector #{connector_package_id} with error #{error}")
+        else
+          Utility::Logger.info("Successfully synced for connector #{connector_package_id}")
+        end
+      end
 
       def client
         @client ||= Utility::EsClient.new
@@ -97,54 +97,57 @@ module Core
         client.indices.create(:index => index_name, :body => body) unless client.indices.exists?(:index => index_name)
       end
 
-      def ensure_alias_exists(alias_name, body = {})
-        body[:aliases] = { alias_name => { :is_write_index => true } }
-        client.indices.create(:index => "#{alias_name}_v1", :body => body) unless client.indices.exists?(:index => alias_name)
-      end
-
-      # should only be used in CLI
-      def ensure_connectors_index_exists
+      def system_index_body(alias_name: nil, mappings: nil)
         body = {
-          :mappings => {
-            :properties => {
-              :api_key_id => { :type => :keyword },
-              :configuration => { :type => :object },
-              :error => { :type => :text },
-              :index_name => { :type => :keyword },
-              :last_seen => { :type => :date },
-              :last_synced => { :type => :date },
-              :scheduling => {
-                :properties => {
-                  :enabled => { :type => :boolean },
-                  :interval => { :type => :text }
-                }
-              },
-              :service_type => { :type => :keyword },
-              :status => { :type => :keyword },
-              :sync_error => { :type => :text },
-              :sync_now => { :type => :boolean },
-              :sync_status => { :type => :keyword }
+          :settings => {
+            :index => {
+              :hidden => true
             }
           }
         }
-        ensure_alias_exists(CONNECTORS_INDEX, body)
+        body[:aliases] = { alias_name => { :is_write_index => true } } unless alias_name.nil? || alias_name.empty?
+        body[:mappings] = mappings unless mappings.nil?
+        body
+      end
+
+      def ensure_connectors_index_exists
+        mappings = {
+          :properties => {
+            :api_key_id => { :type => :keyword },
+            :configuration => { :type => :object },
+            :error => { :type => :text },
+            :index_name => { :type => :keyword },
+            :last_seen => { :type => :date },
+            :last_synced => { :type => :date },
+            :scheduling => {
+              :properties => {
+                :enabled => { :type => :boolean },
+                :interval => { :type => :text }
+              }
+            },
+            :service_type => { :type => :keyword },
+            :status => { :type => :keyword },
+            :sync_error => { :type => :text },
+            :sync_now => { :type => :boolean },
+            :sync_status => { :type => :keyword }
+          }
+        }
+        ensure_index_exists("#{CONNECTORS_INDEX}-v1", system_index_body(:alias_name => CONNECTORS_INDEX, :mappings => mappings))
       end
 
       def ensure_job_index_exists
-        body = {
-          :mappings => {
-            :properties => {
-              :connector_id => { :type => :keyword },
-              :status => { :type => :keyword },
-              :error => { :type => :text },
-              :indexed_document_count => { :type => :integer },
-              :deleted_document_count => { :type => :integer },
-              :created_at => { :type => :date },
-              :completed_at => { :type => :date }
-            }
+        mappings = {
+          :properties => {
+            :connector_id => { :type => :keyword },
+            :status => { :type => :keyword },
+            :error => { :type => :text },
+            :indexed_document_count => { :type => :integer },
+            :deleted_document_count => { :type => :integer },
+            :created_at => { :type => :date },
+            :completed_at => { :type => :date }
           }
         }
-        ensure_alias_exists(JOB_INDEX, body)
+        ensure_index_exists("#{JOB_INDEX}-v1", system_index_body(:alias_name => JOB_INDEX, :mappings => mappings))
       end
     end
 


### PR DESCRIPTION
System indices (currently `.elastic-connectors` and `.elastic-connectors-sync-jobs`) are created at Kibana startup. But connector service can't assume the existence of Kibana, and needs to create those indices if they are absent.

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally