### PR TITLE
Improve PostgreSQL query for identifying primary keys

### DIFF
--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -53,7 +53,11 @@ class PostgreSQLQueries(Queries):
 
     def table_primary_key(self, **kwargs):
         """Query to get the primary key"""
-        return f"SELECT c.column_name FROM information_schema.table_constraints tc JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name) JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema AND tc.table_name = c.table_name AND ccu.column_name = c.column_name WHERE constraint_type = 'PRIMARY KEY' and tc.table_name = '{kwargs['table']}' and tc.constraint_schema = '{kwargs['schema']}'"
+        return (
+            f"SELECT a.attname AS c FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid "
+            f"AND a.attnum = ANY(i.indkey) WHERE i.indrelid = '{kwargs['schema']}.{kwargs['table']}'::regclass "
+            f"AND i.indisprimary"
+        )
 
     def table_data(self, **kwargs):
         """Query to get the table data"""

--- a/tests/sources/fixtures/postgresql/connector.json
+++ b/tests/sources/fixtures/postgresql/connector.json
@@ -33,14 +33,14 @@
                         "label": "Username",
                         "order": 3,
                         "type": "str",
-                        "value": "admin"
+                        "value": "readonly"
                 },
                 "password": {
                         "label": "Password",
                         "order": 4,
                         "sensitive": true,
                         "type": "str",
-                        "value": "Password_123"
+                        "value": "foobar123"
                 },
                 "database": {
                         "label": "Database",


### PR DESCRIPTION
According to the [postgres wiki](https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns), this is the optimal query to use for getting a table's primary key.

The previous query we were using had a limitation insofar as: a user with restricted permissions (_eg_ only the `pg_read_all_data` role) can't see data in `information_schema.table_constraints`, and thus cannot determine the primary key for a table.

The new query being used here does not appear to have that limitation.

-----

Related to the above: we are also updating the Postgres functional tests to configure the connector with a user that has reduced (read-only) permissions. Thanks @artem-shelkovnikov for the suggestion.

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
