### PR TITLE
[GitHub] Add missing re-raise on ClientResponseError

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -641,6 +641,8 @@ class GitHubClient:
                 raise UnauthorizedException(
                     "Your Github token is either expired or revoked. Please check again."
                 ) from exception
+            else:
+                raise
         except Exception:
             raise
 

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -607,6 +607,25 @@ async def test_post_with_unauthorized():
 
 
 @pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+async def test_post_with_error_not_found():
+    async with create_github_source() as source:
+        source.github_client._get_session.post = Mock(
+            side_effect=ClientResponseError(
+                status=404,
+                request_info=aiohttp.RequestInfo(
+                    real_url="", method=None, headers=None, url=""
+                ),
+                history=None,
+            )
+        )
+        with pytest.raises(Exception):
+            await source.github_client.post(
+                {"variable": {"owner": "demo_user"}, "query": "QUERY"}
+            )
+
+
+@pytest.mark.asyncio
 async def test_paginated_api_call():
     expected_response = MOCK_RESPONSE_REPO
     async with create_github_source() as source:


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/6067

This fixes an issue, where a non-401 error leads to an implicit `return None` leading to this error: `TypeError: cannot unpack non-iterable NoneType object`.

The code inside `post` returns an implicit `None`, if a `ClientResponseError` is raised with a `status != 401`:

```
except ClientResponseError as exception:
            if exception.status == 401:
                raise UnauthorizedException(
                    "Your Github token is either expired or revoked. Please check again."
                ) from exception
                # implicit return None
        except Exception:
            raise
```

This leads to the error described above, when trying to unpack it in `_remote_validation`:


```
_, headers = await self.github_client.post(  # pyright: ignore
            query_data=query_data, need_headers=True
        )
```

Fixed by re-raising the original exception, which contains useful information.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)