### PR TITLE
Use VersionData endpoint to download content

### DIFF
--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -33,7 +33,7 @@ TOKEN_ENDPOINT = "/services/oauth2/token"
 QUERY_ENDPOINT = f"/services/data/{API_VERSION}/query"
 DESCRIBE_ENDPOINT = f"/services/data/{API_VERSION}/sobjects"
 DESCRIBE_SOBJECT_ENDPOINT = f"/services/data/{API_VERSION}/sobjects/<sobject>/describe"
-# https://developer.salesforce.com/docs/atlas.en-us.244.0.api_rest.meta/api_rest/resources_sobject_blob_retrieve.htm
+# https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_blob_retrieve.htm
 CONTENT_VERSION_DOWNLOAD_ENDPOINT = f"/services/data/{API_VERSION}/sobjects/ContentVersion/<content_version_id>/VersionData"
 
 RELEVANT_SOBJECTS = [

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -28,7 +28,7 @@ RETRIES = 3
 RETRY_INTERVAL = 1
 
 BASE_URL = "https://<domain>.my.salesforce.com"
-API_VERSION = "v59.0"
+API_VERSION = "v58.0"
 TOKEN_ENDPOINT = "/services/oauth2/token"
 QUERY_ENDPOINT = f"/services/data/{API_VERSION}/query"
 DESCRIBE_ENDPOINT = f"/services/data/{API_VERSION}/sobjects"

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -30,8 +30,9 @@ from connectors.sources.salesforce import (
 from tests.sources.support import create_source
 
 TEST_DOMAIN = "fake"
+CONTENT_FILE_ID = "content_version_id"
 TEST_BASE_URL = f"https://{TEST_DOMAIN}.my.salesforce.com"
-TEST_FILE_DOWNLOAD_URL = f"https://{TEST_DOMAIN}.file.force.com"
+TEST_FILE_DOWNLOAD_URL = f"{TEST_BASE_URL}/services/data/{API_VERSION}/sobjects/ContentVersion/{CONTENT_FILE_ID}/VersionData"
 TEST_QUERY_MATCH_URL = re.compile(f"{TEST_BASE_URL}/services/data/{API_VERSION}/query*")
 TEST_CLIENT_ID = "1234"
 TEST_CLIENT_SECRET = "9876"
@@ -379,8 +380,7 @@ CONTENT_DOCUMENT_LINKS_PAYLOAD = {
                         "type": "ContentVersion",
                         "url": f"/services/data/{API_VERSION}/sobjects/ContentVersion/content_version_id",
                     },
-                    "Id": "content_version_id",
-                    "VersionDataUrl": f"{TEST_FILE_DOWNLOAD_URL}/sfc/servlet.shepherd/version/download/download_id",
+                    "Id": CONTENT_FILE_ID,
                     "CreatedDate": "",
                     "VersionNumber": "2",
                 },
@@ -1051,7 +1051,7 @@ async def test_get_all_with_content_docs_when_success(
             expected_doc["_attachment"] = expected_attachment
 
         mock_responses.get(
-            f"{TEST_FILE_DOWNLOAD_URL}/sfc/servlet.shepherd/version/download/download_id",
+            TEST_FILE_DOWNLOAD_URL,
             status=response_status,
             body=response_body,
         )
@@ -1105,7 +1105,7 @@ async def test_get_all_with_content_docs_and_extraction_service(mock_responses):
             }
 
             mock_responses.get(
-                f"{TEST_FILE_DOWNLOAD_URL}/sfc/servlet.shepherd/version/download/download_id",
+                TEST_FILE_DOWNLOAD_URL,
                 status=200,
                 body=b"chunk1",
             )

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -30,9 +30,9 @@ from connectors.sources.salesforce import (
 from tests.sources.support import create_source
 
 TEST_DOMAIN = "fake"
-CONTENT_FILE_ID = "content_version_id"
+CONTENT_VERSION_ID = "content_version_id"
 TEST_BASE_URL = f"https://{TEST_DOMAIN}.my.salesforce.com"
-TEST_FILE_DOWNLOAD_URL = f"{TEST_BASE_URL}/services/data/{API_VERSION}/sobjects/ContentVersion/{CONTENT_FILE_ID}/VersionData"
+TEST_FILE_DOWNLOAD_URL = f"{TEST_BASE_URL}/services/data/{API_VERSION}/sobjects/ContentVersion/{CONTENT_VERSION_ID}/VersionData"
 TEST_QUERY_MATCH_URL = re.compile(f"{TEST_BASE_URL}/services/data/{API_VERSION}/query*")
 TEST_CLIENT_ID = "1234"
 TEST_CLIENT_SECRET = "9876"
@@ -380,7 +380,7 @@ CONTENT_DOCUMENT_LINKS_PAYLOAD = {
                         "type": "ContentVersion",
                         "url": f"/services/data/{API_VERSION}/sobjects/ContentVersion/content_version_id",
                     },
-                    "Id": CONTENT_FILE_ID,
+                    "Id": CONTENT_VERSION_ID,
                     "CreatedDate": "",
                     "VersionNumber": "2",
                 },


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5912

In Salesforce, when a file is uploaded, a [ContentDocument](https://developer.salesforce.com/docs/atlas.en-us.244.0.object_reference.meta/object_reference/sforce_api_objects_contentdocument.htm) object is created, and it links to multiple [ContentVersion](https://developer.salesforce.com/docs/atlas.en-us.244.0.object_reference.meta/object_reference/sforce_api_objects_contentversion.htm) objects, which keeps all the history of the file.

The `ContentDocument` has a `LatestPublishedVersionId` field linking to the current version of the file, and we used `VersionDataURL` of the `ContentVersion` to download the file:
>The URL used to fetch a file from the binary data endpoint. This field is only populated on direct queries to ContentVersion, and not when queried through a related entity’s foreign key to ContentVersion.

The URL works in browsers but it will only download a js file when used in REST API call.

This PR switches to use [sObject Blob Get](https://developer.salesforce.com/docs/atlas.en-us.244.0.api_rest.meta/api_rest/resources_sobject_blob_retrieve.htm) to download files.

```
/services/data/vXX.X/sobjects/<sObject>/<id>/<blobField>
```


It tries to get `VersionData` of `ContentVersion`object:
```
/services/data/vXX.X/sobjects/ContentVersion/<content_version_id>/VersionData
```

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)