### PR TITLE
Improve the job execution concurrency

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -371,6 +371,20 @@ class ConcurrentTasks:
         )
         return task
 
+    async def try_put(self, coroutine, result_callback=None):
+        """Tries to add a coroutine for immediate execution.
+
+        If the number of running tasks reach `max_concurrency`, this
+        function return a None task immediately
+
+        If provided, `result_callback` will be called when the task is done.
+        """
+
+        if self._sem.locked():
+            return None
+
+        return await self.put(coroutine, result_callback=result_callback)
+
     async def join(self):
         """Wait for all tasks to finish."""
         await asyncio.gather(*self.tasks, return_exceptions=True)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -363,6 +363,9 @@ class ConcurrentTasks:
         await self._sem.acquire()
         task = asyncio.create_task(coroutine())
         self.tasks.append(task)
+        # _callback will be executed when the task is done,
+        # i.e. the wrapped coroutine either returned a value, raised an exception, or the Task was cancelled.
+        # Ref: https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.done
         task.add_done_callback(
             functools.partial(self._callback, result_callback=result_callback)
         )

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -334,7 +334,7 @@ class ConcurrentTasks:
     def __init__(self, max_concurrency=5, results_callback=None):
         self.tasks = []
         self.results_callback = results_callback
-        self._sem = asyncio.Semaphore(max_concurrency)
+        self._sem = asyncio.BoundedSemaphore(max_concurrency)
 
     def __len__(self):
         return len(self.tasks)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -342,12 +342,10 @@ class ConcurrentTasks:
     def _callback(self, task, result_callback=None):
         self.tasks.remove(task)
         self._sem.release()
-        try:
-            exception = task.exception()
-        except Exception as e:
-            exception = e
-        if exception:
-            logger.error(f"Exception found for task {task.get_name()}: {exception}")
+        if task.exception():
+            logger.error(
+                f"Exception found for task {task.get_name()}: {task.exception()}"
+            )
         if result_callback is not None:
             result_callback(task.result())
         # global callback

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -348,6 +348,27 @@ async def test_concurrent_runner_high_concurrency():
     assert second_results == [3]
 
 
+@pytest.mark.asyncio
+async def test_concurrent_runner_try_put():
+    results = []
+
+    def _results_callback(result):
+        results.append(result)
+
+    async def coroutine(i):
+        await asyncio.sleep(0.1)
+        return i
+
+    runner = ConcurrentTasks(1, results_callback=_results_callback)
+    await runner.put(functools.partial(coroutine, 0))
+    task = await runner.try_put(functools.partial(coroutine, 1))
+
+    await runner.join()
+
+    assert task is None
+    assert 1 not in results
+
+
 @contextlib.contextmanager
 def temp_file(converter):
     if converter == "system":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -249,7 +249,7 @@ async def test_concurrent_runner():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_fails():
+async def test_concurrent_runner_fails(patch_logger):
     results = []
 
     def _results_callback(result):
@@ -267,6 +267,7 @@ async def test_concurrent_runner_fails():
 
     await runner.join()
     assert 5 not in results
+    patch_logger.assert_present("I FAILED")
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -249,7 +249,7 @@ async def test_concurrent_runner():
 
 
 @pytest.mark.asyncio
-async def test_concurrent_runner_fails(patch_logger):
+async def test_concurrent_runner_fails():
     results = []
 
     def _results_callback(result):
@@ -267,7 +267,6 @@ async def test_concurrent_runner_fails(patch_logger):
 
     await runner.join()
     assert 5 not in results
-    patch_logger.assert_present("I FAILED")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5193

This PR improves the job execution concurrency by:
1. use fire-and-forget mechanism to execute sync jobs. It puts the sync job to the task pool and doesn't wait for its completion.
2. use non-blocking `try_put` method for job execution. If the task pool is full, it will retry in the next iteration. 

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)