### PR TITLE
[SPO] Fix bugs when handling drive_items in incremental sync

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1579,16 +1579,31 @@ class SharepointOnlineDataSource(BaseDataSource):
 
             return
 
-        ids_to_items = {
-            drive_item["id"]: drive_item for drive_item in drive_items_batch
+        def _is_item_deleted(drive_item):
+            return self.drive_item_operation(drive_item) == OP_DELETE
+
+        # Don't fetch access controls for deleted drive items
+        deleted_drive_items = [
+            drive_item
+            for drive_item in drive_items_batch
+            if _is_item_deleted(drive_item)
+        ]
+        for drive_item in deleted_drive_items:
+            yield drive_item
+
+        # Fetch access controls only for upserts
+        upsert_ids_to_items = {
+            drive_item["id"]: drive_item
+            for drive_item in drive_items_batch
+            if not _is_item_deleted(drive_item)
         }
-        drive_items_ids = list(ids_to_items.keys())
+        upsert_drive_items_ids = list(upsert_ids_to_items.keys())
 
         async for permissions_response in self.client.drive_items_permissions_batch(
-            drive_id, drive_items_ids
+            drive_id, upsert_drive_items_ids
         ):
             drive_item_id = permissions_response.get("id")
-            drive_item = ids_to_items.get(drive_item_id)
+            drive_item = upsert_ids_to_items.get(drive_item_id)
             permissions = permissions_response.get("body", {}).get("value", [])
 
             if drive_item:
@@ -1716,7 +1731,10 @@ class SharepointOnlineDataSource(BaseDataSource):
                     site, site_access_control
                 ), None, OP_INDEX
 
-                async for site_drive in self.site_drives(site, check_timestamp=True):
+                # Edit operation on a drive_item doesn't update the
+                # lastModifiedDateTime of the parent site_drive. Therfore, we
+                # set check_timestamp to False when iterating over site_drives.
+                async for site_drive in self.site_drives(site, check_timestamp=False):
                     yield self._decorate_with_access_control(
                         site_drive, site_access_control
                     ), None, OP_INDEX

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2647,6 +2647,44 @@ class TestSharepointOnlineDataSource:
             )
 
     @pytest.mark.asyncio
+    async def test_drive_items_batch_with_permissions_for_delta_delete_operation(
+        self, patch_sharepoint_client
+    ):
+        async with create_spo_source(use_document_level_security=True) as source:
+            drive_id = 1
+            drive_item_ids = ["1", "2"]
+            drive_items_batch = [
+                {"id": "1", "deleted": {"state": "deleted"}},
+                {"id": "2"},
+            ]
+
+            permissions_responses = [
+                {
+                    "id": drive_item_id,
+                    "body": {
+                        "value": [{"grantedToV2": {"user": {"id": "some user id"}}}]
+                    },
+                }
+                for drive_item_id in drive_item_ids
+            ]
+
+            patch_sharepoint_client.drive_items_permissions_batch = AsyncIterator(
+                permissions_responses
+            )
+
+            drive_items_with_permissions = []
+
+            async for drive_item_with_permission in source._drive_items_batch_with_permissions(
+                drive_id, drive_items_batch, "dummy_site_web_url"
+            ):
+                drive_items_with_permissions.append(drive_item_with_permission)
+
+            assert len(drive_items_with_permissions) == len(drive_item_ids)
+            # Item with id 1 was deleted, so not trying to fetch permissions
+            assert ACCESS_CONTROL not in drive_items_with_permissions[0]
+            assert ACCESS_CONTROL in drive_items_with_permissions[1]
+
+    @pytest.mark.asyncio
     @patch(
         "connectors.sources.sharepoint_online.ACCESS_CONTROL",
         ALLOW_ACCESS_CONTROL_PATCHED,


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/6051

This fixed the issue with changed content of a file (driveItem) not being picked up by an incremental sync. 

The simple solution is to disable timestamp checks for site_drives and then rely on efficient delta api to get all changes for drive items. 

I verified that the  drive_item <-> drive_site is the only scenario when change to an object doesn't update its "parent" `lastModifiedDateTime` field.  Interestingly, drive item updates would result in timestamp updates for its parent "list" and "site", so we are safe at keeping timestamp checks for sites.

For other object types in SPO there were no "unexpected" behaviour when it comes to updating timestamps after edits.

## Bonus bug fix

I realized that with `fetch_drive_item_permissions` enabled, the incremental sync will fail at handling `DELETE` operations since we are trying to fetch ACLs for a deleted document - it will result in 404 error. I added a logic to handle that scenario and manually tested that it works.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference

