### PR TITLE
Rename search_index to connectors_index

### DIFF
--- a/lib/utility/elasticsearch/index/mappings.rb
+++ b/lib/utility/elasticsearch/index/mappings.rb
@@ -21,7 +21,7 @@ module Utility
           }
         }.freeze
 
-        def self.default_text_fields_mappings(search_index:)
+        def self.default_text_fields_mappings(connectors_index:)
           {
             dynamic: true,
             dynamic_templates: [
@@ -68,7 +68,7 @@ module Utility
                 type: 'keyword'
               }
             }.tap do |properties|
-              properties.merge!(WORKPLACE_SEARCH_SUBEXTRACTION_STAMP_FIELD_MAPPINGS) if search_index
+              properties.merge!(WORKPLACE_SEARCH_SUBEXTRACTION_STAMP_FIELD_MAPPINGS) if connectors_index
             end
           }
         end

--- a/spec/utility/elasticsearch/mappings_spec.rb
+++ b/spec/utility/elasticsearch/mappings_spec.rb
@@ -11,10 +11,10 @@ require 'utility/elasticsearch/index/mappings'
 
 describe Utility::Elasticsearch::Index::Mappings do
   describe '#default_text_fields_mappings' do
-    subject { Utility::Elasticsearch::Index::Mappings.default_text_fields_mappings(search_index: search_index) }
+    subject { Utility::Elasticsearch::Index::Mappings.default_text_fields_mappings(connectors_index: connectors_index) }
 
     context 'when the index is a search index' do
-      let(:search_index) { true }
+      let(:connectors_index) { true }
 
       it { is_expected.to be_kind_of(Hash) }
       it { is_expected.to include(dynamic: true, dynamic_templates: Array, properties: Hash) }
@@ -22,7 +22,7 @@ describe Utility::Elasticsearch::Index::Mappings do
     end
 
     context 'when the index is not a search index' do
-      let(:search_index) { false }
+      let(:connectors_index) { false }
 
       it { is_expected.to be_kind_of(Hash) }
       it { is_expected.to include(dynamic: true, dynamic_templates: Array, properties: Hash) }


### PR DESCRIPTION
To make `search_index` more obvious this PR will rename it to `connectors_index`

## Related PRs:
* https://github.com/elastic/ent-search/pull/6657