### PR TITLE
Add support for DLS in Linux Network Drive

### DIFF
--- a/docs/document-level-security/NETWORK_DRIVE.md
+++ b/docs/document-level-security/NETWORK_DRIVE.md
@@ -8,7 +8,8 @@ Document Level Security (DLS) enables you to restrict access to documents based 
 This feature is available by default for the Network Drive connector.
 DLS in the Network drive connector facilitates the syncing of folder & file permissions, including both user and group level permissions.
 
-The present version of Network Drive connector will offer DLS support for Windows Network Drive only.
+The native connector supports DLS for Windows Network Drive. DLS suppport for Linux Network Drive is now available  via self-managed connector client.
+The user would need to add a csv file in the local path that contains users' information such that each row has the following format: `username;user-sid;group-sid1,group-sid-2`.
 
 Refer to [document level security](https://www.elastic.co/guide/en/enterprise-search/master/dls.html) for more information.
 

--- a/tests/sources/fixtures/network_drive/connector.json
+++ b/tests/sources/fixtures/network_drive/connector.json
@@ -62,6 +62,15 @@
                     "value": false,
                     "order": 6,
                     "ui_restrictions": []
+                },
+                "identity_mappings": {
+                    "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",
+                    "depends_on": [{"field": "use_document_level_security", "value": true}],
+                    "order": 7,
+                    "type": "str",
+                    "required": false,
+                    "ui_restrictions": ["advanced"],
+                    "value": ""
                 }
         },
         "filtering": [

--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -885,7 +885,8 @@ async def test_get_docs_with_dls_enabled(
 async def test_read_csv_with_valid_data():
     async with create_source(NASDataSource) as source:
         with mock.patch(
-            "builtins.open", mock.mock_open(read_data="user1;S-1;S-11,S-22\nuser2;S-2;S-22")
+            "builtins.open",
+            mock.mock_open(read_data="user1;S-1;S-11,S-22\nuser2;S-2;S-22"),
         ):
             user_info = source.read_user_info_csv()
             expected_user_info = [
@@ -899,7 +900,7 @@ async def test_read_csv_with_valid_data():
 async def test_read_csv_file_erroneous():
     async with create_source(NASDataSource) as source:
         with mock.patch("builtins.open", mock.mock_open(read_data="0I`00�^")):
-            with mock.patch("csv.reader", side_effect = csv.Error):
+            with mock.patch("csv.reader", side_effect=csv.Error):
                 user_info = source.read_user_info_csv()
                 assert user_info == []
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-python/issues/1774
DLS for Linux Network Drive depends on a local csv file that contains the details of user. DLS for Linux Network Drive would be available via self-managed connector clients.
The format of csv would be as follows:
`username;user-id;groups-sids`

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
