### PR TITLE
Add T10 and T20 rules + fix problems with them

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,8 +1,8 @@
-select = ["A", "ASYNC", "I", "E", "F", "B"]
+select = ["A", "ASYNC", "I", "E", "F", "B", "T10", "T20"]
 ignore = ["E501"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT", "T10", "T20"]
 unfixable = []
 
 exclude = [

--- a/connectors/cli.py
+++ b/connectors/cli.py
@@ -160,32 +160,38 @@ def run(args):
 
     # just display the list of connectors
     if args.action == ["list"]:
-        print("Registered connectors:")
+        print("Registered connectors:")  # noqa: T201
         for source in get_source_klasses(config):
-            print(f"- {source.name}")
-        print("Bye")
+            print(f"- {source.name}")  # noqa: T201
+        print("Bye")  # noqa: T201
         return 0
 
     if args.action == ["config"]:
         service_type = args.service_type
-        print(f"Getting default configuration for service type {service_type}")
+        print(  # noqa: T201
+            f"Getting default configuration for service type {service_type}"
+        )
 
         source_list = config["sources"]
         if service_type not in source_list:
-            print(f"Could not find a connector for service type {service_type}")
+            print(  # noqa: T201
+                f"Could not find a connector for service type {service_type}"
+            )
             return -1
 
         source_klass = get_source_klass(source_list[service_type])
-        print(json.dumps(source_klass.get_simple_configuration(), indent=2))
-        print("Bye")
+        print(  # noqa: T201
+            json.dumps(source_klass.get_simple_configuration(), indent=2)
+        )
+        print("Bye")  # noqa: T201
         return 0
 
     if "list" in args.action:
-        print("Cannot use the `list` action with other actions")
+        print("Cannot use the `list` action with other actions")  # noqa: T201
         return -1
 
     if "config" in args.action:
-        print("Cannot use the `config` action with other actions")
+        print("Cannot use the `config` action with other actions")  # noqa: T201
         return -1
 
     loop = get_event_loop(args.uvloop)
@@ -210,7 +216,7 @@ def main(args=None):
     parser = _parser()
     args = parser.parse_args(args=args)
     if args.version:
-        print(__version__)
+        print(__version__)  # noqa: T201
         return 0
 
     return run(args)

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 import asyncio
 import os
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ class Logger:
 
     def debug(self, msg, exc_info=False):
         if not self.silent:
-            print(msg)
+            print(msg)  # noqa: T201
         self.logs.append(msg)
         if exc_info:
             self.logs.append(traceback.format_exc())

--- a/tests/sources/fixtures/azure_blob_storage/fixture.py
+++ b/tests/sources/fixtures/azure_blob_storage/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 import os
 
 from azure.storage.blob import BlobServiceClient

--- a/tests/sources/fixtures/box/fixture.py
+++ b/tests/sources/fixtures/box/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to handle api calls received from connector."""
 import io
 import os

--- a/tests/sources/fixtures/confluence/fixture.py
+++ b/tests/sources/fixtures/confluence/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to responsible to generate confluence documents using the Flask framework.
 """
 import io

--- a/tests/sources/fixtures/dir/fixture.py
+++ b/tests/sources/fixtures/dir/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 import os
 import random
 import shutil

--- a/tests/sources/fixtures/dropbox/fixture.py
+++ b/tests/sources/fixtures/dropbox/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Dropbox module responsible to generate files/folders using flask.
 """
 

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -3,6 +3,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
+# ruff: noqa: T203
 import importlib
 import importlib.util
 import logging

--- a/tests/sources/fixtures/github/fixture.py
+++ b/tests/sources/fixtures/github/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to responsible to generate GitHub documents using the Flask framework.
 """
 import base64

--- a/tests/sources/fixtures/google_cloud_storage/fixture.py
+++ b/tests/sources/fixtures/google_cloud_storage/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Google Cloud Storage module responsible to generate blob(s) on the fake Google Cloud Storage server.
 """
 import os

--- a/tests/sources/fixtures/google_cloud_storage/mocker.py
+++ b/tests/sources/fixtures/google_cloud_storage/mocker.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module responsible for mocking POST call to Google Cloud Storage Data Source
 """
 from flask import Flask

--- a/tests/sources/fixtures/google_drive/fixture.py
+++ b/tests/sources/fixtures/google_drive/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to handle api calls received from connector."""
 
 import os

--- a/tests/sources/fixtures/jira/fixture.py
+++ b/tests/sources/fixtures/jira/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to responsible to generate jira documents using the Flask framework.
 """
 import io

--- a/tests/sources/fixtures/microsoft_teams/fixture.py
+++ b/tests/sources/fixtures/microsoft_teams/fixture.py
@@ -1,3 +1,9 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+# ruff: noqa: T201
 import io
 import os
 

--- a/tests/sources/fixtures/mongodb/fixture.py
+++ b/tests/sources/fixtures/mongodb/fixture.py
@@ -1,3 +1,9 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+# ruff: noqa: T201
 import os
 
 import bson

--- a/tests/sources/fixtures/mongodb_serverless/fixture.py
+++ b/tests/sources/fixtures/mongodb_serverless/fixture.py
@@ -1,3 +1,9 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+# ruff: noqa: T201
 import os
 import shutil
 

--- a/tests/sources/fixtures/mssql/fixture.py
+++ b/tests/sources/fixtures/mssql/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 import os
 import random
 

--- a/tests/sources/fixtures/mysql/fixture.py
+++ b/tests/sources/fixtures/mysql/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 import os
 import random
 

--- a/tests/sources/fixtures/network_drive/fixture.py
+++ b/tests/sources/fixtures/network_drive/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Network Drive module responsible to generate file/folder(s) on Network Drive server.
 """
 import os

--- a/tests/sources/fixtures/onedrive/fixture.py
+++ b/tests/sources/fixtures/onedrive/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to handle api calls received from connector."""
 
 import io

--- a/tests/sources/fixtures/oracle/fixture.py
+++ b/tests/sources/fixtures/oracle/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Oracle module responsible to generate records on the Oracle server.
 """
 import os

--- a/tests/sources/fixtures/postgresql/fixture.py
+++ b/tests/sources/fixtures/postgresql/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 import asyncio
 import os
 import random

--- a/tests/sources/fixtures/s3/fixture.py
+++ b/tests/sources/fixtures/s3/fixture.py
@@ -1,3 +1,9 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+# ruff: noqa: T201
 import os
 
 import boto3

--- a/tests/sources/fixtures/salesforce/fixture.py
+++ b/tests/sources/fixtures/salesforce/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to handle api calls received from connector."""
 
 import io

--- a/tests/sources/fixtures/servicenow/fixture.py
+++ b/tests/sources/fixtures/servicenow/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to responsible to generate ServiceNow documents using the Flask framework.
 """
 import base64

--- a/tests/sources/fixtures/sharepoint_online/fixture.py
+++ b/tests/sources/fixtures/sharepoint_online/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to handle api calls received from connector."""
 
 import os

--- a/tests/sources/fixtures/sharepoint_server/fixture.py
+++ b/tests/sources/fixtures/sharepoint_server/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to handle api calls received from connector."""
 
 import os

--- a/tests/sources/fixtures/zoom/fixture.py
+++ b/tests/sources/fixtures/zoom/fixture.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+# ruff: noqa: T201
 """Module to responsible to generate Zoom documents using the Flask framework."""
 
 import os

--- a/tests/sources/test_google_cloud_storage.py
+++ b/tests/sources/test_google_cloud_storage.py
@@ -590,11 +590,11 @@ async def test_api_call_for_attribute_error(catch_stdout):
 
     async with create_gcs_source() as source:
         with pytest.raises(AttributeError):
-            async for _ in source._google_storage_client.api_call(
+            async for resp in source._google_storage_client.api_call(
                 resource="buckets_dummy",
                 method="list",
                 full_response=True,
                 project=source._google_storage_client.user_project_id,
                 userProject=source._google_storage_client.user_project_id,
             ):
-                print("Method called successfully....")
+                assert resp is not None


### PR DESCRIPTION
Adds 3 linting rules and fixes or ignores places that are violating it:

- T100 is usage of debugger statements
- T201 is usage of `print`
- T203 is usage of `pprint`

I personally often forget `print` statements and adding this rule will help me a lot :)