### PR TITLE
[pre-8.10-stable] [CI] Update pull-requests.json (#1811)

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -2,12 +2,12 @@
   "jobs": [
     {
       "enabled": true,
-      "pipelineSlug": "connectors-python",
+      "pipelineSlug": "connectors",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
       "allowed_list": ["praveen-elastic", "moxarth-elastic", "khusbu-crest", "akanshi-crest"],
       "set_commit_status": true,
-      "commit_status_context": "buildkite/connectors-python",
+      "commit_status_context": "buildkite/connectors",
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `pre-8.10-stable`:
 - [[CI] Update pull-requests.json (#1811)](https://github.com/elastic/connectors/pull/1811)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)