### PR TITLE
Use DTZ rule and fix code that breaks it

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-select = ["E", "F", "B"]
+select = ["E", "F", "B", "DTZ"]
 ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -5,8 +5,8 @@
 #
 
 import datetime
-from datetime import timezone
 import re
+from datetime import timezone
 from enum import Enum
 
 from dateutil.parser import ParserError, parser
@@ -59,13 +59,17 @@ def to_float(value):
 def to_datetime(value):
     try:
         date_parser = parser()
-        parsed_date_or_datetime = date_parser.parse(timestr=value).astimezone(timezone.utc)
+        parsed_date_or_datetime = date_parser.parse(timestr=value).astimezone(
+            timezone.utc
+        )
 
         if isinstance(parsed_date_or_datetime, datetime.datetime):
             return parsed_date_or_datetime
         elif isinstance(parsed_date_or_datetime, datetime.date):
             # adds 00:00 to the date and returns datetime
-            return datetime.datetime.combine(parsed_date_or_datetime, datetime.time.min).replace(tzinfo=timezone.utc)
+            return datetime.datetime.combine(
+                parsed_date_or_datetime, datetime.time.min
+            ).replace(tzinfo=timezone.utc)
 
         return value
 

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -5,6 +5,7 @@
 #
 
 import datetime
+from datetime import timezone
 import re
 from enum import Enum
 
@@ -58,13 +59,13 @@ def to_float(value):
 def to_datetime(value):
     try:
         date_parser = parser()
-        parsed_date_or_datetime = date_parser.parse(timestr=value)
+        parsed_date_or_datetime = date_parser.parse(timestr=value).astimezone(timezone.utc)
 
         if isinstance(parsed_date_or_datetime, datetime.datetime):
             return parsed_date_or_datetime
         elif isinstance(parsed_date_or_datetime, datetime.date):
             # adds 00:00 to the date and returns datetime
-            return datetime.datetime.combine(parsed_date_or_datetime, datetime.time.min)
+            return datetime.datetime.combine(parsed_date_or_datetime, datetime.time.min).replace(tzinfo=timezone.utc)
 
         return value
 

--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -10,7 +10,7 @@ import contextlib
 import inspect
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps
 from typing import AsyncGenerator
 
@@ -36,7 +36,7 @@ class ExtraLogger(logging.Logger):
             {
                 "service.type": "connectors-python",
                 "service.version": __version__,
-                "labels.index_date": datetime.now().strftime("%Y.%m.%d"),
+                "labels.index_date": datetime.now(timezone.utc).strftime("%Y.%m.%d"),
             }
         )
         super(ExtraLogger, self)._log(level, msg, args, exc_info, extra)

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -200,6 +200,9 @@ class JobSchedulingService(BaseService):
                 )
                 return False
 
+            print("NEXT is {next_sync}")
+            print("NOW is {now}")
+
             next_sync_due = (next_sync - now).total_seconds()
             if next_sync_due - self.idling > 0:
                 logger.debug(

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -10,7 +10,7 @@ Event loop
 - instantiates connector plugins
 - mirrors an Elasticsearch index with a collection of documents
 """
-from datetime import datetime
+from datetime import datetime, timezone
 
 from connectors.es.client import License, with_concurrency_control
 from connectors.es.index import DocumentNotFoundError
@@ -176,7 +176,7 @@ class JobSchedulingService(BaseService):
                 return False
 
             job_type_value = job_type.value
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             last_sync_scheduled_at = connector.last_sync_scheduled_at_by_job_type(
                 job_type
             )

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -789,9 +789,7 @@ class SharepointOnlineDataSource(BaseDataSource):
         # same everything. But it will already be an absolutely new document.
         # Therefore every time we try to download the attachment we say that
         # it was just recently created so that framework would always re-download it.
-        new_timestamp = datetime.now(
-                timezone.utc
-            )
+        new_timestamp = datetime.now(timezone.utc)
 
         doc = {
             "_id": attachment["odata.id"],

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -73,7 +73,7 @@ def iso_utc(when=None):
 
 def next_run(quartz_definition):
     """Returns the datetime of the next run."""
-    cron_obj = QuartzCron(quartz_definition, datetime.utcnow())
+    cron_obj = QuartzCron(quartz_definition, datetime.now(timezone.utc))
     return cron_obj.next_trigger()
 
 
@@ -492,7 +492,7 @@ def evaluate_timedelta(seconds, time_skew=0):
         seconds (int): Number of seconds to add in current time
         time_skew (int): Time of clock skew. Defaults to 0
     """
-    modified_time = datetime.utcnow() + timedelta(seconds=seconds)
+    modified_time = datetime.now(timezone.utc) + timedelta(seconds=seconds)
     # account for clock skew
     modified_time -= timedelta(seconds=time_skew)
     return iso_utc(when=modified_time)
@@ -507,7 +507,7 @@ def is_expired(expires_at):
     # Recreate in case there's no expires_at present
     if expires_at is None:
         return True
-    return datetime.utcnow() >= expires_at
+    return datetime.now(timezone.utc) >= expires_at
 
 
 def get_pem_format(key, max_split=-1):

--- a/tests/filtering/test_basic_rule.py
+++ b/tests/filtering/test_basic_rule.py
@@ -5,6 +5,7 @@
 #
 
 import datetime
+from datetime import timezone
 
 import pytest
 
@@ -92,10 +93,12 @@ AMOUNT_INT_VALUE = 100
 
 CREATED_AT_DATE_KEY = "created_at_date"
 # we expect that the data sources parse their dates to datetime
-CREATED_AT_DATE_VALUE = datetime.datetime(year=2022, month=1, day=1, hour=0, minute=0)
+CREATED_AT_DATE_VALUE = datetime.datetime(
+    year=2022, month=1, day=1, hour=0, minute=0, tzinfo=timezone.utc
+)
 CREATED_AT_DATETIME_KEY = "created_at_datetime"
 CREATED_AT_DATETIME_VALUE = datetime.datetime(
-    year=2022, month=1, day=1, hour=5, minute=10, microsecond=5
+    year=2022, month=1, day=1, hour=5, minute=10, microsecond=5, tzinfo=timezone.utc
 )
 
 DOCUMENT_ONE = {
@@ -1266,15 +1269,17 @@ def test_coerce_rule_value_to_datetime_date_if_it_is_datetime():
         policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
         rule=Rule.LESS_THAN,
-        value=str(datetime.datetime(year=2022, month=1, day=1)),
+        value=str(datetime.datetime(year=2022, month=1, day=1, tzinfo=timezone.utc)),
     )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
-        datetime.datetime(year=2023, month=2, day=2)
+        datetime.datetime(year=2023, month=2, day=2, tzinfo=timezone.utc)
     )
 
     assert isinstance(coerced_rule_value, datetime.datetime)
-    assert coerced_rule_value == datetime.datetime(year=2022, month=1, day=1)
+    assert coerced_rule_value == datetime.datetime(
+        year=2022, month=1, day=1, tzinfo=timezone.utc
+    )
 
 
 def test_coerce_rule_value_to_datetime_date_if_it_is_date():
@@ -1284,15 +1289,17 @@ def test_coerce_rule_value_to_datetime_date_if_it_is_date():
         policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
         rule=Rule.LESS_THAN,
-        value=str(datetime.date(year=2022, month=1, day=1)),
+        value=str(datetime.date(year=2022, month=1, day=1, tzinfo=timezone.utc)),
     )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
-        datetime.date(year=2023, month=2, day=2)
+        datetime.date(year=2023, month=2, day=2, tzinfo=timezone.utc)
     )
 
     assert isinstance(coerced_rule_value, datetime.date)
-    assert coerced_rule_value == datetime.datetime(year=2022, month=1, day=1)
+    assert coerced_rule_value == datetime.datetime(
+        year=2022, month=1, day=1, tzinfo=timezone.utc
+    )
 
 
 def test_coerce_rule_to_default_if_type_is_not_registered():

--- a/tests/filtering/test_basic_rule.py
+++ b/tests/filtering/test_basic_rule.py
@@ -1289,11 +1289,11 @@ def test_coerce_rule_value_to_datetime_date_if_it_is_date():
         policy=Policy.INCLUDE,
         field=DESCRIPTION_KEY,
         rule=Rule.LESS_THAN,
-        value=str(datetime.date(year=2022, month=1, day=1, tzinfo=timezone.utc)),
+        value=str(datetime.date(year=2022, month=1, day=1)),
     )
 
     coerced_rule_value = basic_rule.coerce_rule_value_based_on_document_value(
-        datetime.date(year=2023, month=2, day=2, tzinfo=timezone.utc)
+        datetime.date(year=2023, month=2, day=2)
     )
 
     assert isinstance(coerced_rule_value, datetime.date)

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -195,7 +195,7 @@ ACCESS_CONTROL_INDEX_PREFIX = "search-acl-filter-"
 
 def test_utc():
     # All dates are in ISO 8601 UTC so we can serialize them
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     then = json.loads(json.dumps({"date": iso_utc(when=now)}))["date"]
     assert now.isoformat() == then
 

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1209,7 +1209,7 @@ async def test_connector_update_last_sync_scheduled_at_by_job_type(
     doc_id = "2"
     seq_no = 2
     primary_term = 1
-    new_ts = datetime.utcnow() + timedelta(seconds=30)
+    new_ts = datetime.now(timezone.utc) + timedelta(seconds=30)
     connector_doc = {
         "_id": doc_id,
         "_seq_no": seq_no,

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -5,7 +5,7 @@
 #
 import asyncio
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -283,7 +283,7 @@ async def test_connector_scheduled_incremental_sync(
 ):
     connector = mock_connector(
         service_type=service_type,
-        next_sync=datetime.utcnow(),
+        next_sync=datetime.now(timezone.utc),
         incremental_sync_enabled=incremental_sync_enabled,
         document_level_security_enabled=False,
     )

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -217,7 +217,7 @@ async def test_connector_both_on_demand_and_scheduled(
     sync_job_index_mock,
     set_env,
 ):
-    connector = mock_connector(sync_now=True, next_sync=datetime.now(timezone.utc))
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     await create_and_run_service()
 
@@ -393,8 +393,8 @@ async def test_connector_prepare_failed(
 async def test_run_when_sync_fails_then_continues_service_execution(
     connector_index_mock, set_env
 ):
-    connector = mock_connector(next_sync=datetime.utcnow())
-    another_connector = mock_connector(next_sync=datetime.utcnow())
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
+    another_connector = mock_connector(next_sync=datetime.now(timezone.utc))
     connector_index_mock.supported_connectors.return_value = AsyncIterator(
         [connector, another_connector]
     )

--- a/tests/sources/test_azure_blob_storage.py
+++ b/tests/sources/test_azure_blob_storage.py
@@ -92,8 +92,8 @@ def test_prepare_blob_doc():
     }
     expected_output = {
         "_id": "container1/blob1",
-        "_timestamp": "2022-04-21T12:12:30",
-        "created at": "2022-04-21T12:12:30",
+        "_timestamp": "2022-04-21T12:12:30+00:00",
+        "created at": "2022-04-21T12:12:30+00:00",
         "content type": "plain/text",
         "container metadata": "{'key1': 'value1', 'key2': 'value2'}",
         "metadata": "{'key1': 'value1', 'key2': 'value2'}",
@@ -173,8 +173,8 @@ async def test_get_blob():
     with patch.object(ContainerClient, "list_blobs", return_value=mock_response):
         expected_output = {
             "_id": "container1/blob1",
-            "_timestamp": "2022-04-21T12:12:30",
-            "created at": "2022-04-21T12:12:30",
+            "_timestamp": "2022-04-21T12:12:30+00:00",
+            "created at": "2022-04-21T12:12:30+00:00",
             "content type": "plain/text",
             "container metadata": "{'key1': 'value1'}",
             "metadata": "{'key1': 'value1', 'key2': 'value2'}",

--- a/tests/sources/test_azure_blob_storage.py
+++ b/tests/sources/test_azure_blob_storage.py
@@ -6,7 +6,7 @@
 """Tests the Azure Blob Storage source class methods"""
 
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -83,8 +83,8 @@ def test_prepare_blob_doc():
         "container": "container1",
         "name": "blob1",
         "content_settings": {"content_type": "plain/text"},
-        "last_modified": datetime(2022, 4, 21, 12, 12, 30),
-        "creation_time": datetime(2022, 4, 21, 12, 12, 30),
+        "last_modified": datetime(2022, 4, 21, 12, 12, 30, tzinfo=timezone.utc),
+        "creation_time": datetime(2022, 4, 21, 12, 12, 30, tzinfo=timezone.utc),
         "metadata": "{'key1': 'value1', 'key2': 'value2'}",
         "lease": {"status": "Locked", "state": "Leased", "duration": "Infinite"},
         "blob_tier": "private",
@@ -124,7 +124,7 @@ async def test_get_container():
         [
             {
                 "name": "container1",
-                "last_modified": datetime(2022, 4, 21, 12, 12, 30),
+                "last_modified": datetime(2022, 4, 21, 12, 12, 30, tzinfo=timezone.utc),
                 "metadata": {"key1": "value1"},
                 "lease": {
                     "status": "Locked",
@@ -157,8 +157,8 @@ async def test_get_blob():
                 "container": "container1",
                 "name": "blob1",
                 "content_settings": {"content_type": "plain/text"},
-                "last_modified": datetime(2022, 4, 21, 12, 12, 30),
-                "creation_time": datetime(2022, 4, 21, 12, 12, 30),
+                "last_modified": datetime(2022, 4, 21, 12, 12, 30, tzinfo=timezone.utc),
+                "creation_time": datetime(2022, 4, 21, 12, 12, 30, tzinfo=timezone.utc),
                 "metadata": "{'key1': 'value1', 'key2': 'value2'}",
                 "lease": {
                     "status": "Locked",

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 from unittest.mock import Mock
 
@@ -124,7 +124,7 @@ async def test_advanced_rules_validator(advanced_rules, is_valid):
 
 
 def build_resp():
-    doc1 = {"id": "one", "tuple": (1, 2, 3), "date": datetime.now()}
+    doc1 = {"id": "one", "tuple": (1, 2, 3), "date": datetime.now(timezone.utc)}
     doc2 = {"id": "two", "dict": {"a": "b"}, "decimal": Decimal128("0.0005")}
 
     class Docs(dict):

--- a/tests/sources/test_mysql.py
+++ b/tests/sources/test_mysql.py
@@ -5,6 +5,7 @@
 #
 import asyncio
 import datetime
+from datetime import timezone
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 import aiomysql
@@ -73,7 +74,7 @@ ALICE = {"id": 1, "name": "Alice", "age": 30}
 BOB = {"id": 2, "name": "Bob", "age": 30}
 TIME = "2023-01-18T17:18:56.814003+00:00"
 TIMESTAMP = datetime.datetime(
-    year=2023, month=1, day=2, hour=5, second=10, microsecond=3
+    year=2023, month=1, day=2, hour=5, second=10, microsecond=3, tzinfo=timezone.utc
 )
 
 

--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -186,19 +186,19 @@ async def test_get_files(dir_mock):
     expected_output = [
         {
             "_id": "1",
-            "_timestamp": "2022-04-21T12:12:30",
+            "_timestamp": "2022-04-21T12:12:30+00:00",
             "path": "\\1.2.3.4/dummy_path/a1.md",
             "title": "a1.md",
-            "created_at": "2022-01-11T12:12:30",
+            "created_at": "2022-01-11T12:12:30+00:00",
             "size": "30",
             "type": "file",
         },
         {
             "_id": "122",
-            "_timestamp": "2022-05-21T12:12:30",
+            "_timestamp": "2022-05-21T12:12:30+00:00",
             "path": "\\1.2.3.4/dummy_path/A",
             "title": "A",
-            "created_at": "2022-02-11T12:12:30",
+            "created_at": "2022-02-11T12:12:30+00:00",
             "size": "200",
             "type": "folder",
         },

--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -7,6 +7,7 @@
 """
 import asyncio
 import datetime
+from datetime import timezone
 from io import BytesIO
 from unittest import mock
 
@@ -38,11 +39,11 @@ def mock_file(name):
     mock_stats["allocation_size"].get_value.return_value = "30"
     mock_stats["creation_time"] = mock.Mock()
     mock_stats["creation_time"].get_value.return_value = datetime.datetime(
-        2022, 1, 11, 12, 12, 30
+        2022, 1, 11, 12, 12, 30, tzinfo=timezone.utc
     )
     mock_stats["change_time"] = mock.Mock()
     mock_stats["change_time"].get_value.return_value = datetime.datetime(
-        2022, 4, 21, 12, 12, 30
+        2022, 4, 21, 12, 12, 30, tzinfo=timezone.utc
     )
 
     mock_response._dir_info.fields = mock_stats
@@ -68,11 +69,11 @@ def mock_folder(name):
     mock_stats["allocation_size"].get_value.return_value = "200"
     mock_stats["creation_time"] = mock.Mock()
     mock_stats["creation_time"].get_value.return_value = datetime.datetime(
-        2022, 2, 11, 12, 12, 30
+        2022, 2, 11, 12, 12, 30, tzinfo=timezone.utc
     )
     mock_stats["change_time"] = mock.Mock()
     mock_stats["change_time"].get_value.return_value = datetime.datetime(
-        2022, 5, 21, 12, 12, 30
+        2022, 5, 21, 12, 12, 30, tzinfo=timezone.utc
     )
     mock_response._dir_info.fields = mock_stats
     return mock_response

--- a/tests/sources/test_s3.py
+++ b/tests/sources/test_s3.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -62,7 +62,7 @@ class Summary:
         Returns:
             datetime: Current time
         """
-        return datetime.now()
+        return datetime.now(timezone.utc)
 
     @property
     async def storage_class(self):

--- a/tests/sources/test_sharepoint.py
+++ b/tests/sources/test_sharepoint.py
@@ -928,7 +928,7 @@ async def test_set_access_token_when_token_expires_at_is_str():
     """This method tests set access token  api call when token_expires_at type is str"""
     # Setup
     source = create_source(SharepointDataSource)
-    source.sharepoint_client.token_expires_at = "2023-02-10T09:02:23.629821"
+    source.sharepoint_client.token_expires_at = "2023-02-10T09:02:23.629821+00:00"
     mock_token = {"access_token": "test2344", "expires_in": "1234555"}
     async_response_token = MockResponse(mock_token, 200)
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -24,7 +24,7 @@ from connectors.protocol import JobType, Pipeline
 from tests.commons import AsyncIterator
 
 INDEX = "some-index"
-TIMESTAMP = datetime(year=2023, month=1, day=1)
+TIMESTAMP = datetime(year=2023, month=1, day=1, tzinfo=timezone.utc)
 NO_FILTERING = ()
 DOC_ONE_ID = 1
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -4,8 +4,8 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
-import datetime
 from copy import deepcopy
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 from unittest.mock import ANY, Mock, call
 
@@ -24,7 +24,7 @@ from connectors.protocol import JobType, Pipeline
 from tests.commons import AsyncIterator
 
 INDEX = "some-index"
-TIMESTAMP = datetime.datetime(year=2023, month=1, day=1)
+TIMESTAMP = datetime(year=2023, month=1, day=1)
 NO_FILTERING = ()
 DOC_ONE_ID = 1
 
@@ -32,7 +32,7 @@ DOC_ONE = {"_id": DOC_ONE_ID, "_timestamp": TIMESTAMP}
 
 DOC_ONE_DIFFERENT_TIMESTAMP = {
     "_id": DOC_ONE_ID,
-    "_timestamp": TIMESTAMP + datetime.timedelta(days=1),
+    "_timestamp": TIMESTAMP + timedelta(days=1),
 }
 
 DOC_TWO = {"_id": 2, "_timestamp": TIMESTAMP}
@@ -138,7 +138,7 @@ async def test_prepare_content_index(mock_responses):
 
 def set_responses(mock_responses, ts=None):
     if ts is None:
-        ts = datetime.datetime.now().isoformat()
+        ts = datetime.now(timezone.utc).isoformat()
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.get(
         "http://nowhere.com:9200/search-some-index",
@@ -251,7 +251,7 @@ async def test_async_bulk(mock_responses):
 
         yield {
             "_id": "1",
-            "_timestamp": datetime.datetime.now().isoformat(),
+            "_timestamp": datetime.now(timezone.utc).isoformat(),
         }, _dl, "index"
         yield {"_id": "3"}, _dl_none, "index"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ import string
 import tempfile
 import time
 import timeit
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import Mock, mock_open, patch
 
 import pytest
@@ -51,11 +51,11 @@ from connectors.utils import (
 )
 
 
-@freeze_time("2023-01-18 17:18:56.814003", tick=True)
+@freeze_time("2023-01-18 17:18:56.814003+00:00", tick=True)
 def test_next_run():
     # can run within two minutes
-    assert next_run("1 * * * * *").isoformat(" ", "seconds") == "2023-01-18 17:19:01"
-    assert next_run("* * * * * *").isoformat(" ", "seconds") == "2023-01-18 17:18:57"
+    assert next_run("1 * * * * *").isoformat(" ", "seconds") == "2023-01-18 17:19:01+00:00"
+    assert next_run("* * * * * *").isoformat(" ", "seconds") == "2023-01-18 17:18:57+00:00"
 
     # this should get parsed
     next_run("0/5 14,18,52 * ? JAN,MAR,SEP MON-FRI 2010-2030")
@@ -448,7 +448,7 @@ def test_url_encode():
 def test_is_expired():
     """This method checks whether token expires or not"""
     # Execute
-    expires_at = datetime.fromisoformat("2023-02-10T09:02:23.629821")
+    expires_at = datetime.fromisoformat("2023-02-10T09:02:23.629821+00:00")
     actual_response = is_expired(expires_at=expires_at)
     # Assert
     assert actual_response is True
@@ -461,7 +461,7 @@ def test_evaluate_timedelta():
     expected_response = evaluate_timedelta(seconds=86399, time_skew=20)
 
     # Assert
-    assert expected_response == "2023-02-19T14:25:05.158843"
+    assert expected_response == "2023-02-19T10:25:05.158843+00:00" # -4 hours because of tz_offset
 
 
 def test_get_pem_format():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ import string
 import tempfile
 import time
 import timeit
-from datetime import datetime, timezone
+from datetime import datetime
 from unittest.mock import Mock, mock_open, patch
 
 import pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,8 +54,12 @@ from connectors.utils import (
 @freeze_time("2023-01-18 17:18:56.814003+00:00", tick=True)
 def test_next_run():
     # can run within two minutes
-    assert next_run("1 * * * * *").isoformat(" ", "seconds") == "2023-01-18 17:19:01+00:00"
-    assert next_run("* * * * * *").isoformat(" ", "seconds") == "2023-01-18 17:18:57+00:00"
+    assert (
+        next_run("1 * * * * *").isoformat(" ", "seconds") == "2023-01-18 17:19:01+00:00"
+    )
+    assert (
+        next_run("* * * * * *").isoformat(" ", "seconds") == "2023-01-18 17:18:57+00:00"
+    )
 
     # this should get parsed
     next_run("0/5 14,18,52 * ? JAN,MAR,SEP MON-FRI 2010-2030")
@@ -461,7 +465,9 @@ def test_evaluate_timedelta():
     expected_response = evaluate_timedelta(seconds=86399, time_skew=20)
 
     # Assert
-    assert expected_response == "2023-02-19T10:25:05.158843+00:00" # -4 hours because of tz_offset
+    assert (
+        expected_response == "2023-02-19T10:25:05.158843+00:00"
+    )  # -4 hours because of tz_offset
 
 
 def test_get_pem_format():


### PR DESCRIPTION
Small problem found: we have no linter verifying that we use timezones in consistent manner.

- Adding "DTZ" rule for Ruff: https://beta.ruff.rs/docs/rules/#flake8-datetimez-dtz
- Fixing code that breaks the rules