### PR TITLE
Rename connectors-python to connectors in pr pipeline

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -2,12 +2,12 @@
   "jobs": [
     {
       "enabled": true,
-      "pipelineSlug": "connectors-python",
+      "pipelineSlug": "connectors",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
       "allowed_list": ["praveen-elastic", "moxarth-elastic", "khusbu-crest", "akanshi-crest"],
       "set_commit_status": true,
-      "commit_status_context": "buildkite/connectors-python",
+      "commit_status_context": "buildkite/connectors",
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",


### PR DESCRIPTION
This PR renames the PR pipeline from `connectors-python` to `connectors` because it couldn't reflect the pipeline status:

![image](https://github.com/elastic/connectors/assets/54903978/adfcdfb9-2ed7-4899-966d-fe536c6bff73)


## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)