### PR TITLE
Make validate_configuration! not fail if configuration is validated in symbols

### DIFF
--- a/lib/core/connector_settings.rb
+++ b/lib/core/connector_settings.rb
@@ -6,6 +6,7 @@
 
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/core_ext/object/blank'
 require 'utility/logger'
 
@@ -17,7 +18,7 @@ module Core
         Utility::Logger.debug("Connector settings not found for connector_package_id: #{connector_package_id}")
         return nil
       end
-      new(es_response)
+      new(es_response.with_indifferent_access)
     end
 
     def id

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -43,8 +43,8 @@ module Core
     private
 
     def validate_configuration!
-      expected_fields = @connector_instance.configurable_fields.keys.map { |field| field.to_s }
-      actual_fields = @connector_settings.configuration.keys.map { |field| field.to_s }
+      expected_fields = @connector_instance.configurable_fields.keys.map(&:to_s)
+      actual_fields = @connector_settings.configuration.keys.map(&:to_s)
 
       raise IncompatibleConfigurableFieldsError.new(expected_fields, actual_fields) if expected_fields != actual_fields
     end

--- a/lib/core/sync_job_runner.rb
+++ b/lib/core/sync_job_runner.rb
@@ -43,8 +43,8 @@ module Core
     private
 
     def validate_configuration!
-      expected_fields = @connector_instance.configurable_fields.keys
-      actual_fields = @connector_settings.configuration.keys
+      expected_fields = @connector_instance.configurable_fields.keys.map { |field| field.to_s }
+      actual_fields = @connector_settings.configuration.keys.map { |field| field.to_s }
 
       raise IncompatibleConfigurableFieldsError.new(expected_fields, actual_fields) if expected_fields != actual_fields
     end


### PR DESCRIPTION
When just starting up a connector, an error message is displayed:

```
/Users/artemshelkovnikov/git_tree/connectors/lib/core/sync_job_runner.rb:49:in `validate_configuration!': Connector expected configurable fields: [:api_token, :base_url], actual stored fields: ["api_token", "base_url"] (Core::IncompatibleConfigurableFieldsError)
```

It happens due to the fact that it's possible to declare configurable fields both way - as a symbol and as a string. When these values are de-serialized from the database, they are always stringified.

This commit aims to fix the validation, by stringifying the field names when validating them. 