### PR TITLE
Add flake8-comprehentions(C4) ruff rule

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,8 +1,8 @@
-select = ["A", "ASYNC", "I", "E", "F", "B"]
+select = ["A", "ASYNC", "I", "E", "F", "B", "C4"]
 ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+fixable = ["A", "B", "C", "C4", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
 unfixable = []
 
 exclude = [

--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -31,19 +31,14 @@ def parse(basic_rules_json):
     if not basic_rules_json:
         return []
 
-    map_to_basic_rules_list = list(
-        map(
-            lambda basic_rule_json: BasicRule.from_json(basic_rule_json),
-            basic_rules_json,
-        )
-    )
+    map_to_basic_rules_list = [
+        BasicRule.from_json(basic_rule_json) for basic_rule_json in basic_rules_json
+    ]
 
     return sorted(
-        list(
-            filter(
-                lambda basic_rule: not basic_rule.is_default_rule(),
-                map_to_basic_rules_list,
-            )
+        filter(
+            lambda basic_rule: not basic_rule.is_default_rule(),
+            map_to_basic_rules_list,
         ),
         key=lambda basic_rule: basic_rule.order,
     )

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -170,7 +170,7 @@ class Field:
                 return (
                     value is None
                     or len(value) <= 0
-                    or all([x in (None, "") for x in value])
+                    or all(x in (None, "") for x in value)
                 )
             case _:
                 # int and bool

--- a/connectors/sources/generic_database.py
+++ b/connectors/sources/generic_database.py
@@ -35,7 +35,7 @@ def configured_tables(tables):
         list(
             filter(
                 lambda table: table_filter(table),
-                map(lambda table: table.strip(), tables.split(",")),
+                (table.strip() for table in tables.split(",")),
             )
         )
         if isinstance(tables, str)

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -813,9 +813,9 @@ class GitHubAdvancedRulesValidator(AdvancedRulesValidator):
                 validation_message=e.message,
             )
 
-        self.source.github_client.repos = set(
+        self.source.github_client.repos = {
             rule["repository"] for rule in advanced_rules
-        )
+        }
         invalid_repos = await self.source.get_invalid_repos()
 
         if len(invalid_repos) > 0:

--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -117,11 +117,11 @@ class MSSQLAdvancedRulesValidator(AdvancedRulesValidator):
                 validation_message=e.message,
             )
 
-        tables_to_filter = set(
+        tables_to_filter = {
             table
             for query_info in advanced_rules
             for table in query_info.get("tables", [])
-        )
+        }
         tables = {
             table
             async for table in self.source.mssql_client.get_tables_to_fetch(
@@ -594,7 +594,7 @@ class MSSQLDataSource(BaseDataSource):
         async for row in self.yield_rows_for_query(
             primary_key_columns=primary_key_columns, tables=tables, query=query
         ):
-            doc_id = f"{self.database}_{self.schema}_{hash_id([table for table in tables], row, primary_key_columns)}"
+            doc_id = f"{self.database}_{self.schema}_{hash_id(list(tables), row, primary_key_columns)}"
 
             yield self.serialize(
                 doc=self.row2doc(

--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -463,7 +463,7 @@ class OutlookDocFormatter:
                 recipient.email_address for recipient in (mail.bcc_recipients or [])
             ],
             "importance": mail.importance,
-            "categories": [category for category in (mail.categories or [])],
+            "categories": list((mail.categories or [])),
             "message": html_to_text(html=mail.body),
         }
 
@@ -528,7 +528,7 @@ class OutlookDocFormatter:
             "complete_date": ews_format_to_datetime(
                 source_datetime=task.complete_date, timezone=timezone
             ),
-            "categories": [category for category in (task.categories or [])],
+            "categories": list((task.categories or [])),
             "importance": task.importance,
             "content": task.text_body,
             "status": task.status,

--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -113,11 +113,11 @@ class PostgreSQLAdvancedRulesValidator(AdvancedRulesValidator):
                 validation_message=e.message,
             )
 
-        tables_to_filter = set(
+        tables_to_filter = {
             table
             for query_info in advanced_rules
             for table in query_info.get("tables", [])
-        )
+        }
         tables = {
             table
             async for table in self.source.postgresql_client.get_tables_to_fetch(
@@ -538,7 +538,7 @@ class PostgreSQLDataSource(BaseDataSource):
         async for row in self.yield_rows_for_query(
             primary_key_columns=primary_key_columns, tables=tables, query=query
         ):
-            doc_id = f"{self.database}_{self.schema}_{hash_id([table for table in tables], row, primary_key_columns)}"
+            doc_id = f"{self.database}_{self.schema}_{hash_id(list(tables), row, primary_key_columns)}"
 
             yield self.serialize(
                 doc=self.row2doc(

--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -360,7 +360,7 @@ class ServiceNowAdvancedRulesValidator(AdvancedRulesValidator):
                 validation_message=e.message,
             )
 
-        services_to_filter = set(rule["service"] for rule in advanced_rules)
+        services_to_filter = {rule["service"] for rule in advanced_rules}
 
         (
             _,
@@ -657,7 +657,7 @@ class ServiceNowDataSource(BaseDataSource):
         self._logger.info("Fetching ServiceNow data")
         if filtering and filtering.has_advanced_rules():
             advanced_rules = filtering.get_advanced_rules()
-            services = set(rule["service"] for rule in advanced_rules)
+            services = {rule["service"] for rule in advanced_rules}
 
             (
                 servicenow_mapping,

--- a/tests/filtering/test_validation.py
+++ b/tests/filtering/test_validation.py
@@ -1009,10 +1009,8 @@ def test_basic_rules_set_no_conflicting_policies_validation(
     else:
         assert not any(result.is_valid for result in validation_results)
 
-    validation_results_rule_ids = set(
-        map(lambda result: result.rule_id, validation_results)
-    )
-    basic_rule_ids = set(map(lambda rule: rule["id"], basic_rules))
+    validation_results_rule_ids = {result.rule_id for result in validation_results}
+    basic_rule_ids = {rule["id"] for rule in basic_rules}
 
     assert validation_results_rule_ids == basic_rule_ids
 

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -2153,9 +2153,13 @@ def test_updated_configuration_fields():
     )
 
     # all keys included where there are changes (excludes 'tenant_name')
-    assert result.keys() == set(
-        ["new_config", "tenant_id", "client_id", "secret_value", "some_toggle"]
-    )
+    assert result.keys() == {
+        "new_config",
+        "tenant_id",
+        "client_id",
+        "secret_value",
+        "some_toggle",
+    }
 
     # order is adjusted
     assert result["client_id"]["order"] == 4

--- a/tests/sources/test_google_drive.py
+++ b/tests/sources/test_google_drive.py
@@ -185,7 +185,7 @@ async def test_prepare_files(files, expected_files):
         async for file in source.prepare_files(
             client=source.google_drive_client(),
             files_page=files[0],
-            paths=dict(),
+            paths={},
             seen_ids=set(),
         ):
             processed_files.append(file)
@@ -596,7 +596,7 @@ async def test_get_docs_with_domain_wide_delegation():
         )
 
         mock_empty_response_future = asyncio.Future()
-        mock_empty_response_future.set_result(dict())
+        mock_empty_response_future.set_result({})
 
         mock_gdrive_client.get_all_folders = mock.MagicMock(
             return_value=mock_empty_response_future

--- a/tests/sources/test_mysql.py
+++ b/tests/sources/test_mysql.py
@@ -336,7 +336,7 @@ async def test_client_get_column_names_for_query(patch_connection_pool):
 
     async with client:
         result = await client.get_column_names_for_query("SELECT * FROM *")
-        expected_columns = list(map(lambda column: column[0], columns))
+        expected_columns = [column[0] for column in columns]
 
         assert result == expected_columns
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -272,7 +272,7 @@ def dls_enabled(value):
 
 
 def access_control_matches(actual, expected):
-    return all([access_control in expected for access_control in actual])
+    return all(access_control in expected for access_control in actual)
 
 
 def access_control_is_equal(actual, expected):
@@ -641,7 +641,7 @@ class TestMicrosoftAPISession:
         for response in responses.values():
             mock_responses.get(response["url"], payload=response["payload"])
 
-        pages = list()
+        pages = []
 
         async for page in microsoft_api_session.scroll_delta_url(
             url=responses["page1"]["url"]
@@ -2263,23 +2263,19 @@ class TestSharepointOnlineDataSource:
             assert len(site_collections) == len(self.site_collections)
             assert len(sites) == len(self.sites)
             assert all(
-                [
-                    access_control_matches(
-                        site[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
-                    )
-                    for site in sites
-                ]
+                access_control_matches(
+                    site[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
+                )
+                for site in sites
             )
 
             assert len(site_drives) == len(self.site_drives)
             assert all(
-                [
-                    access_control_matches(
-                        site_drive[ALLOW_ACCESS_CONTROL_PATCHED],
-                        expected_access_control,
-                    )
-                    for site_drive in site_drives
-                ]
+                access_control_matches(
+                    site_drive[ALLOW_ACCESS_CONTROL_PATCHED],
+                    expected_access_control,
+                )
+                for site_drive in site_drives
             )
 
             assert len(drive_items) == sum([len(j) for j in self.drive_items])
@@ -2290,56 +2286,46 @@ class TestSharepointOnlineDataSource:
                 *expected_access_control,
             ]
             assert all(
-                [
-                    access_control_matches(
-                        drive_item[ALLOW_ACCESS_CONTROL_PATCHED],
-                        expected_drive_item_access_control,
-                    )
-                    for drive_item in drive_items
-                ]
+                access_control_matches(
+                    drive_item[ALLOW_ACCESS_CONTROL_PATCHED],
+                    expected_drive_item_access_control,
+                )
+                for drive_item in drive_items
             )
 
             assert len(site_lists) == len(self.site_lists)
             assert all(
-                [
-                    access_control_matches(
-                        site_list[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
-                    )
-                    for site_list in site_lists
-                ]
+                access_control_matches(
+                    site_list[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
+                )
+                for site_list in site_lists
             )
 
             assert (
                 len(list_items) == len(self.site_list_items) - 1
             )  # -1 because one of them is ignored!
             assert all(
-                [
-                    access_control_matches(
-                        list_item[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
-                    )
-                    for list_item in list_items
-                ]
+                access_control_matches(
+                    list_item[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
+                )
+                for list_item in list_items
             )
 
             assert len(list_item_attachments) == len(self.site_list_item_attachments)
             assert all(
-                [
-                    access_control_matches(
-                        list_item_attachment[ALLOW_ACCESS_CONTROL_PATCHED],
-                        expected_access_control,
-                    )
-                    for list_item_attachment in list_item_attachments
-                ]
+                access_control_matches(
+                    list_item_attachment[ALLOW_ACCESS_CONTROL_PATCHED],
+                    expected_access_control,
+                )
+                for list_item_attachment in list_item_attachments
             )
 
             assert len(site_pages) == len(self.site_pages)
             assert all(
-                [
-                    access_control_matches(
-                        site_page[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
-                    )
-                    for site_page in site_pages
-                ]
+                access_control_matches(
+                    site_page[ALLOW_ACCESS_CONTROL_PATCHED], expected_access_control
+                )
+                for site_page in site_pages
             )
 
             assert source.sync_cursor()["cursor_timestamp"] == self.today
@@ -2374,8 +2360,8 @@ class TestSharepointOnlineDataSource:
         for page in self.drive_items_delta:
             deleted += len(list(filter(lambda item: "deleted" in item, page)))
 
-        docs = list()
-        downloads = list()
+        docs = []
+        downloads = []
         operations = {"index": 0, "delete": 0}
 
         async for doc, download_func, operation in source.get_docs_incrementally(
@@ -2719,23 +2705,19 @@ class TestSharepointOnlineDataSource:
             ]
 
             assert all(
-                [
-                    access_control_is_equal(
-                        drive_item[ALLOW_ACCESS_CONTROL_PATCHED],
-                        expected_drive_item_access_control,
-                    )
-                    for drive_item in drive_items
-                ]
+                access_control_is_equal(
+                    drive_item[ALLOW_ACCESS_CONTROL_PATCHED],
+                    expected_drive_item_access_control,
+                )
+                for drive_item in drive_items
             )
 
             assert all(
-                [
-                    not access_control_is_equal(
-                        drive_item[ALLOW_ACCESS_CONTROL_PATCHED],
-                        drive_item_access_control_with_ac_inhertiance,
-                    )
-                    for drive_item in drive_items
-                ]
+                not access_control_is_equal(
+                    drive_item[ALLOW_ACCESS_CONTROL_PATCHED],
+                    drive_item_access_control_with_ac_inhertiance,
+                )
+                for drive_item in drive_items
             )
 
     @pytest.mark.asyncio
@@ -2762,13 +2744,11 @@ class TestSharepointOnlineDataSource:
             site_pages = [i for i in results if i["object_type"] == "site_page"]
 
             assert all(
-                [
-                    access_control_is_equal(
-                        site_page[ALLOW_ACCESS_CONTROL_PATCHED],
-                        admin_site_access_controls,
-                    )
-                    for site_page in site_pages
-                ]
+                access_control_is_equal(
+                    site_page[ALLOW_ACCESS_CONTROL_PATCHED],
+                    admin_site_access_controls,
+                )
+                for site_page in site_pages
             )
 
     @pytest.mark.asyncio
@@ -3276,7 +3256,7 @@ class TestSharepointOnlineDataSource:
             expected_email = f"email:{email}"
             expected_user = f"user:{username}"
             expected_user_id = f"user_id:{user_id}"
-            expected_groups = list(map(lambda group: f"group:{group}", groups))
+            expected_groups = [f"group:{group}" for group in groups]
 
             user_doc = await source._user_access_control_doc(user)
             access_control = user_doc["query"]["template"]["params"]["access_control"]
@@ -3290,7 +3270,7 @@ class TestSharepointOnlineDataSource:
             assert user_doc["identity"]["user_id"] == expected_user_id
             assert expected_email in access_control
             assert expected_user in access_control
-            all([group in access_control for group in expected_groups])
+            all(group in access_control for group in expected_groups)
 
     @pytest.mark.asyncio
     async def test_get_access_control_with_dls_disabled(self, patch_sharepoint_client):
@@ -3377,10 +3357,8 @@ class TestSharepointOnlineDataSource:
 
         assert len(actual_emails_and_usernames) == len(expected_emails_and_usernames)
         assert all(
-            [
-                email_or_username in expected_emails_and_usernames
-                for email_or_username in actual_emails_and_usernames
-            ]
+            email_or_username in expected_emails_and_usernames
+            for email_or_username in actual_emails_and_usernames
         )
 
     def test_prefix_group(self):


### PR DESCRIPTION
Adding new linter rule: https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4

This rule helps with simplifying the code working with comprehentions. All the changes in the code are done with `make autoformat` and remove redundant usage of `list`, `set` and such.