### PR TITLE
Align with connectors gem versioning

### DIFF
--- a/connectors_utility.gemspec
+++ b/connectors_utility.gemspec
@@ -1,10 +1,16 @@
+require_relative 'lib/app/config'
+
 Gem::Specification.new do |s|
   s.name        = 'connectors_utility'
-  s.version     = '0.5'
+  s.version     = App::Config['version']
   s.homepage    = 'https://github.com/elastic/connectors'
   s.summary     = 'Gem containing shared Connector Services libraries'
   s.description = ''
   s.authors     = ['Elastic']
+  s.metadata    = {
+    "revision" => App::Config['revision'],
+    "repository" => App::Config['repository']
+  }
   s.email       = 'ent-search-dev@elastic.co'
   s.files       = %w[
                     LICENSE


### PR DESCRIPTION
It makes `connectors_utility` compatible with ES cross-versioning. 