### PR TITLE
Change connector interface

### DIFF
--- a/lib/connectors/base/connector.rb
+++ b/lib/connectors/base/connector.rb
@@ -13,32 +13,7 @@ require 'utility/logger'
 module Connectors
   module Base
     class Connector
-      def sync_content_and_yield(connector)
-        error = nil
-        sync_content(connector)
-      rescue StandardError => e
-        Utility::Logger.error_with_backtrace(message: "Error happened when syncing #{display_name}", exception: e)
-        error = e.message
-      ensure
-        yield error
-      end
-
-      def sync_content(connector)
-        error = nil
-        sync(connector)
-      rescue StandardError => e
-        Utility::Logger.error("Error happened when syncing #{display_name}. Error: #{e.message}")
-        error = e.message
-      ensure
-        yield error
-      end
-
-      def sync(connector)
-        @sink = Core::OutputSink::CombinedSink.new(
-          [Core::OutputSink::ConsoleSink.new,
-           Core::OutputSink::EsSink.new(connector['index_name'])]
-        )
-      end
+      def yield_documents(connector_settings); end
 
       def source_status(params = {})
         health_check(params)

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -68,12 +68,10 @@ module Connectors
         Connectors::GitLab::CustomClient::ClientError
       end
 
-      def yield_projects
+      def yield_projects(&block)
         next_page_link = nil
         loop do
-          next_page_link = @extractor.yield_projects_page(next_page_link) do |projects_chunk|
-            yield projects_chunk
-          end
+          next_page_link = @extractor.yield_projects_page(next_page_link, &block)
           break unless next_page_link.present?
         end
       end

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -81,6 +81,10 @@ module Connectors
       def yield_project_files(projects_chunk)
         projects_chunk.each_with_index do |project, idx|
           project = project.with_indifferent_access
+
+          chunk_size = projects_chunk.size
+          Utility::Logger.info("Fetching files for project #{project[:id]} (#{idx + 1} out of #{chunk_size})...")
+
           files = @extractor.fetch_project_repository_files(project[:id])
 
           yield files

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -22,10 +22,9 @@ module Connectors
       def initialize
         super()
         @extractor = Connectors::GitLab::Extractor.new(
-          :base_url => configurable_fields[:base_url][:value],
-          :api_token => configurable_fields[:api_token][:value]
+          :base_url => configurable_fields['base_url'][:value],
+          :api_token => configurable_fields['api_token'][:value]
         )
-        @sink = nil # later set in sync
       end
 
       def display_name
@@ -34,11 +33,11 @@ module Connectors
 
       def configurable_fields
         @configurable_fields ||= {
-          :api_token => {
+          'api_token' => {
             :label => 'API Token',
             :value => App::Config[:gitlab][:api_token]
           },
-          :base_url => {
+          'base_url' => {
             :label => 'Base URL',
             :value => App::Config[:gitlab][:api_base_url] || Connectors::GitLab::DEFAULT_BASE_URL
           }

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -33,11 +33,11 @@ module Connectors
 
       def configurable_fields
         @configurable_fields ||= {
-          'api_token' => {
+          :api_token => {
             :label => 'API Token',
             :value => App::Config[:gitlab][:api_token]
           },
-          'base_url' => {
+          :base_url => {
             :label => 'Base URL',
             :value => App::Config[:gitlab][:api_base_url] || Connectors::GitLab::DEFAULT_BASE_URL
           }

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -44,18 +44,18 @@ module Connectors
         }
       end
 
-      def sync(connector_settings)
-        super(connector_settings)
+      def yield_documents(_connector_settings)
+        yield_projects do |projects_chunk|
+          projects_chunk.each do |project|
+            yield Connectors::GitLab::Adapter.to_es_document(:project, project)
 
-        extract_projects
-      end
-
-      def deleted(_params = {})
-        []
-      end
-
-      def permissions(_params = {})
-        []
+            yield_project_files(projects_chunk) do |files|
+              files.each do |file|
+                yield Connectors::GitLab::Adapter.to_es_document(:file, file)
+              end
+            end
+          end
+        end
       end
 
       private
@@ -68,36 +68,23 @@ module Connectors
         Connectors::GitLab::CustomClient::ClientError
       end
 
-      def extract_projects
+      def yield_projects
         next_page_link = nil
         loop do
           next_page_link = @extractor.yield_projects_page(next_page_link) do |projects_chunk|
-            projects = projects_chunk.map { |p| Connectors::GitLab::Adapter.to_es_document(:project, p) }
-            @sink.ingest_multiple(projects)
-            extract_project_files(projects_chunk)
+            yield projects_chunk
           end
           break unless next_page_link.present?
         end
-      rescue StandardError => e
-        puts(e.message)
-        puts(e.backtrace)
-        raise e
       end
 
-      def extract_project_files(projects_chunk)
+      def yield_project_files(projects_chunk)
         projects_chunk.each_with_index do |project, idx|
           project = project.with_indifferent_access
           files = @extractor.fetch_project_repository_files(project[:id])
-          chunk_size = projects_chunk.size
-          puts("Fetching files for project #{project[:id]} (#{idx + 1} out of #{chunk_size})...")
-          files = files.map { |file| Connectors::GitLab::Adapter.to_es_document(:file, file) }
-          project[:files] = files
-          @sink.ingest_multiple(files)
+
+          yield files
         end
-      rescue StandardError => e
-        puts(e.message)
-        puts(e.backtrace)
-        raise e
       end
     end
   end

--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -22,8 +22,8 @@ module Connectors
       def initialize
         super()
         @extractor = Connectors::GitLab::Extractor.new(
-          :base_url => configurable_fields['base_url'][:value],
-          :api_token => configurable_fields['api_token'][:value]
+          :base_url => configurable_fields[:base_url][:value],
+          :api_token => configurable_fields[:api_token][:value]
         )
       end
 

--- a/lib/connectors/mongodb/connector.rb
+++ b/lib/connectors/mongodb/connector.rb
@@ -36,9 +36,7 @@ module Connectors
         Connectors::MongoDB::CustomClient.new(hostname, database)
       end
 
-      def sync(connector)
-        super(connector)
-
+      def yield_documents(connector)
         config = connector.configuration
 
         host = config[:host][:value]
@@ -51,7 +49,7 @@ module Connectors
           doc = document.with_indifferent_access
           transform!(doc)
 
-          @sink.ingest(doc)
+          yield doc
         end
       end
 

--- a/lib/connectors/stub_connector/connector.rb
+++ b/lib/connectors/stub_connector/connector.rb
@@ -31,7 +31,7 @@ module Connectors
         true
       end
 
-      def yield_documents(connector)
+      def yield_documents(_connector)
         data = { name: 'stub connector' }
         yield data
       end

--- a/lib/connectors/stub_connector/connector.rb
+++ b/lib/connectors/stub_connector/connector.rb
@@ -31,9 +31,9 @@ module Connectors
         true
       end
 
-      def sync(connector)
-        super
-        @sink.ingest({ :id => 1, :name => 'stub connector' })
+      def yield_documents(connector)
+        data = { name: 'stub connector' }
+        yield data
       end
     end
   end

--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -30,6 +30,10 @@ module Core
       @elasticsearch_response[:_source][property_name]
     end
 
+    def index_name
+      self[:index_name]
+    end
+
     def service_type
       self[:service_type]
     end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -9,7 +9,7 @@
 require 'concurrent'
 require 'cron_parser'
 require 'connectors/registry'
-require 'utility/sink'
+require 'core/output_sink'
 
 module Core
   class IncompatibleConfigurableFieldsError < StandardError
@@ -21,7 +21,7 @@ module Core
   class SyncJobRunner
     def initialize(connector_settings, service_type)
       @connector_settings = connector_settings
-      @sink = Utility::Sink::ElasticSink.new(connector_settings.index_name)
+      @sink = Core::OutputSink::ElasticSink.new(connector_settings.index_name)
       @connector_instance = Connectors::REGISTRY.connector(service_type)
     end
 


### PR DESCRIPTION
A simplification step - connector instead of calling sink directly, can return documents (or in future events about documents), and the framework will use its own internals and settings to push the data into desired sink.

Change in a nutshell:

Before:

Connector decides how, when and where to ingest.

```ruby
def sync(settings)
    GitLabClient.get_projects.each |do| project
        @sink.ingest(project)
    end
end
```

After:

Connector returns the documents to ingest, delegating ingestion itself to the framework

```ruby
def yield_documents(settings)
    GitLabClient.get_projects.each |do| project
        yield project
    end
end
```

Upcoming future:

Connector returns events of sync - whether the document was created, updated or deleted, delegating further index operations to the framework.

```ruby
def yield_documents(settings)
    GitLabClient.get_projects.each |do| project
        yield :upsert project
    end
end
```
