### PR TITLE
Rename Framework namespace to Core

### DIFF
--- a/lib/app/connector.rb
+++ b/lib/app/connector.rb
@@ -8,7 +8,7 @@
 
 require 'active_support'
 require 'connectors'
-require 'framework'
+require 'core'
 require 'utility'
 require 'app/config'
 
@@ -45,9 +45,9 @@ module App
       end
 
       def create_sync_job_runner
-        connector_settings = Framework::ConnectorSettings.fetch(App::Config['connector_package_id'])
+        connector_settings = Core::ConnectorSettings.fetch(App::Config['connector_package_id'])
 
-        Framework::SyncJobRunner.new(connector_settings)
+        Core::SyncJobRunner.new(connector_settings)
       end
     end
   end

--- a/lib/app/console_app.rb
+++ b/lib/app/console_app.rb
@@ -13,8 +13,8 @@ require 'connectors/registry'
 require 'app/menu'
 require 'app/connector'
 require 'utility/logger'
-require 'framework/elastic_connector_actions'
-require 'framework/connector_settings'
+require 'core/elastic_connector_actions'
+require 'core/connector_settings'
 
 module App
   ENV['TZ'] = 'UTC'
@@ -35,9 +35,9 @@ module App
       puts 'Initiating synchronization...'
       # these might not have been created without kibana
       connector_id = App::Config[:connector_package_id]
-      config_settings = Framework::ConnectorSettings.fetch(connector_id)
-      Framework::ElasticConnectorActions.ensure_index_exists(config_settings[:index_name])
-      Framework::ElasticConnectorActions.force_sync(connector_id)
+      config_settings = Core::ConnectorSettings.fetch(connector_id)
+      Core::ElasticConnectorActions.ensure_index_exists(config_settings[:index_name])
+      Core::ElasticConnectorActions.force_sync(connector_id)
       App::Connector.start!
     end
 
@@ -63,7 +63,7 @@ module App
         return false
       end
       # these might not have been created without kibana
-      Framework::ElasticConnectorActions.ensure_connectors_index_exists
+      Core::ElasticConnectorActions.ensure_connectors_index_exists
       # create the connector
       created_id = create_connector(index_name, force: true)
       App::Config[:connector_package_id] = created_id
@@ -71,11 +71,11 @@ module App
     end
 
     def create_connector(index_name, force: false)
-      connector_settings = Framework::ConnectorSettings.fetch(App::Config['connector_package_id'])
+      connector_settings = Core::ConnectorSettings.fetch(App::Config['connector_package_id'])
 
       if connector_settings.nil? || force
-        created_id = Framework::ElasticConnectorActions.create_connector(index_name, App::Config['service_type'])
-        connector_settings = Framework::ConnectorSettings.fetch(created_id)
+        created_id = Core::ElasticConnectorActions.create_connector(index_name, App::Config['service_type'])
+        connector_settings = Core::ConnectorSettings.fetch(created_id)
       end
 
       connector_settings.id

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -13,7 +13,6 @@ require 'connectors/gitlab/custom_client'
 require 'connectors/gitlab/adapter'
 require 'utility/sink'
 require 'app/config'
-require 'framework/connector_settings'
 
 module Connectors
   module GitLab
@@ -46,11 +45,10 @@ module Connectors
         }
       end
 
-      def sync(_connector = {})
-        config = Framework::ConnectorSettings.fetch(App::Config[:connector_package_id])
+      def sync(connector_settings)
         @sink = Utility::Sink::CombinedSink.new(
           [Utility::Sink::ConsoleSink.new,
-           Utility::Sink::ElasticSink.new(config[:index_name])]
+           Utility::Sink::ElasticSink.new(connector_settings[:index_name])]
         )
         extract_projects
       end

--- a/lib/core.rb
+++ b/lib/core.rb
@@ -6,6 +6,6 @@
 
 # frozen_string_literal: true
 
-require 'framework/connector_settings'
-require 'framework/sync_job_runner'
-require 'framework/elastic_connector_actions'
+require 'core/connector_settings'
+require 'core/sync_job_runner'
+require 'core/elastic_connector_actions'

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -9,7 +9,7 @@
 require 'active_support/core_ext/object/blank'
 require 'utility/logger'
 
-module Framework
+module Core
   class ConnectorSettings
     def self.fetch(connector_package_id)
       es_response = ElasticConnectorActions.load_connector_settings(connector_package_id)

--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -9,7 +9,7 @@
 require 'active_support/core_ext/hash'
 require 'utility'
 
-module Framework
+module Core
   class ElasticConnectorActions
     CONNECTORS_INDEX = '.elastic-connectors'
 

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -10,7 +10,7 @@ require 'concurrent'
 require 'cron_parser'
 require 'connectors/registry'
 
-module Framework
+module Core
   class IncompatibleConfigurableFieldsError < StandardError
     def initialize(expected_fields, actual_fields)
       super("Connector expected configurable fields: #{expected_fields}, actual stored fields: #{actual_fields}")


### PR DESCRIPTION
Simple `s/Framework/Core/g`.

I think "Core" is a better name for it, "Framework" is wider, more generic and marketable, so let's not use it in our namespaces.