### PR TITLE
[Linter] Add ASYNC rules and fix issues

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-select = ["A", "I", "E", "F", "B"]
+select = ["A", "ASYNC", "I", "E", "F", "B"]
 ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.

--- a/connectors/sources/directory.py
+++ b/connectors/sources/directory.py
@@ -12,6 +12,8 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 
+import aiofiles
+
 from connectors.source import BaseDataSource
 from connectors.utils import TIKA_SUPPORTED_FILETYPES, get_base64_value
 
@@ -62,11 +64,12 @@ class DirectoryDataSource(BaseDataSource):
             return
 
         self._logger.info(f"Reading {path}")
-        with open(file=path, mode="rb") as f:
+        async with aiofiles.open(file=path, mode="rb") as f:
+            content = await f.read()
             return {
                 "_id": self.get_id(path),
                 "_timestamp": timestamp,
-                "_attachment": get_base64_value(f.read()),
+                "_attachment": get_base64_value(content),
             }
 
     async def get_docs(self, filtering=None):

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,4 +1,5 @@
 aiohttp==3.8.5
+aiofiles==23.2.1
 elasticsearch[async]==8.8.0
 elastic-transport==8.4.0
 pyyaml==6.0

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import asyncio
 import json
 import logging
 import time
@@ -84,7 +85,7 @@ async def test_async_tracer():
 
         @tracer.start_as_current_span("trace me", "special")
         async def traceable():
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
 
         await traceable()
         ecs_log = logs[0]
@@ -107,14 +108,14 @@ async def test_async_tracer_slow():
 
         @tracer.start_as_current_span("trace me", "special", slow_log=10)
         async def traceable():
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
 
         await traceable()
         assert (len(logs)) == 0
 
         @tracer.start_as_current_span("trace me", "special", slow_log=0.01)
         async def traceable_slow():
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
 
         await traceable_slow()
         assert (len(logs)) == 1


### PR DESCRIPTION
I skimmed through the `ruff` docs and saw that there are `ASYNC` rules:

- No blocking http calls
- No blocking sleep, open or subprocess calls
- No blocking os method calls

I think these can be pretty useful to avoid blocking the event loop. We already had examples in the past, where we used blocking `os` calls.

Also fixed the issues the linter found. Added `aiofiles` as requirement to enable local async file operations.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)