### PR TITLE
Make OneDrive ftest use shared fixture

### DIFF
--- a/tests/commons.py
+++ b/tests/commons.py
@@ -95,6 +95,10 @@ class WeightedFakeProvider:
         ]
 
     @cached_property
+    def fake(self):
+        return self.fake_provider.fake
+
+    @cached_property
     def _htmls(self):
         return [
             self.fake_provider.small_html(),

--- a/tests/sources/fixtures/onedrive/fixture.py
+++ b/tests/sources/fixtures/onedrive/fixture.py
@@ -7,14 +7,14 @@
 
 import io
 import os
-import random
-import string
 import time
 
-from faker import Faker
 from flask import Flask, make_response, request
 from flask_limiter import HEADERS, Limiter
 from flask_limiter.util import get_remote_address
+from tests.commons import WeightedFakeProvider
+
+fake_provider = WeightedFakeProvider()
 
 app = Flask(__name__)
 
@@ -56,23 +56,9 @@ if THROTTLING:
 
     limiter.init_app(app)
 
-SMALL = 100000
-MEDIUM = 500000
-LARGE = 1000000
-
-
-def _create_data(size):
-    return "".join([random.choice(string.ascii_letters) for _ in range(size)])
-
-
-FILE_DATA = {
-    SMALL: _create_data(size=SMALL),
-    MEDIUM: _create_data(size=MEDIUM),
-    LARGE: _create_data(size=LARGE),
-}
 
 TOKEN_EXPIRATION_TIMEOUT = 3699  # seconds
-fake = Faker()
+fake = fake_provider.fake
 DRIVE_ID = fake.uuid4()
 ROOT = os.environ.get("ROOT_HOST_URL", "http://127.0.0.1:10972")
 
@@ -85,6 +71,7 @@ class DataGenerator:
     def __init__(self):
         self.users = []
         self.files_per_user = {}
+        self.files_by_id = {}
 
     def generate(self):
         # Generate users in Azure AD
@@ -100,8 +87,9 @@ class DataGenerator:
             # Generate files and folders in the OneDrive for each user
 
             for file_id in range(1, FILE_COUNT_PER_USER + 1):
+                item_id = f"{user_id}-{file_id}"
                 item = {
-                    "id": f"{user_id}-{file_id}",
+                    "id": item_id,
                 }
 
                 if file_id % 11 == 0:  # Every 11th is a folder
@@ -109,19 +97,13 @@ class DataGenerator:
                     item["name"] = fake.word()
                     item["size"] = 0
                 else:
+                    file_content = fake_provider.get_html()
+                    item["size"] = len(file_content.encode("UTF-8"))
                     item["file"] = {
                         "mimeType": "text/plain",
                     }
-                    item["name"] = fake.file_name(extension="txt")
-
-                    if file_id % 5 == 0:  # Every 5th is a large file
-                        item["size"] = LARGE
-
-                    elif file_id % 3 == 0:  # Every 3rd is a medium file
-                        item["size"] = MEDIUM
-
-                    else:  # Rest are small files
-                        item["size"] = SMALL
+                    item["name"] = fake.file_name(extension="html")
+                    self.files_by_id[item_id] = file_content
 
                 self.files_per_user[user["id"]].append(item)
 
@@ -171,7 +153,7 @@ class DataGenerator:
 
         for file in files_list:
             if file.get("id") == item_id:
-                return FILE_DATA[file["size"]]
+                return self.files_by_id[item_id]
 
 
 class OneDriveAPI:

--- a/tests/sources/fixtures/onedrive/fixture.py
+++ b/tests/sources/fixtures/onedrive/fixture.py
@@ -12,6 +12,7 @@ import time
 from flask import Flask, make_response, request
 from flask_limiter import HEADERS, Limiter
 from flask_limiter.util import get_remote_address
+
 from tests.commons import WeightedFakeProvider
 
 fake_provider = WeightedFakeProvider()


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3397

This PR changes the fixture for the respected content source to make use of shared test setup using `WeightedFakeProvider` class.

This class takes care of generating large fake data with certain distribution, for example:

```python
# In 65% cases generate small files
# In 20% cases generate medium size files
# In 10% cases generate large files
# in 5% cases generate huge files
fake_provider = WeightedFakeProvider(weights=[0.65, 0.2, 0.1, 0.05])

fake_provider.get_html() # <---- gets HTML of size depending on distribution
fake_provider.get_text() # <---- gets text of size depending on distribution

# Important difference
# get_text() returns huge amount of text that can be ingested, for example 2MB payload
# get_html() returns a huge payload that has too little text, for example for 2MB html it's around 1KB of text to text download/subextraction of rich content better
```

The final goal of the PR is to have more comparable benchmarks in our nightly functional tests of the amount of memory or cpu that is needed to run the connector.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally

## Related Pull Requests

- [ ] https://github.com/elastic/connectors-python/pull/1709
- [ ] https://github.com/elastic/connectors-python/pull/1710
- [ ] https://github.com/elastic/connectors-python/pull/1717
- [ ] https://github.com/elastic/connectors-python/pull/1718
- [ ] https://github.com/elastic/connectors-python/pull/1719
- [ ] https://github.com/elastic/connectors-python/pull/1720
- [ ] https://github.com/elastic/connectors-python/pull/1725
- [ ] https://github.com/elastic/connectors-python/pull/1726
- [ ] https://github.com/elastic/connectors-python/pull/1734
- [ ] https://github.com/elastic/connectors-python/pull/1735
- [ ] https://github.com/elastic/connectors-python/pull/1744
- [ ] https://github.com/elastic/connectors-python/pull/1745
- [ ] https://github.com/elastic/connectors-python/pull/1754
- [ ] https://github.com/elastic/connectors-python/pull/1755
- [ ] https://github.com/elastic/connectors-python/pull/1756
- [ ] https://github.com/elastic/connectors-python/pull/1763
- [ ] https://github.com/elastic/connectors-python/pull/1764
