### PR TITLE
Make Network Drive ftest use shared fixture

### DIFF
--- a/tests/sources/fixtures/network_drive/fixture.py
+++ b/tests/sources/fixtures/network_drive/fixture.py
@@ -5,10 +5,13 @@
 #
 """Network Drive module responsible to generate file/folder(s) on Network Drive server.
 """
-import random
-import string
+import os
 
 import smbclient
+
+from tests.commons import WeightedFakeProvider
+
+fake_provider = WeightedFakeProvider()
 
 SERVER = "127.0.0.1"
 NUMBER_OF_SMALL_FILES = 10000
@@ -17,26 +20,15 @@ NUMBER_OF_FILES_TO_BE_DELETED = 10
 USERNAME = "admin"
 PASSWORD = "abc@123"
 
+DATA_SIZE = os.environ.get("DATA_SIZE", "medium")
 
-def generate_small_files():
-    """Method for generating small files on Network Drive server"""
-    try:
-        smbclient.register_session(server=SERVER, username=USERNAME, password=PASSWORD)
-
-        print("Started loading small files on network drive server....")
-
-        for number in range(0, NUMBER_OF_SMALL_FILES):
-            with smbclient.open_file(
-                rf"\\{SERVER}/Folder1/file{number}.txt", mode="w"
-            ) as fd:
-                fd.write(f"File {number} dummy content....")
-
-        print(f"Loaded {NUMBER_OF_SMALL_FILES} small files on network drive server....")
-    except Exception as error:
-        print(
-            f"Error occurred while generating small files on Network Drive server. Error: {error}"
-        )
-        raise
+match DATA_SIZE:
+    case "small":
+        FILE_COUNT = 1000
+    case "medium":
+        FILE_COUNT = 5000
+    case "large":
+        FILE_COUNT = 25000
 
 
 def generate_folder():
@@ -54,42 +46,31 @@ def generate_folder():
         )
 
 
-def generate_large_files():
-    """Method for generating large files on Network Drive server"""
+def generate_files():
+    """Method for generating files on Network Drive server"""
     try:
-        size_of_file = 1024**2  # 1 Mb of text
-        large_data = "".join(
-            [random.choice(string.ascii_letters) for i in range(size_of_file)]
-        )
-
         smbclient.register_session(server=SERVER, username=USERNAME, password=PASSWORD)
 
-        print("Started loading large files on network drive server....")
+        print("Started loading files on network drive server....")
 
-        for number in range(0, NUMBER_OF_LARGE_FILES):
+        for number in range(FILE_COUNT):
             with smbclient.open_file(
-                rf"\\{SERVER}/Folder1/Large-Data-Folder/large_size_file{number}.txt",
+                rf"\\{SERVER}/Folder1/file{number}.html",
                 mode="w",
             ) as fd:
-                fd.write(large_data)
+                fd.write(fake_provider.get_html())
 
-        print(f"Loaded {NUMBER_OF_LARGE_FILES} large files on network drive server....")
+        print(f"Loaded {FILE_COUNT} files on network drive server....")
     except Exception as error:
         print(
-            f"Error occurred while generating large files on Network Drive server. Error: {error}"
+            f"Error occurred while generating files on Network Drive server. Error: {error}"
         )
         raise
 
 
 def load():
-    if NUMBER_OF_SMALL_FILES:
-        generate_small_files()
     generate_folder()
-    if NUMBER_OF_LARGE_FILES:
-        generate_large_files()
-    print(
-        f"Loaded {NUMBER_OF_LARGE_FILES} large files, {NUMBER_OF_SMALL_FILES} small files, and 1 folder on network drive server."
-    )
+    generate_files()
 
 
 def remove():
@@ -100,8 +81,8 @@ def remove():
         print("Started deleting files from network drive server....")
 
         for number in range(0, NUMBER_OF_FILES_TO_BE_DELETED):
-            smbclient.remove(rf"\\{SERVER}/Folder1/file{number}.txt")
-            smbclient.remove(rf"\\{SERVER}/Folder1/.deleted/file{number}.txt")
+            smbclient.remove(rf"\\{SERVER}/Folder1/file{number}.html")
+            smbclient.remove(rf"\\{SERVER}/Folder1/.deleted/file{number}.html")
 
         print(
             f"Deleted {NUMBER_OF_FILES_TO_BE_DELETED} files from network drive server...."


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3397

This PR changes the fixture for the respected content source to make use of shared test setup using `WeightedFakeProvider` class.

This class takes care of generating large fake data with certain distribution, for example:

```python
# In 65% cases generate small files
# In 20% cases generate medium size files
# In 10% cases generate large files
# in 5% cases generate huge files
fake_provider = WeightedFakeProvider(weights=[0.65, 0.2, 0.1, 0.05])

fake_provider.get_html() # <---- gets HTML of size depending on distribution
fake_provider.get_text() # <---- gets text of size depending on distribution

# Important difference
# get_text() returns huge amount of text that can be ingested, for example 2MB payload
# get_html() returns a huge payload that has too little text, for example for 2MB html it's around 1KB of text to text download/subextraction of rich content better
```

The final goal of the PR is to have more comparable benchmarks in our nightly functional tests of the amount of memory or cpu that is needed to run the connector.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally

## Related Pull Requests

- [ ] https://github.com/elastic/connectors-python/pull/1709
- [ ] https://github.com/elastic/connectors-python/pull/1710
- [ ] https://github.com/elastic/connectors-python/pull/1717
- [ ] https://github.com/elastic/connectors-python/pull/1718
- [ ] https://github.com/elastic/connectors-python/pull/1719
- [ ] https://github.com/elastic/connectors-python/pull/1720
- [ ] https://github.com/elastic/connectors-python/pull/1725
- [ ] https://github.com/elastic/connectors-python/pull/1726
- [ ] https://github.com/elastic/connectors-python/pull/1735
- [ ] https://github.com/elastic/connectors-python/pull/1736
- [ ] https://github.com/elastic/connectors-python/pull/1744
- [ ] https://github.com/elastic/connectors-python/pull/1745
- [ ] https://github.com/elastic/connectors-python/pull/1754
- [ ] https://github.com/elastic/connectors-python/pull/1755
- [ ] https://github.com/elastic/connectors-python/pull/1756
- [ ] https://github.com/elastic/connectors-python/pull/1763
- [ ] https://github.com/elastic/connectors-python/pull/1764
