### PR TITLE
Make Salesforce ftest use shared fixture

### DIFF
--- a/tests/commons.py
+++ b/tests/commons.py
@@ -95,6 +95,10 @@ class WeightedFakeProvider:
         ]
 
     @cached_property
+    def fake(self):
+        return self.fake_provider.fake
+
+    @cached_property
     def _htmls(self):
         return [
             self.fake_provider.small_html(),

--- a/tests/sources/fixtures/salesforce/fixture.py
+++ b/tests/sources/fixtures/salesforce/fixture.py
@@ -9,9 +9,9 @@ import io
 import os
 import random
 import re
-import string
 
 from flask import Flask, request
+
 from tests.commons import WeightedFakeProvider
 
 fake_provider = WeightedFakeProvider()
@@ -110,7 +110,7 @@ OBJECTS_WITH_CONTENT_DOCUMENTS = [
 
 
 def generate_string(size):
-    return fake.text(size) 
+    return fake.text(size)
 
 
 # We pre-generate 50 content document ids so we can randomly link them to multiple objects

--- a/tests/sources/fixtures/salesforce/fixture.py
+++ b/tests/sources/fixtures/salesforce/fixture.py
@@ -12,11 +12,24 @@ import re
 import string
 
 from flask import Flask, request
+from tests.commons import WeightedFakeProvider
 
-RANDOMISER_CHARSET = string.ascii_letters + string.digits
-DATA_SIZE = os.environ.get("DATA_SIZE", "small").lower()
-_SIZES = {"small": 500000, "medium": 1000000, "large": 3000000}
-FILE_SIZE = _SIZES[DATA_SIZE]
+fake_provider = WeightedFakeProvider()
+fake = fake_provider.fake
+
+DATA_SIZE = os.environ.get("DATA_SIZE", "medium").lower()
+
+match DATA_SIZE:
+    case "small":
+        RECORD_COUNT = 500
+    case "medium":
+        RECORD_COUNT = 2000
+    case "large":
+        RECORD_COUNT = 10000
+    case _:
+        raise Exception(
+            f"Unknown DATA_SIZE: {DATA_SIZE}. Expecting 'small', 'medium' or 'large'"
+        )
 
 SOBJECTS = [
     "Account",
@@ -97,18 +110,17 @@ OBJECTS_WITH_CONTENT_DOCUMENTS = [
 
 
 def generate_string(size):
-    return "".join([random.choice(RANDOMISER_CHARSET) for _ in range(size)])
+    return fake.text(size) 
 
 
 # We pre-generate 50 content document ids so we can randomly link them to multiple objects
 # This will allow us to simulate the memory/CPU demand of objects having duplicate files attached
 CONTENT_DOCUMENT_IDS = [generate_string(18) for _ in range(50)]
-FILE_DATA = generate_string(FILE_SIZE)
 
 
 def generate_records(table_name):
     records = []
-    for _ in range(2000):
+    for _ in range(RECORD_COUNT):
         record = {"Id": generate_string(18)}
         if table_name in OBJECTS_WITH_CONTENT_DOCUMENTS:
             record["ContentDocumentLinks"] = {
@@ -120,8 +132,8 @@ def generate_records(table_name):
 
 
 def generate_content_document_records():
-    # 1 in every 6 docs gets 1 attached file
-    # 1 in every 6 docs gets 2 attached files
+    # 1 in every 12 docs gets 1 attached file
+    # 1 in every 12 docs gets 2 attached files
     d6 = random.choice(range(6))
     if d6 > 1:
         return []
@@ -191,7 +203,7 @@ def describe_sobject(_version, _sobject):
 
 @app.route("/sfc/servlet.shepherd/version/download/<_download_id>", methods=["GET"])
 def download(_download_id):
-    return io.BytesIO(bytes(FILE_DATA, encoding="utf-8"))
+    return io.BytesIO(bytes(fake_provider.get_html(), encoding="utf-8"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/3397

This PR changes the fixture for the respected content source to make use of shared test setup using `WeightedFakeProvider` class.

This class takes care of generating large fake data with certain distribution, for example:

```python
# In 65% cases generate small files
# In 20% cases generate medium size files
# In 10% cases generate large files
# in 5% cases generate huge files
fake_provider = WeightedFakeProvider(weights=[0.65, 0.2, 0.1, 0.05])

fake_provider.get_html() # <---- gets HTML of size depending on distribution
fake_provider.get_text() # <---- gets text of size depending on distribution

# Important difference
# get_text() returns huge amount of text that can be ingested, for example 2MB payload
# get_html() returns a huge payload that has too little text, for example for 2MB html it's around 1KB of text to text download/subextraction of rich content better
```

The final goal of the PR is to have more comparable benchmarks in our nightly functional tests of the amount of memory or cpu that is needed to run the connector.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally

## Related Pull Requests

- [ ] https://github.com/elastic/connectors-python/pull/1709
- [ ] https://github.com/elastic/connectors-python/pull/1710
- [ ] https://github.com/elastic/connectors-python/pull/1717
- [ ] https://github.com/elastic/connectors-python/pull/1718
- [ ] https://github.com/elastic/connectors-python/pull/1719
- [ ] https://github.com/elastic/connectors-python/pull/1720
- [ ] https://github.com/elastic/connectors-python/pull/1725
- [ ] https://github.com/elastic/connectors-python/pull/1726
- [ ] https://github.com/elastic/connectors-python/pull/1734
- [ ] https://github.com/elastic/connectors-python/pull/1735
- [ ] https://github.com/elastic/connectors-python/pull/1736
- [ ] https://github.com/elastic/connectors-python/pull/1744
- [ ] https://github.com/elastic/connectors-python/pull/1745
- [ ] https://github.com/elastic/connectors-python/pull/1754
- [ ] https://github.com/elastic/connectors-python/pull/1756
- [ ] https://github.com/elastic/connectors-python/pull/1763
- [ ] https://github.com/elastic/connectors-python/pull/1764
