### PR TITLE
Fix gitlab connector

### DIFF
--- a/lib/connectors/gitlab/connector.rb
+++ b/lib/connectors/gitlab/connector.rb
@@ -46,7 +46,7 @@ module Connectors
       end
 
       def sync(connector_settings)
-        super
+        super(connector_settings)
 
         extract_projects
       end


### PR DESCRIPTION
After recent PR with merge/rebase conflicts, I've introduced a bug to Gitlab connector - it does not correctly call `super()` when calling `sync()`.

This PR fixes this incorrect merge conflict resolution.