### PR TITLE
Make MySQL ftest use shared fixture

### DIFF
--- a/tests/commons.py
+++ b/tests/commons.py
@@ -95,6 +95,10 @@ class WeightedFakeProvider:
         ]
 
     @cached_property
+    def fake(self):
+        return self.fake_provider.fake
+
+    @cached_property
     def _htmls(self):
         return [
             self.fake_provider.small_html(),

--- a/tests/sources/fixtures/mysql/fixture.py
+++ b/tests/sources/fixtures/mysql/fixture.py
@@ -5,9 +5,9 @@
 #
 import os
 import random
-import string
 
 from mysql.connector import connect
+
 from tests.commons import WeightedFakeProvider
 
 fake_provider = WeightedFakeProvider(weights=[0.65, 0.3, 0.05, 0])
@@ -30,7 +30,6 @@ BATCH_SIZE = 100
 DATABASE_NAME = "customerinfo"
 
 
-
 def get_num_docs():
     print(NUM_TABLES * (RECORD_COUNT - RECORDS_TO_DELETE))
 
@@ -45,9 +44,7 @@ def inject_lines(table, cursor, lines):
         batch_size = min(BATCH_SIZE, lines - inserted)
         for row_id in range(batch_size):
             rows.append((fake_provider.fake.name(), row_id, fake_provider.get_text()))
-        sql_query = (
-            f"INSERT INTO customers_{table} (name, age, description) VALUES (%s, %s, %s)"
-        )
+        sql_query = f"INSERT INTO customers_{table} (name, age, description) VALUES (%s, %s, %s)"
         cursor.executemany(sql_query, rows)
         inserted += batch_size
         print(f"Inserting batch #{batch} of {batch_size} documents.")
@@ -76,7 +73,9 @@ def remove():
     cursor.execute(f"USE {DATABASE_NAME}")
     for table in range(NUM_TABLES):
         print(f"Working on table {table}...")
-        rows = [(row_id,) for row_id in random.sample(range(1, 1000), RECORDS_TO_DELETE)]
+        rows = [
+            (row_id,) for row_id in random.sample(range(1, 1000), RECORDS_TO_DELETE)
+        ]
         print(rows)
         sql_query = f"DELETE from customers_{table} WHERE id IN (%s)"
         cursor.executemany(sql_query, rows)

--- a/tests/sources/fixtures/mysql/fixture.py
+++ b/tests/sources/fixtures/mysql/fixture.py
@@ -39,7 +39,7 @@ def inject_lines(table, cursor, lines):
     batch_count = max(int(lines / BATCH_SIZE), 1)
 
     inserted = 0
-    print(f"Inserting {lines} lines")
+    print(f"Inserting {lines} lines in {batch_count} batches")
     for batch in range(batch_count):
         rows = []
         batch_size = min(BATCH_SIZE, lines - inserted)


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3397

This PR changes the fixture for the respected content source to make use of shared test setup using `WeightedFakeProvider` class.

This class takes care of generating large fake data with certain distribution, for example:

```python
# In 65% cases generate small files
# In 20% cases generate medium size files
# In 10% cases generate large files
# in 5% cases generate huge files
fake_provider = WeightedFakeProvider(weights=[0.65, 0.2, 0.1, 0.05])

fake_provider.get_html() # <---- gets HTML of size depending on distribution
fake_provider.get_text() # <---- gets text of size depending on distribution

# Important difference
# get_text() returns huge amount of text that can be ingested, for example 2MB payload
# get_html() returns a huge payload that has too little text, for example for 2MB html it's around 1KB of text to text download/subextraction of rich content better
```

The final goal of the PR is to have more comparable benchmarks in our nightly functional tests of the amount of memory or cpu that is needed to run the connector.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally

## Related Pull Requests

- [ ] https://github.com/elastic/connectors-python/pull/1709
- [ ] https://github.com/elastic/connectors-python/pull/1710
- [ ] https://github.com/elastic/connectors-python/pull/1717
- [ ] https://github.com/elastic/connectors-python/pull/1718
- [ ] https://github.com/elastic/connectors-python/pull/1719
- [ ] https://github.com/elastic/connectors-python/pull/1720
- [ ] https://github.com/elastic/connectors-python/pull/1725
- [ ] https://github.com/elastic/connectors-python/pull/1726
- [ ] https://github.com/elastic/connectors-python/pull/1734
- [ ] https://github.com/elastic/connectors-python/pull/1736
- [ ] https://github.com/elastic/connectors-python/pull/1744
- [ ] https://github.com/elastic/connectors-python/pull/1745
- [ ] https://github.com/elastic/connectors-python/pull/1754
- [ ] https://github.com/elastic/connectors-python/pull/1755
- [ ] https://github.com/elastic/connectors-python/pull/1756
- [ ] https://github.com/elastic/connectors-python/pull/1763
- [ ] https://github.com/elastic/connectors-python/pull/1764
