### PR TITLE
Move update_connector_field to the correct scope

### DIFF
--- a/lib/core/elastic_connector_actions.rb
+++ b/lib/core/elastic_connector_actions.rb
@@ -154,16 +154,16 @@ module Core
         }
         ensure_index_exists("#{JOB_INDEX}-v1", system_index_body(:alias_name => JOB_INDEX, :mappings => mappings))
       end
-    end
 
-    def update_connector_field(connector_package_id, field_name, value)
-      body = {
-        :doc => {
-          field_name => value
+      def update_connector_field(connector_package_id, field_name, value)
+        body = {
+          :doc => {
+            field_name => value
+          }
         }
-      }
-      client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
-      Utility::Logger.info("Successfully updated field #{field_name} connector #{connector_package_id}")
+        client.update(:index => CONNECTORS_INDEX, :id => connector_package_id, :body => body)
+        Utility::Logger.info("Successfully updated field #{field_name} connector #{connector_package_id}")
+      end
     end
   end
 end


### PR DESCRIPTION
`update_connector_field` method is outside of `class << self`, thus not available to class methods of ElasticConnectorActions.

This PR fixes this problem by moving `update_connector_field` inside the `class << self` scope.