### PR TITLE
Remove size from nightly QA ftest calls

### DIFF
--- a/.buildkite/nightly_steps.yml
+++ b/.buildkite/nightly_steps.yml
@@ -43,12 +43,12 @@ steps:
       - "perf8-report-*/**/*"
   - label: "🔨 Sharepoint Server"
     command:
-      - ".buildkite/run_nigthly.sh sharepoint_server extra_small"
+      - ".buildkite/run_nigthly.sh sharepoint_server"
     artifact_paths:
       - "perf8-report-*/**/*"
   - label: "🔨 Sharepoint Online"
     command:
-      - ".buildkite/run_nigthly.sh sharepoint_online medium"
+      - ".buildkite/run_nigthly.sh sharepoint_online"
     artifact_paths:
       - "perf8-report-*/**/*"
   - label: "🔨 Microsoft SQL"


### PR DESCRIPTION
Small fix for current [nightly QA build failure](https://buildkite.com/elastic/connectors-python-nightly-aarch64/builds/199#018b3a1e-716c-41ba-8570-73f456a88e28) for Sharepoint Server:

```
[FTEST][20:20:44][INFO] Executing action: 'get_num_docs'.
--
  | Traceback (most recent call last):
  | File "/opt/buildkite-agent/builds/bk-agent-prod-aws-1697487168483713019/elastic/connectors-python-nightly-aarch64/tests/sources/fixtures/fixture.py", line 189, in <module>
  | main()
  | File "/opt/buildkite-agent/builds/bk-agent-prod-aws-1697487168483713019/elastic/connectors-python-nightly-aarch64/tests/sources/fixtures/fixture.py", line 164, in main
  | return func()
  | File "/opt/buildkite-agent/builds/bk-agent-prod-aws-1697487168483713019/elastic/connectors-python-nightly-aarch64/tests/sources/fixtures/sharepoint_server/fixture.py", line 76, in get_num_docs
  | total_attachments = total_subsites * lists_per_site * attachments_per_list
  | NameError: name 'total_subsites' is not defined
```

This happens because previously I deleted handling size for `extra_small` DATA_SIZE. In the code the size handling is the following:

```python
DATA_SIZE = os.environ.get("DATA_SIZE", "medium").lower()

match DATA_SIZE:
    case "small":
        total_subsites = 1
        lists_per_site = 10
        attachments_per_list = 5
    case "medium":
        total_subsites = 10
        lists_per_site = 40
        attachments_per_list = 15
    case "large":
        total_subsites = 100
        lists_per_site = 1000
        attachments_per_list = 40
```

Since there's no case for "extra_small", the variables are not defined and the code that uses it will error out - like it happened in the log.

Since this size is not there, removing it from `sharepoint_server` setting in the nightly pipeline.

Additionally I've removed the parameter for sharepoint_online ftest - just for consistency. 