### PR TITLE
Rename fields in .elastic-connectors

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -55,7 +55,7 @@ module Core
       body = {
         :doc => {
           :sync_now => false,
-          :sync_status => Connectors::SyncStatus::IN_PROGRESS,
+          :last_sync_status => Connectors::SyncStatus::IN_PROGRESS,
           :last_synced => Time.now
         }
       }
@@ -67,8 +67,8 @@ module Core
     def self.complete_sync(connector_package_id, error)
       body = {
         :doc => {
-          :sync_status => error.nil? ? Connectors::SyncStatus::COMPLETED : Connectors::SyncStatus::FAILED,
-          :sync_error => error,
+          :last_sync_status => error.nil? ? Connectors::SyncStatus::COMPLETED : Connectors::SyncStatus::FAILED,
+          :last_sync_error => error,
           :last_synced => Time.now
         }
       }


### PR DESCRIPTION
Rename `sync_status` and `sync_error` to `last_sync_status` and `last_sync_error` in `.elastic-connectors`. See discussion [here](https://elastic.slack.com/archives/C03GAPTQ2JF/p1657121990619269)

## Checklists

#### Pre-Review Checklist
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
