### PR TITLE
Add non-blocking try_put method to ConcurrentTasks

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -380,11 +380,11 @@ class ConcurrentTasks:
 
         # put a task into pool
         # it will block until the task was put successfully
-        task = task_pool.put(a_coroutine)
+        task = await task_pool.put(coroutine)
 
         # put a task without blocking
         # it will try to put the task, and return None if it can't be put immediately
-        task = task_pool.try_put(a_coroutine)
+        task = task_pool.try_put(coroutine)
 
         # call join to wait for all tasks in pool to complete
         # this is not required to execute the tasks in pool

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -372,6 +372,25 @@ class ConcurrentTasks:
 
     - `max_concurrency`: max concurrent tasks allowed, default: 5
     - `results_callback`: when provided, synchronous function called with the result of each task.
+
+    Examples:
+
+        # create a task pool with the default max concurrency
+        task_pool = ConcurrentTasks()
+
+        # put a task into pool
+        # it will block until the task was put successfully
+        task = task_pool.put(a_coroutine)
+
+        # put a task without blocking
+        # it will try to put the task, and return None if it can't be put immediately
+        task = task_pool.try_put(a_coroutine)
+
+        # call join to wait for all tasks in pool to complete
+        # this is not required to execute the tasks in pool
+        # a task will be automatically scheduled to execute once it's put successfully
+        # call join() only when you need to do something after all tasks in pool complete
+        await task_pool.join()
     """
 
     def __init__(self, max_concurrency=5, results_callback=None):

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -428,6 +428,7 @@ class ConcurrentTasks:
 
         if self._sem.try_acquire():
             return self._add_task(coroutine, result_callback=result_callback)
+        return None
 
     async def join(self):
         """Wait for all tasks to finish."""

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -414,6 +414,20 @@ class ConcurrentTasks:
         )
         return task
 
+    async def try_put(self, coroutine, result_callback=None):
+        """Tries to add a coroutine for immediate execution.
+
+        If the number of running tasks reach `max_concurrency`, this
+        function return a None task immediately
+
+        If provided, `result_callback` will be called when the task is done.
+        """
+
+        if self._sem.locked():
+            return None
+
+        return await self.put(coroutine, result_callback=result_callback)
+
     async def join(self):
         """Wait for all tasks to finish."""
         await asyncio.gather(*self.tasks, return_exceptions=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -324,7 +324,7 @@ async def test_concurrent_runner_canceled_with_waiting_task():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_fails():
+async def test_concurrent_runner_fails(patch_logger):
     results = []
 
     def _results_callback(result):
@@ -343,6 +343,7 @@ async def test_concurrent_runner_fails():
 
     await runner.join()
     assert 5 not in results
+    patch_logger.assert_present("I FAILED")
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -374,6 +374,27 @@ async def test_concurrent_runner_high_concurrency():
     assert second_results == [3]
 
 
+@pytest.mark.asyncio
+async def test_concurrent_runner_try_put():
+    results = []
+
+    def _results_callback(result):
+        results.append(result)
+
+    async def coroutine(i):
+        await asyncio.sleep(0.1)
+        return i
+
+    runner = ConcurrentTasks(1, results_callback=_results_callback)
+    await runner.put(functools.partial(coroutine, 0))
+    task = await runner.try_put(functools.partial(coroutine, 1))
+
+    await runner.join()
+
+    assert task is None
+    assert 1 not in results
+
+
 @contextlib.contextmanager
 def temp_file(converter):
     if converter == "system":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -324,7 +324,7 @@ async def test_concurrent_runner_canceled_with_waiting_task():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_fails(patch_logger):
+async def test_concurrent_runner_fails():
     results = []
 
     def _results_callback(result):
@@ -343,7 +343,6 @@ async def test_concurrent_runner_fails(patch_logger):
 
     await runner.join()
     assert 5 not in results
-    patch_logger.assert_present("I FAILED")
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -387,7 +387,7 @@ async def test_concurrent_runner_try_put():
 
     runner = ConcurrentTasks(1, results_callback=_results_callback)
     await runner.put(functools.partial(coroutine, 0))
-    task = await runner.try_put(functools.partial(coroutine, 1))
+    task = runner.try_put(functools.partial(coroutine, 1))
 
     await runner.join()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -412,14 +412,6 @@ async def test_concurrent_runner_try_put(initial_capacity, expected_result):
         assert task is None
         assert 100 not in results
 
-    # try_put the third task
-    task_2 = runner.try_put(functools.partial(coroutine, 2))
-
-    await runner.join()
-
-    assert task_2 is not None
-    assert 2 in results
-
 
 @contextlib.contextmanager
 def temp_file(converter):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -298,32 +298,6 @@ async def test_concurrent_runner_canceled():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_canceled_with_waiting_task():
-    results = []
-
-    def _results_callback(result):
-        results.append(result)
-
-    async def coroutine(i, sleep_time):
-        await asyncio.sleep(sleep_time)
-        return i
-
-    runner = ConcurrentTasks(max_concurrency=10, results_callback=_results_callback)
-    for i in range(10):
-        await runner.put(functools.partial(coroutine, i, 1))  # long-running task
-
-    # create a task to put a waiting task so that it won't block
-    asyncio.create_task(runner.put(functools.partial(coroutine, 100, 0.1)))
-    runner.cancel()
-    # wait for the first 10 tasks to be canceled
-    await runner.join()
-    # wait for the 11th task to complete
-    await runner.join()
-    assert len(results) == 1
-    assert results[0] == 100
-
-
-@pytest.mark.asyncio
 async def test_concurrent_runner_fails():
     results = []
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -298,6 +298,32 @@ async def test_concurrent_runner_canceled():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_runner_canceled_with_waiting_task():
+    results = []
+
+    def _results_callback(result):
+        results.append(result)
+
+    async def coroutine(i, sleep_time):
+        await asyncio.sleep(sleep_time)
+        return i
+
+    runner = ConcurrentTasks(max_concurrency=10, results_callback=_results_callback)
+    for i in range(10):
+        await runner.put(functools.partial(coroutine, i, 1))  # long-running task
+
+    # create a task to put a waiting task so that it won't block
+    asyncio.create_task(runner.put(functools.partial(coroutine, 100, 0.1)))
+    runner.cancel()
+    # wait for the first 10 tasks to be canceled
+    await runner.join()
+    # wait for the 11th task to complete
+    await runner.join()
+    assert len(results) == 1
+    assert results[0] == 100
+
+
+@pytest.mark.asyncio
 async def test_concurrent_runner_fails():
     results = []
 


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5193

### What's the change

This PR adds a `try_put` method to `ConcurrentTasks`. Compared to the `put` method, `try_put` will return a `None` task immediately if the `ConcurrentTasks` are not ready to accept a new task.

### Why the change

The new method will be used in #1865, by both `AccessControlSyncJobExecutionService` and `ContentSyncJobExecutionService`. 

The existing `put` method is blocking, which will prevent the loop of both services from going to the next iteration.

While `try_put` will return immediately if there's no space available, allowing the service to try in the next iteration instead of blocking.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)