### PR TITLE
[Outlook] Add a new field for `max concurrent tasks`

### DIFF
--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -767,7 +767,7 @@ class OutlookDataSource(BaseDataSource):
             "use_text_extraction_service": {
                 "display": "toggle",
                 "label": "Use text extraction service",
-                "order": 7,
+                "order": 12,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
                 "ui_restrictions": ["advanced"],
@@ -777,7 +777,8 @@ class OutlookDataSource(BaseDataSource):
                 "default_value": MAX_CONCURRENCY,
                 "display": "numeric",
                 "label": "Maximum concurrent tasks",
-                "order": 8,
+                "tooltip": "This value denotes the number of tasks that run in parallel. It depends on the number of accounts in the Azure AD.",
+                "order": 13,
                 "required": False,
                 "type": "int",
             },

--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -45,7 +45,7 @@ RETRIES = 3
 RETRY_INTERVAL = 2
 
 QUEUE_MEM_SIZE = 5 * 1024 * 1024  # Size in Megabytes
-MAX_CONCURRENCY = 10
+MAX_CONCURRENCY = 2000
 
 OUTLOOK_SERVER = "outlook_server"
 OUTLOOK_CLOUD = "outlook_cloud"
@@ -664,7 +664,9 @@ class OutlookDataSource(BaseDataSource):
 
         self.tasks = 0
         self.queue = MemQueue(maxmemsize=QUEUE_MEM_SIZE, refresh_timeout=120)
-        self.fetchers = ConcurrentTasks(max_concurrency=MAX_CONCURRENCY)
+        self.fetchers = ConcurrentTasks(
+            max_concurrency=self.configuration["max_concurrent_tasks"]
+        )
 
     @cached_property
     def client(self):
@@ -770,6 +772,14 @@ class OutlookDataSource(BaseDataSource):
                 "type": "bool",
                 "ui_restrictions": ["advanced"],
                 "value": False,
+            },
+            "max_concurrent_tasks": {
+                "default_value": MAX_CONCURRENCY,
+                "display": "numeric",
+                "label": "Maximum concurrent tasks",
+                "order": 8,
+                "required": False,
+                "type": "int",
             },
         }
 

--- a/docs/reference/outlook.md
+++ b/docs/reference/outlook.md
@@ -99,6 +99,10 @@ MIID+jCCAuKgAwIBAgIGAJJMzlxLMA0GCSqGSIb3DQEBCwUAMHoxCzAJBgNVBAYT
 
 **Note:** This configuration is applicable for `Outlook Server` only.
 
+#### `Max concurrent tasks`
+
+This value denotes the number of tasks that run in parallel. It depends on the number of accounts in the Azure AD. Default value is 2000.
+
 ### Content Extraction
 
 Refer to [content extraction](https://www.elastic.co/guide/en/enterprise-search/current/connectors-content-extraction.html) in the official docs.


### PR DESCRIPTION
This PR is adding a new RCF called `Maximum concurrent tasks` to update the fetchers value. The default value for the field is 2000.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
