### PR TITLE
[Filtering] Improve basic rule error messages

### DIFF
--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -11,6 +11,7 @@ from enum import Enum
 from dateutil.parser import ParserError, parser
 
 from connectors.logger import logger
+from connectors.utils import Format, shorten_str
 
 IS_BOOL_FALSE = re.compile("^(false|f|no|n|off)$", re.I)
 IS_BOOL_TRUE = re.compile("^(true|t|yes|y|on)$", re.I)
@@ -252,6 +253,7 @@ class BasicRule:
     """A BasicRule is used to match documents based on different comparisons (see `matches` method)."""
 
     DEFAULT_RULE_ID = "DEFAULT"
+    SHORTEN_UUID_BY = 26  # UUID: 32 random chars + 4 hyphens; keep 10 characters
 
     def __init__(self, id_, order, policy, field, rule, value):
         self.id_ = id_
@@ -371,3 +373,9 @@ class BasicRule:
             _format_field(key, value) for key, value in self.__dict__.items()
         ]
         return "Basic rule: " + ", ".join(formatted_fields)
+
+    def __format__(self, format_spec):
+        if format_spec == Format.SHORT.value:
+            # order uses a 0 based index
+            return f"Basic rule {self.order + 1} (id: {shorten_str(self.id_, BasicRule.SHORTEN_UUID_BY)})"
+        return str(self)

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -377,5 +377,5 @@ class BasicRule:
     def __format__(self, format_spec):
         if format_spec == Format.SHORT.value:
             # order uses a 0 based index
-            return f"Basic rule {self.order + 1} (id: {shorten_str(self.id_, BasicRule.SHORTEN_UUID_BY)})"
+            return f"Basic rule {self.order + 1} (id: '{shorten_str(self.id_, BasicRule.SHORTEN_UUID_BY)}')"
         return str(self)

--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -10,6 +10,7 @@ import fastjsonschema
 
 from connectors.filtering.basic_rule import BasicRule, Policy, Rule
 from connectors.logger import logger
+from connectors.utils import Format
 
 
 class ValidationTarget(Enum):
@@ -263,7 +264,7 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
     @classmethod
     def semantic_duplicates_validation_results(cls, basic_rule, semantic_duplicate):
         def semantic_duplicate_msg(rule_one, rule_two):
-            return f"Rule with id '{rule_one}' is semantically equal to rule with id '{rule_two}'"
+            return f"{format(rule_one, Format.SHORT.value)} is semantically equal to {format(rule_two, Format.SHORT.value)}."
 
         return [
             # We need two error messages to highlight both rules in the UI
@@ -271,14 +272,14 @@ class BasicRulesSetSemanticValidator(BasicRulesSetValidator):
                 rule_id=basic_rule.id_,
                 is_valid=False,
                 validation_message=semantic_duplicate_msg(
-                    basic_rule.id_, semantic_duplicate.id_
+                    basic_rule, semantic_duplicate
                 ),
             ),
             SyncRuleValidationResult(
                 rule_id=semantic_duplicate.id_,
                 is_valid=False,
                 validation_message=semantic_duplicate_msg(
-                    semantic_duplicate.id_, basic_rule.id_
+                    semantic_duplicate, basic_rule
                 ),
             ),
         ]
@@ -311,8 +312,7 @@ class BasicRuleNoMatchAllRegexValidator(BasicRuleValidator):
             return SyncRuleValidationResult(
                 rule_id=basic_rule.id_,
                 is_valid=False,
-                validation_message=f"Match all regexps: '{BasicRuleNoMatchAllRegexValidator.MATCH_ALL_REGEXPS}' are "
-                f"not allowed.",
+                validation_message=f"{format(basic_rule, Format.SHORT.value)} uses a match all regexps {BasicRuleNoMatchAllRegexValidator.MATCH_ALL_REGEXPS}, which are not allowed.",
             )
 
         return SyncRuleValidationResult.valid_result(rule_id=basic_rule.id_)

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -77,6 +77,11 @@ TIKA_SUPPORTED_FILETYPES = [
 ISO_ZULU_TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
+class Format(Enum):
+    VERBOSE = "verbose"
+    SHORT = "short"
+
+
 def iso_utc(when=None):
     if when is None:
         when = datetime.now(timezone.utc)
@@ -810,3 +815,46 @@ def validate_email_address(email_address):
 
     # non None values indicate a match
     return re.fullmatch(EMAIL_REGEX_PATTERN, email_address) is not None
+
+
+def shorten_str(string, shorten_by):
+    """
+    Shorten a string by removing characters from the middle, replacing them with '...'.
+
+    If balanced shortening is not possible, retains an extra character at the beginning.
+
+    Args:
+        string (str): The string to be shortened.
+        shorten_by (int): The number of characters to remove from the string.
+
+    Returns:
+        str: The shortened string.
+
+    Examples:
+        >>> shorten_str("abcdefgh", 1)
+        'abcdefgh'
+        >>> shorten_str("abcdefgh", 4)
+        'ab...gh'
+        >>> shorten_str("abcdefgh", 5)
+        'ab...h'
+        >>> shorten_str("abcdefgh", 1000)
+        'a...h'
+    """
+
+    if string is None or string == "":
+        return ""
+
+    if not string or shorten_by < 3:
+        return string
+
+    length = len(string)
+    shorten_by = min(length - 2, shorten_by)
+
+    keep = (length - shorten_by) // 2
+    balanced_shortening = (shorten_by + length) % 2 == 0
+
+    if balanced_shortening:
+        return f"{string[:keep]}...{string[-keep:]}"
+    else:
+        # keep one more at the front
+        return f"{string[:keep + 1]}...{string[-keep:]}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,7 @@ from connectors.utils import (
     iterable_batches_generator,
     next_run,
     retryable,
+    shorten_str,
     ssl_context,
     truncate_id,
     url_encode,
@@ -806,3 +807,27 @@ def test_base64url_to_base64(base64url_encoded_value, base64_expected_value):
 )
 def test_validate_email_address(email_address, is_valid):
     assert validate_email_address(email_address) == is_valid
+
+
+@pytest.mark.parametrize(
+    "original, shorten_by, shortened",
+    [
+        ("", 0, ""),
+        ("", 1000, ""),
+        (None, 0, ""),
+        (None, 1000, ""),
+        # introducing '...' would increase the string length -> no shortening
+        ("abcdefgh", 0, "abcdefgh"),
+        ("abcdefgh", 1, "abcdefgh"),
+        ("abcdefgh", 2, "abcdefgh"),
+        # valid shortening
+        ("abcdefgh", 4, "ab...gh"),
+        ("abcdefgh", 5, "ab...h"),
+        ("abcdefg", 4, "ab...g"),
+        ("abcdefg", 5, "a...g"),
+        # shortens to the max, if shorten_by is bigger than the actual string
+        ("abcdefgh", 1000, "a...h"),
+    ],
+)
+def test_shorten_str(original, shorten_by, shortened):
+    assert shorten_str(original, shorten_by) == shortened


### PR DESCRIPTION
## Related to https://github.com/orgs/elastic/projects/740/views/51?pane=issue&itemId=36690345

The previous error message would look like:

`Rule with id '95af5dc4-e2bd-4b1b-8f16-a28976384431' is semantically equal to Rule with id '37e5adc4-e2bd-4b1b-8f16-a2897631d852'`

The new error messages looks like:

`Basic rule 1 (id: '95af5...84431') is semantically equal to Basic rule 2 (id: '37e5a...1d852').`

It includes the `order` and truncates the UUID without introducing a high probability of clashes between truncated ids. This balances the need for support or a developer to look up the basic rule id in an index and end-user UX.

I've also introduced a `Format` enum, which allows the `BasicRule` class (and potentially other classes) to specify a format. We've had discussions that some logs messages are too long and it's useful to shorten them, if you want based on a config value. This enum would allow for these changes to happen. Additionally we could also introduce a `SECURE` format for sensitive information (but future stuff...).

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)