### PR TITLE
Make S3 ftest use shared fixture

### DIFF
--- a/tests/sources/fixtures/s3/fixture.py
+++ b/tests/sources/fixtures/s3/fixture.py
@@ -1,6 +1,9 @@
 import os
-import random
 import string
+import boto3
+from tests.commons import WeightedFakeProvider
+
+fake_provider = WeightedFakeProvider()
 
 BUCKET_NAME = "ent-search-ingest-dev"
 REGION_NAME = "us-west-2"
@@ -11,27 +14,22 @@ AWS_SECRET_KEY = "dummy_secret_key"
 AWS_ACCESS_KEY_ID = "dummy_access_key"
 
 if DATA_SIZE == "small":
-    FOLDER_COUNT = 400
-    SMALL_TEXT_COUNT = 500
-    BIG_TEXT_COUNT = 100
-    OBJECT_COUNT = 5
+    FOLDER_COUNT = 50
+    FILE_COUNT = 250
+    OBJECT_TO_DELETE_COUNT = 5
 elif DATA_SIZE == "medium":
-    FOLDER_COUNT = 2000
-    SMALL_TEXT_COUNT = 2500
-    BIG_TEXT_COUNT = 500
-    OBJECT_COUNT = 10
+    FOLDER_COUNT = 150
+    FILE_COUNT = 1000
+    OBJECT_TO_DELETE_COUNT = 10
 else:
-    FOLDER_COUNT = 4000
-    SMALL_TEXT_COUNT = 5000
-    BIG_TEXT_COUNT = 1000
-    OBJECT_COUNT = 15
+    FOLDER_COUNT = 300
+    FILE_COUNT = 3000
+    OBJECT_TO_DELETE_COUNT = 15
 
+fake_provider = WeightedFakeProvider()
 
-def random_text(k=0):
-    return "".join(random.choices(string.ascii_uppercase + string.digits, k=k))
-
-
-BIG_TEXT = random_text(k=1024 * 20)
+def get_num_docs():
+    print(FOLDER_COUNT + FILE_COUNT - OBJECT_TO_DELETE_COUNT)
 
 
 def setup():
@@ -41,66 +39,52 @@ def setup():
 
 def load():
     """Method for generating 10k document for aws s3 emulator"""
-    import boto3
-
-    try:
-        s3_client = boto3.client(
-            "s3",
-            endpoint_url=f"{AWS_ENDPOINT_URL}:{AWS_PORT}",
-            region_name=REGION_NAME,
-            aws_access_key_id=AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=AWS_SECRET_KEY,
-        )
-        s3_client.create_bucket(
+    s3_client = boto3.client(
+        "s3",
+        endpoint_url=f"{AWS_ENDPOINT_URL}:{AWS_PORT}",
+        region_name=REGION_NAME,
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_KEY,
+    )
+    s3_client.create_bucket(
+        Bucket=BUCKET_NAME,
+        CreateBucketConfiguration={
+            "LocationConstraint": REGION_NAME,
+        },
+    )
+    print("Creating objects on the aws-moto server")
+    # add folders to the bucket
+    for object_id in range(FOLDER_COUNT):
+        if object_id % 100 == 0:
+            print(f"Inserted [{object_id}/{FOLDER_COUNT}] folders")
+        s3_client.put_object(
+            Key=f"{BUCKET_NAME}/{object_id}/",
             Bucket=BUCKET_NAME,
-            CreateBucketConfiguration={
-                "LocationConstraint": REGION_NAME,
-            },
+            StorageClass="STANDARD",
         )
-        print("Creating objects on the aws-moto server")
-        # add folders to the bucket
-        for object_id in range(0, FOLDER_COUNT):
-            s3_client.put_object(
-                Key=f"{BUCKET_NAME}/{object_id}/",
-                Bucket=BUCKET_NAME,
-                StorageClass="STANDARD",
-            )
-        # add small text files to the bucket
-        for object_id in range(0, SMALL_TEXT_COUNT):
-            s3_client.put_object(
-                Key=f"{BUCKET_NAME}/small_file_{object_id}.txt",
-                Bucket=BUCKET_NAME,
-                Body=f"Testing object{object_id} document for bucket: {BUCKET_NAME}",
-                StorageClass="STANDARD",
-            )
-        # add big text files to the bucket
-        for object_id in range(0, BIG_TEXT_COUNT):
-            s3_client.put_object(
-                Key=f"{BUCKET_NAME}/big_file_{object_id}.txt",
-                Bucket=BUCKET_NAME,
-                Body=BIG_TEXT,
-                StorageClass="STANDARD",
-            )
-    except Exception:
-        raise
+    # add small text files to the bucket
+    for object_id in range(FILE_COUNT):
+        if object_id % 100 == 0:
+            print(f"Inserted [{object_id}/{FILE_COUNT}] objects")
+        s3_client.put_object(
+            Key=f"{BUCKET_NAME}/small_file_{object_id}.html",
+            Bucket=BUCKET_NAME,
+            Body=fake_provider.get_html(),
+            StorageClass="STANDARD",
+        )
 
 
 def remove():
     """Method for removing 15 random document from aws s3 emulator"""
-    import boto3
-
-    try:
-        s3_client = boto3.client(
-            "s3",
-            endpoint_url=f"{AWS_ENDPOINT_URL}:{AWS_PORT}",
-            region_name=REGION_NAME,
-            aws_access_key_id=AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=AWS_SECRET_KEY,
+    s3_client = boto3.client(
+        "s3",
+        endpoint_url=f"{AWS_ENDPOINT_URL}:{AWS_PORT}",
+        region_name=REGION_NAME,
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_KEY,
+    )
+    print("Removing data from aws-moto server.")
+    for object_id in range(OBJECT_TO_DELETE_COUNT):
+        s3_client.delete_object(
+            Bucket=BUCKET_NAME, Key=f"{BUCKET_NAME}/{object_id}/"
         )
-        print("Removing data from aws-moto server.")
-        for object_id in range(0, OBJECT_COUNT):
-            s3_client.delete_object(
-                Bucket=BUCKET_NAME, Key=f"{BUCKET_NAME}/{object_id}/"
-            )
-    except Exception:
-        raise

--- a/tests/sources/fixtures/s3/fixture.py
+++ b/tests/sources/fixtures/s3/fixture.py
@@ -1,6 +1,7 @@
 import os
-import string
+
 import boto3
+
 from tests.commons import WeightedFakeProvider
 
 fake_provider = WeightedFakeProvider()
@@ -27,6 +28,7 @@ else:
     OBJECT_TO_DELETE_COUNT = 15
 
 fake_provider = WeightedFakeProvider()
+
 
 def get_num_docs():
     print(FOLDER_COUNT + FILE_COUNT - OBJECT_TO_DELETE_COUNT)
@@ -85,6 +87,4 @@ def remove():
     )
     print("Removing data from aws-moto server.")
     for object_id in range(OBJECT_TO_DELETE_COUNT):
-        s3_client.delete_object(
-            Bucket=BUCKET_NAME, Key=f"{BUCKET_NAME}/{object_id}/"
-        )
+        s3_client.delete_object(Bucket=BUCKET_NAME, Key=f"{BUCKET_NAME}/{object_id}/")


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3397

This PR changes the fixture for the respected content source to make use of shared test setup using `WeightedFakeProvider` class.

This class takes care of generating large fake data with certain distribution, for example:

```python
# In 65% cases generate small files
# In 20% cases generate medium size files
# In 10% cases generate large files
# in 5% cases generate huge files
fake_provider = WeightedFakeProvider(weights=[0.65, 0.2, 0.1, 0.05])

fake_provider.get_html() # <---- gets HTML of size depending on distribution
fake_provider.get_text() # <---- gets text of size depending on distribution

# Important difference
# get_text() returns huge amount of text that can be ingested, for example 2MB payload
# get_html() returns a huge payload that has too little text, for example for 2MB html it's around 1KB of text to text download/subextraction of rich content better
```

The final goal of the PR is to have more comparable benchmarks in our nightly functional tests of the amount of memory or cpu that is needed to run the connector.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally

## Related Pull Requests

- [ ] https://github.com/elastic/connectors-python/pull/1709
- [ ] https://github.com/elastic/connectors-python/pull/1710
- [ ] https://github.com/elastic/connectors-python/pull/1717
- [ ] https://github.com/elastic/connectors-python/pull/1718
- [ ] https://github.com/elastic/connectors-python/pull/1719
- [ ] https://github.com/elastic/connectors-python/pull/1720
- [ ] https://github.com/elastic/connectors-python/pull/1725
- [ ] https://github.com/elastic/connectors-python/pull/1726
- [ ] https://github.com/elastic/connectors-python/pull/1734
- [ ] https://github.com/elastic/connectors-python/pull/1735
- [ ] https://github.com/elastic/connectors-python/pull/1736
- [ ] https://github.com/elastic/connectors-python/pull/1744
- [ ] https://github.com/elastic/connectors-python/pull/1745
- [ ] https://github.com/elastic/connectors-python/pull/1755
- [ ] https://github.com/elastic/connectors-python/pull/1756
- [ ] https://github.com/elastic/connectors-python/pull/1763
- [ ] https://github.com/elastic/connectors-python/pull/1764
