### PR TITLE
Use BoundedSemaphore instead of asyncio.Event to control the max concurrency

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -359,7 +359,7 @@ class ConcurrentTasks:
     def __init__(self, max_concurrency=5, results_callback=None):
         self.tasks = []
         self.results_callback = results_callback
-        self._sem = asyncio.Semaphore(max_concurrency)
+        self._sem = asyncio.BoundedSemaphore(max_concurrency)
 
     def __len__(self):
         return len(self.tasks)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -388,6 +388,9 @@ class ConcurrentTasks:
         await self._sem.acquire()
         task = asyncio.create_task(coroutine())
         self.tasks.append(task)
+        # _callback will be executed when the task is done,
+        # i.e. the wrapped coroutine either returned a value, raised an exception, or the Task was cancelled.
+        # Ref: https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.done
         task.add_done_callback(
             functools.partial(self._callback, result_callback=result_callback)
         )

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -357,21 +357,22 @@ class ConcurrentTasks:
     """
 
     def __init__(self, max_concurrency=5, results_callback=None):
-        self.max_concurrency = max_concurrency
         self.tasks = []
         self.results_callback = results_callback
-        self._task_over = asyncio.Event()
+        self._sem = asyncio.Semaphore(max_concurrency)
 
     def __len__(self):
         return len(self.tasks)
 
     def _callback(self, task, result_callback=None):
         self.tasks.remove(task)
-        self._task_over.set()
-        if task.exception():
-            logger.error(
-                f"Exception found for task {task.get_name()}: {task.exception()}"
-            )
+        self._sem.release()
+        try:
+            exception = task.exception()
+        except Exception as e:
+            exception = e
+        if exception:
+            logger.error(f"Exception found for task {task.get_name()}: {exception}")
         if result_callback is not None:
             result_callback(task.result())
         # global callback
@@ -386,11 +387,7 @@ class ConcurrentTasks:
 
         If provided, `result_callback` will be called when the task is done.
         """
-        # If self.tasks has reached its max size, we wait for one task to finish
-        if len(self.tasks) >= self.max_concurrency:
-            await self._task_over.wait()
-            # rearm
-            self._task_over.clear()
+        await self._sem.acquire()
         task = asyncio.create_task(coroutine())
         self.tasks.append(task)
         task.add_done_callback(

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -367,12 +367,10 @@ class ConcurrentTasks:
     def _callback(self, task, result_callback=None):
         self.tasks.remove(task)
         self._sem.release()
-        try:
-            exception = task.exception()
-        except Exception as e:
-            exception = e
-        if exception:
-            logger.error(f"Exception found for task {task.get_name()}: {exception}")
+        if task.exception():
+            logger.error(
+                f"Exception found for task {task.get_name()}: {task.exception()}"
+            )
         if result_callback is not None:
             result_callback(task.result())
         # global callback

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,7 +258,7 @@ async def test_concurrent_runner():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_fails():
+async def test_concurrent_runner_fails(patch_logger):
     results = []
 
     def _results_callback(result):
@@ -276,6 +276,7 @@ async def test_concurrent_runner_fails():
 
     await runner.join()
     assert 5 not in results
+    patch_logger.assert_present("I FAILED")
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,6 +258,30 @@ async def test_concurrent_runner():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_runner_canceled():
+    results = []
+    tasks = []
+
+    def _results_callback(result):
+        results.append(result)
+
+    async def coroutine(i):
+        await asyncio.sleep(1)
+        return i
+
+    runner = ConcurrentTasks(max_concurrency=10, results_callback=_results_callback)
+    for i in range(10):
+        tasks.append(await runner.put(functools.partial(coroutine, i)))
+
+    runner.cancel()
+    await runner.join()
+    assert len(tasks) == 10
+    for task in tasks:
+        assert task.cancelled()
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
 async def test_concurrent_runner_fails():
     results = []
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,7 +258,7 @@ async def test_concurrent_runner():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_fails(patch_logger):
+async def test_concurrent_runner_fails():
     results = []
 
     def _results_callback(result):
@@ -276,7 +276,6 @@ async def test_concurrent_runner_fails(patch_logger):
 
     await runner.join()
     assert 5 not in results
-    patch_logger.assert_present("I FAILED")
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -282,6 +282,32 @@ async def test_concurrent_runner_canceled():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_runner_canceled_with_waiting_task():
+    results = []
+
+    def _results_callback(result):
+        results.append(result)
+
+    async def coroutine(i, sleep_time):
+        await asyncio.sleep(sleep_time)
+        return i
+
+    runner = ConcurrentTasks(max_concurrency=10, results_callback=_results_callback)
+    for i in range(10):
+        await runner.put(functools.partial(coroutine, i, 1))  # long-running task
+
+    # create a task to put a waiting task so that it won't block
+    asyncio.create_task(runner.put(functools.partial(coroutine, 100, 0.1)))
+    runner.cancel()
+    # wait for the first 10 tasks to be canceled
+    await runner.join()
+    # wait for the 11th task to complete
+    await runner.join()
+    assert len(results) == 1
+    assert results[0] == 100
+
+
+@pytest.mark.asyncio
 async def test_concurrent_runner_fails():
     results = []
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5193

### What's the change:

This PR uses `asyncio.BoundedSemaphore` instead of `asyncio.Event` to control the max concurrency of `ConcurrentTasks`

### Why the change:

1. `BoundedSemaphore` is a better fit for this use case.
2. There's a [bug](https://github.com/elastic/connectors-python/pull/1477#issuecomment-1690159544) in the original implementation, and you can verify it by adding and running this test in [test_utils.py](https://github.com/elastic/connectors-python/blob/main/tests/test_utils.py):
```python
@pytest.mark.asyncio
async def test_concurrent_runner():
    async def coroutine(i, sleep_time):
        await asyncio.sleep(sleep_time)
        print(f"Complete task {i}")

    runner = ConcurrentTasks(max_concurrency=1)
    # push a short-running task a and wait for its completion
    await runner.put(functools.partial(coroutine, "a", 0.1))
    print()
    print(f"task a was pushed into pool at {datetime.now()}")
    await runner.join()

    # push a long-running task b and a short-running task c, c was supposed to block until b is done
    await runner.put(functools.partial(coroutine, "b", 5))
    print(f"task b was pushed into pool at {datetime.now()}")
    await runner.put(functools.partial(coroutine, "c", 0.1))
    print(f"task c was pushed into pool at {datetime.now()}")
    await runner.join()
```

The output in `main` branch:
```shell
task a was pushed into pool at 2023-08-24 21:40:34.742396
Complete task a
task b was pushed into pool at 2023-08-24 21:40:34.844073
task c was pushed into pool at 2023-08-24 21:40:34.844197 # task c was pushed into the pool at the same time with task b, but it's supposed to block and wait for the completion of task b (5 seconds)
Complete task c # task c was completed first
Complete task b
```

If you run the same test in this PR, you get:
```shell
task a was pushed into pool at 2023-08-24 21:48:27.405617
Complete task a
task b was pushed into pool at 2023-08-24 21:48:27.506222
Complete task b
task c was pushed into pool at 2023-08-24 21:48:32.508061
Complete task c
```

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)