### PR TITLE
Make PostgreSQL ftest use shared fixture

### DIFF
--- a/tests/commons.py
+++ b/tests/commons.py
@@ -95,6 +95,10 @@ class WeightedFakeProvider:
         ]
 
     @cached_property
+    def fake(self):
+        return self.fake_provider.fake
+
+    @cached_property
     def _htmls(self):
         return [
             self.fake_provider.small_html(),

--- a/tests/sources/fixtures/postgresql/fixture.py
+++ b/tests/sources/fixtures/postgresql/fixture.py
@@ -28,6 +28,12 @@ match DATA_SIZE:
         NUM_TABLES = 5
         RECORD_COUNT = 7000
 
+RECORDS_TO_DELETE = 10
+
+
+def get_num_docs():
+    print(NUM_TABLES * (RECORD_COUNT - RECORDS_TO_DELETE))
+
 
 def load():
     """Generate tables and loads table data in the microsoft server."""
@@ -79,8 +85,11 @@ def remove():
         """Removes 10 random items per table"""
         connect = await asyncpg.connect(CONNECTION_STRING)
         for table in range(NUM_TABLES):
-            rows = [(row_id,) for row_id in random.sample(range(1, RECORD_COUNT), 10)]
-            sql_query = f"DELETE from customers_{table} where name=$1"
+            rows = [
+                (row_id,)
+                for row_id in random.sample(range(1, RECORD_COUNT), RECORDS_TO_DELETE)
+            ]
+            sql_query = f"DELETE FROM customers_{table} WHERE id IN ($1)"
             await connect.executemany(sql_query, rows)
         await connect.close()
 

--- a/tests/sources/fixtures/postgresql/fixture.py
+++ b/tests/sources/fixtures/postgresql/fixture.py
@@ -5,8 +5,10 @@
 #
 import asyncio
 import os
+import random
 
 import asyncpg
+
 from tests.commons import WeightedFakeProvider
 
 fake_provider = WeightedFakeProvider(weights=[0.65, 0.3, 0.05, 0])
@@ -25,6 +27,7 @@ match DATA_SIZE:
     case "large":
         NUM_TABLES = 5
         RECORD_COUNT = 7000
+
 
 def load():
     """Generate tables and loads table data in the microsoft server."""
@@ -45,7 +48,9 @@ def load():
             rows = []
             batch_size = min(BATCH_SIZE, lines - inserted)
             for row_id in range(batch_size):
-                rows.append((fake_provider.fake.name(), row_id, fake_provider.get_text()))
+                rows.append(
+                    (fake_provider.fake.name(), row_id, fake_provider.get_text())
+                )
             sql_query = (
                 f"INSERT INTO customers_{table}"
                 + "(name, age, description) VALUES ($1, $2, $3)"

--- a/tests/sources/fixtures/postgresql/fixture.py
+++ b/tests/sources/fixtures/postgresql/fixture.py
@@ -5,36 +5,31 @@
 #
 import asyncio
 import os
-import random
-import string
 
 import asyncpg
+from tests.commons import WeightedFakeProvider
 
-DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
+fake_provider = WeightedFakeProvider(weights=[0.65, 0.3, 0.05, 0])
+
 CONNECTION_STRING = "postgresql://admin:Password_123@127.0.0.1:9090/xe"
-_SIZES = {"small": 5, "medium": 10, "large": 30}
-NUM_TABLES = _SIZES[DATA_SIZE]
+BATCH_SIZE = 100
+DATA_SIZE = os.environ.get("DATA_SIZE", "medium").lower()
 
-
-def random_text(k=1024 * 20):
-    """Function to generate random text
-
-    Args:
-        k (int, optional): size of data in bytes. Defaults to 1024*20.
-
-    Returns:
-        string: random text
-    """
-    return "".join(random.choices(string.ascii_uppercase + string.digits, k=k))
-
-
-BIG_TEXT = random_text()
-
+match DATA_SIZE:
+    case "small":
+        NUM_TABLES = 1
+        RECORD_COUNT = 500
+    case "medium":
+        NUM_TABLES = 3
+        RECORD_COUNT = 3000
+    case "large":
+        NUM_TABLES = 5
+        RECORD_COUNT = 7000
 
 def load():
     """Generate tables and loads table data in the microsoft server."""
 
-    async def inject_lines(table, connect, start, lines):
+    async def inject_lines(table, connect, lines):
         """Ingest rows in table
 
         Args:
@@ -43,25 +38,30 @@ def load():
             start (int): Starting row
             lines (int): Number of rows
         """
-        rows = []
-        for row_id in range(lines):
-            row_id += start
-            rows.append((f"user_{row_id}", row_id, BIG_TEXT))
-        sql_query = (
-            f"INSERT INTO customers_{table}"
-            + "(name, age, description) VALUES ($1, $2, $3)"
-        )
-        await connect.executemany(sql_query, rows)
+        batch_count = int(lines / BATCH_SIZE)
+        inserted = 0
+        print(f"Inserting {lines} lines")
+        for batch in range(batch_count):
+            rows = []
+            batch_size = min(BATCH_SIZE, lines - inserted)
+            for row_id in range(batch_size):
+                rows.append((fake_provider.fake.name(), row_id, fake_provider.get_text()))
+            sql_query = (
+                f"INSERT INTO customers_{table}"
+                + "(name, age, description) VALUES ($1, $2, $3)"
+            )
+            await connect.executemany(sql_query, rows)
+            inserted += batch_size
+            print(f"Inserting batch #{batch} of {batch_size} documents.")
 
     async def load_rows():
         """N tables of 10001 rows each. each row is ~ 1024*20 bytes"""
         connect = await asyncpg.connect(CONNECTION_STRING)
         for table in range(NUM_TABLES):
             print(f"Adding data from table #{table}...")
-            sql_query = f"CREATE TABLE IF NOT EXISTS customers_{table} (name VARCHAR(255), age int, description TEXT, PRIMARY KEY (name))"
+            sql_query = f"CREATE TABLE IF NOT EXISTS customers_{table} (id SERIAL PRIMARY KEY, name VARCHAR(255), age int, description TEXT)"
             await connect.execute(sql_query)
-            for i in range(10):
-                await inject_lines(table, connect, i * 1000, 1000)
+            await inject_lines(table, connect, RECORD_COUNT)
         await connect.close()
 
     asyncio.get_event_loop().run_until_complete(load_rows())
@@ -74,7 +74,7 @@ def remove():
         """Removes 10 random items per table"""
         connect = await asyncpg.connect(CONNECTION_STRING)
         for table in range(NUM_TABLES):
-            rows = [(f"user_{row_id}",) for row_id in random.sample(range(1, 1000), 10)]
+            rows = [(row_id,) for row_id in random.sample(range(1, RECORD_COUNT), 10)]
             sql_query = f"DELETE from customers_{table} where name=$1"
             await connect.executemany(sql_query, rows)
         await connect.close()


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3397

This PR changes the fixture for the respected content source to make use of shared test setup using `WeightedFakeProvider` class.

This class takes care of generating large fake data with certain distribution, for example:

```python
# In 65% cases generate small files
# In 20% cases generate medium size files
# In 10% cases generate large files
# in 5% cases generate huge files
fake_provider = WeightedFakeProvider(weights=[0.65, 0.2, 0.1, 0.05])

fake_provider.get_html() # <---- gets HTML of size depending on distribution
fake_provider.get_text() # <---- gets text of size depending on distribution

# Important difference
# get_text() returns huge amount of text that can be ingested, for example 2MB payload
# get_html() returns a huge payload that has too little text, for example for 2MB html it's around 1KB of text to text download/subextraction of rich content better
```

The final goal of the PR is to have more comparable benchmarks in our nightly functional tests of the amount of memory or cpu that is needed to run the connector.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally

## Related Pull Requests

- [ ] https://github.com/elastic/connectors-python/pull/1709
- [ ] https://github.com/elastic/connectors-python/pull/1710
- [ ] https://github.com/elastic/connectors-python/pull/1717
- [ ] https://github.com/elastic/connectors-python/pull/1718
- [ ] https://github.com/elastic/connectors-python/pull/1719
- [ ] https://github.com/elastic/connectors-python/pull/1720
- [ ] https://github.com/elastic/connectors-python/pull/1725
- [ ] https://github.com/elastic/connectors-python/pull/1726
- [ ] https://github.com/elastic/connectors-python/pull/1734
- [ ] https://github.com/elastic/connectors-python/pull/1735
- [ ] https://github.com/elastic/connectors-python/pull/1736
- [ ] https://github.com/elastic/connectors-python/pull/1744
- [ ] https://github.com/elastic/connectors-python/pull/1754
- [ ] https://github.com/elastic/connectors-python/pull/1755
- [ ] https://github.com/elastic/connectors-python/pull/1756
- [ ] https://github.com/elastic/connectors-python/pull/1763
- [ ] https://github.com/elastic/connectors-python/pull/1764
