### PR TITLE
Add connector configuration initialization

### DIFF
--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -42,7 +42,6 @@ module Core
     end
 
     def configuration_initialized?
-      return false if configuration.nil?
       configuration.present?
     end
 

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -24,6 +24,10 @@ module Core
     end
 
     def execute
+      unless @connector_settings.configuration_initialized?
+        @connector_settings.update_configuration(@connector_instance.configurable_fields)
+      end
+
       validate_configuration!
 
       return unless should_sync?
@@ -39,8 +43,6 @@ module Core
     private
 
     def validate_configuration!
-      return unless @connector_settings.configuration_initialized?
-
       expected_fields = @connector_instance.configurable_fields.keys
       actual_fields = @connector_settings.configuration.keys
 


### PR DESCRIPTION
Now when connector starts up and no configuration is there, connector just runs as is.

What happens now instead is - connector starts up and writes its default configuration into Elasticsearch if none is provided.

This way Kibana can show configurable fields to the user, so that they can do the initial connector setup.