### PR TITLE
[Network Drive] Add Dropdown for Drive type

### DIFF
--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -14,6 +14,7 @@ from io import BytesIO
 import fastjsonschema
 import smbclient
 import winrm
+from requests.exceptions import ConnectionError
 from smbprotocol.exceptions import SMBException, SMBOSError
 from smbprotocol.file_info import (
     InfoType,
@@ -38,7 +39,7 @@ from connectors.filtering.validation import (
     AdvancedRulesValidator,
     SyncRuleValidationResult,
 )
-from connectors.source import BaseDataSource
+from connectors.source import BaseDataSource, ConfigurableFieldValueError
 from connectors.utils import (
     TIKA_SUPPORTED_FILETYPES,
     RetryStrategy,
@@ -58,6 +59,9 @@ MAX_CHUNK_SIZE = 65536
 DEFAULT_FILE_SIZE_LIMIT = 10485760
 RETRIES = 3
 RETRY_INTERVAL = 2
+
+WINDOWS = "windows"
+LINUX = "linux"
 
 
 def _prefix_user(user):
@@ -247,6 +251,7 @@ class NASDataSource(BaseDataSource):
         self.server_ip = self.configuration["server_ip"]
         self.port = self.configuration["server_port"]
         self.drive_path = self.configuration["drive_path"]
+        self.drive_type = self.configuration["drive_type"]
         self.identity_mappings = self.configuration["identity_mappings"]
         self.session = None
         self.security_info = SecurityInfo(self.username, self.password, self.server_ip)
@@ -297,10 +302,28 @@ class NASDataSource(BaseDataSource):
                 "type": "bool",
                 "value": False,
             },
+            "drive_type": {
+                "display": "dropdown",
+                "label": "Drive type",
+                "depends_on": [
+                    {"field": "use_document_level_security", "value": True},
+                ],
+                "options": [
+                    {"label": "Windows", "value": WINDOWS},
+                    {"label": "Linux", "value": LINUX},
+                ],
+                "order": 7,
+                "type": "str",
+                "ui_restrictions": ["advanced"],
+                "value": WINDOWS,
+            },
             "identity_mappings": {
                 "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",
-                "depends_on": [{"field": "use_document_level_security", "value": True}],
-                "order": 7,
+                "depends_on": [
+                    {"field": "use_document_level_security", "value": True},
+                    {"field": "drive_type", "value": LINUX},
+                ],
+                "order": 8,
                 "type": "str",
                 "required": False,
                 "ui_restrictions": ["advanced"],
@@ -445,6 +468,8 @@ class NASDataSource(BaseDataSource):
             executor=None, func=partial(self.fetch_file_content, path=file["path"])
         )
 
+        if not content:
+            return
         attachment = content.read()
         content.close()
         return {
@@ -454,17 +479,22 @@ class NASDataSource(BaseDataSource):
         }
 
     def list_file_permission(self, file_path, file_type, mode, access):
-        with smbclient.open_file(
-            file_path,
-            mode=mode,
-            buffering=0,
-            file_type=file_type,
-            desired_access=access,
-        ) as file:
-            descriptor = self.security_info.get_descriptor(
-                file_descriptor=file.fd, info=SECURITY_INFO_DACL
+        try:
+            with smbclient.open_file(
+                file_path,
+                mode=mode,
+                buffering=0,
+                file_type=file_type,
+                desired_access=access,
+            ) as file:
+                descriptor = self.security_info.get_descriptor(
+                    file_descriptor=file.fd, info=SECURITY_INFO_DACL
+                )
+                return descriptor.get_dacl()["aces"]
+        except SMBOSError as error:
+            self._logger.error(
+                f"Cannot read the contents of file on path:{file_path}. Error {error}"
             )
-            return descriptor.get_dacl()["aces"]
 
     def _dls_enabled(self):
         if (
@@ -521,8 +551,8 @@ class NASDataSource(BaseDataSource):
                 for row in csv_reader:
                     user_info.append(
                         {
-                            "username": row[0],
-                            "user_id": row[1],
+                            "name": row[0],
+                            "user_sid": row[1],
                             "groups": row[2].split(",") if len(row[2]) > 0 else [],
                         }
                     )
@@ -538,36 +568,49 @@ class NASDataSource(BaseDataSource):
             return
 
         # This if block fetches users, groups via local csv file path
-        if self.identity_mappings:
-            self._logger.info(
-                f"Fetching all groups and users from configured file path '{self.identity_mappings}'"
-            )
+        if self.drive_type == LINUX:
+            if self.identity_mappings:
+                self._logger.info(
+                    f"Fetching all groups and users from configured file path '{self.identity_mappings}'"
+                )
 
-            for user in self.read_user_info_csv():
-                yield await self._user_access_control_doc(
-                    user["name"], user["sid"], user["groups"]
+                for user in self.read_user_info_csv():
+                    yield await self._user_access_control_doc(
+                        user=user["name"],
+                        sid=user["user_sid"],
+                        groups_info=user["groups"],
+                    )
+            else:
+                raise ConfigurableFieldValueError(
+                    "CSV file path cannot be empty. Please provide a valid csv file path."
                 )
         else:
-            self._logger.info(
-                f"Fetching all groups and members for drive at path '{self.drive_path}'"
-            )
-            groups_info = await asyncio.to_thread(self.security_info.fetch_groups)
-
-            groups_members = {}
-            for group_name, _ in groups_info.items():
-                groups_members[group_name] = await asyncio.to_thread(
-                    self.security_info.fetch_members, group_name
+            try:
+                self._logger.info(
+                    f"Fetching all groups and members for drive at path '{self.drive_path}'"
                 )
+                groups_info = await asyncio.to_thread(self.security_info.fetch_groups)
 
-            self._logger.info(
-                f"Fetching all users for drive at path '{self.drive_path}'"
-            )
-            users_info = await asyncio.to_thread(self.security_info.fetch_users)
+                groups_members = {}
+                for group_name, _ in groups_info.items():
+                    groups_members[group_name] = await asyncio.to_thread(
+                        self.security_info.fetch_members, group_name
+                    )
 
-            for user, sid in users_info.items():
-                yield await self._user_access_control_doc(
-                    user, sid, groups_info, groups_members
+                self._logger.info(
+                    f"Fetching all users for drive at path '{self.drive_path}'"
                 )
+                users_info = await asyncio.to_thread(self.security_info.fetch_users)
+
+                for user, sid in users_info.items():
+                    yield await self._user_access_control_doc(
+                        user=user,
+                        sid=sid,
+                        groups_info=groups_info,
+                        groups_members=groups_members,
+                    )
+            except ConnectionError as exception:
+                raise ConnectionError("Something went wrong") from exception
 
     async def get_entity_permission(self, file_path, file_type):
         if not self._dls_enabled():
@@ -590,7 +633,7 @@ class NASDataSource(BaseDataSource):
                 mode="br",
                 access=DirectoryAccessMask.READ_CONTROL,
             )
-        for permission in list_permissions:
+        for permission in list_permissions or []:
             if (
                 permission["ace_type"].value == ACCESS_ALLOWED_TYPE
                 or permission["mask"].value == ACCESS_MASK_DENIED_WRITE_PERMISSION

--- a/tests/sources/fixtures/network_drive/connector.json
+++ b/tests/sources/fixtures/network_drive/connector.json
@@ -1,135 +1,148 @@
 {
-        "name": "network_drive",
-        "index_name": "search-network_drive",
-        "service_type": "network_drive",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "username": {
-                        "label": "Username",
-                        "order": 1,
-                        "type": "str",
-                        "value": "admin"
-                },
-                "password": {
-                        "label": "Password",
-                        "order": 2,
-                        "sensitive": true,
-                        "type": "str",
-                        "value": "abc@123"
-                },
-                "server_ip": {
-                        "label": "SMB IP",
-                        "order": 3,
-                        "type": "str",
-                        "value": "127.0.0.1"
-                },
-                "server_port": {
-                        "display": "numeric",
-                        "label": "SMB port",
-                        "order": 4,
-                        "type": "int",
-                        "value": 445
-                },
-                "drive_path": {
-                        "label": "SMB path",
-                        "order": 5,
-                        "type": "str",
-                        "value": "Folder1"
-                },
-                "use_document_level_security": {
-                    "depends_on": [],
-                    "display": "toggle",
-                    "tooltip": null,
-                    "default_value": false,
-                    "label": "Enable document level security",
-                    "sensitive": false,
-                    "type": "bool",
-                    "required": false,
-                    "options": [],
-                    "validations": [],
-                    "value": false,
-                    "order": 6,
-                    "ui_restrictions": []
-                },
-                "identity_mappings": {
-                    "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",
-                    "depends_on": [{"field": "use_document_level_security", "value": true}],
-                    "order": 7,
+    "name": "network_drive",
+    "index_name": "search-network_drive",
+    "service_type": "network_drive",
+    "sync_cursor": null,
+    "is_native": false,
+    "api_key_id": null,
+    "status": "configured",
+    "language": "en",
+    "last_access_control_sync_error": null,
+    "last_access_control_sync_status": null,
+    "last_sync_status": "canceled",
+    "last_sync_error": null,
+    "last_synced": null,
+    "last_seen": null,
+    "created_at": null,
+    "updated_at": null,
+    "configuration": {
+            "username": {
+                    "label": "Username",
+                    "order": 1,
                     "type": "str",
-                    "required": false,
-                    "ui_restrictions": ["advanced"],
-                    "value": ""
-                }
-        },
-        "filtering": [
-                {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
+                    "value": "admin"
+            },
+            "password": {
+                    "label": "Password",
+                    "order": 2,
+                    "sensitive": true,
+                    "type": "str",
+                    "value": "abc@123"
+            },
+            "server_ip": {
+                    "label": "SMB IP",
+                    "order": 3,
+                    "type": "str",
+                    "value": "127.0.0.1"
+            },
+            "server_port": {
+                    "display": "numeric",
+                    "label": "SMB port",
+                    "order": 4,
+                    "type": "int",
+                    "value": 445
+            },
+            "drive_path": {
+                    "label": "SMB path",
+                    "order": 5,
+                    "type": "str",
+                    "value": "Folder1"
+            },
+            "use_document_level_security": {
+                "depends_on": [],
+                "display": "toggle",
+                "tooltip": null,
+                "default_value": false,
+                "label": "Enable document level security",
+                "sensitive": false,
+                "type": "bool",
+                "required": false,
+                "options": [],
+                "validations": [],
+                "value": false,
+                "order": 6,
+                "ui_restrictions": []
+            },
+            "drive_type":{
+                "display": "dropdown",
+                "label": "Drive type",
+                "depends_on": [{"field": "use_document_level_security", "value": true}],
+                "options": [
+                    {"label": "Windows", "value": "windows"},
+                    {"label": "Linux", "value": "linux"}
+                  ],
+                "order":7,
+                "type": "str",
+                "ui_restrictions": ["advanced"],
+                "value":"windows"
+            },
+            "identity_mappings": {
+                "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",
+                "depends_on": [{"field": "use_document_level_security", "value": true},{"field": "drive_type", "value": "linux"}],
+                "order": 8,
+                "type": "str",
+                "required": false,
+                "ui_restrictions": ["advanced"],
+                "value": ""
+            }
+    },
+    "filtering": [
+            {
+                    "domain": "DEFAULT",
+                    "draft": {
+                        "advanced_snippet": {
+                            "updated_at": "2023-01-31T16:41:27.341Z",
+                            "created_at": "2023-01-31T16:38:49.244Z",
+                            "value": {}
                         },
-                        "active": {
-                            "advanced_snippet": {
+                        "rules": [
+                            {
+                                "field": "_",
                                 "updated_at": "2023-01-31T16:41:27.341Z",
                                 "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
+                                "rule": "regex",
+                                "id": "DEFAULT",
+                                "value": ".*",
+                                "order": 1,
+                                "policy": "include"
                             }
+                        ],
+                        "validation": {
+                            "state": "valid",
+                            "errors": []
                         }
-                }
+                    },
+                    "active": {
+                        "advanced_snippet": {
+                            "updated_at": "2023-01-31T16:41:27.341Z",
+                            "created_at": "2023-01-31T16:38:49.244Z",
+                            "value": {}
+                        },
+                        "rules": [
+                            {
+                                "field": "_",
+                                "updated_at": "2023-01-31T16:41:27.341Z",
+                                "created_at": "2023-01-31T16:38:49.244Z",
+                                "rule": "regex",
+                                "id": "DEFAULT",
+                                "value": ".*",
+                                "order": 1,
+                                "policy": "include"
+                            }
+                        ],
+                        "validation": {
+                            "state": "valid",
+                            "errors": []
+                        }
+                    }
+            }
 
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
-        }
+    ],
+    "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
+    "pipeline": {
+            "extract_binary_content": true,
+            "name": "ent-search-generic-ingestion",
+            "reduce_whitespace": true,
+            "run_ml_inference": true
+    }
 }

--- a/tests/sources/fixtures/network_drive/connector.json
+++ b/tests/sources/fixtures/network_drive/connector.json
@@ -1,148 +1,148 @@
 {
-    "name": "network_drive",
-    "index_name": "search-network_drive",
-    "service_type": "network_drive",
-    "sync_cursor": null,
-    "is_native": false,
-    "api_key_id": null,
-    "status": "configured",
-    "language": "en",
-    "last_access_control_sync_error": null,
-    "last_access_control_sync_status": null,
-    "last_sync_status": "canceled",
-    "last_sync_error": null,
-    "last_synced": null,
-    "last_seen": null,
-    "created_at": null,
-    "updated_at": null,
-    "configuration": {
-            "username": {
-                    "label": "Username",
-                    "order": 1,
+        "name": "network_drive",
+        "index_name": "search-network_drive",
+        "service_type": "network_drive",
+        "sync_cursor": null,
+        "is_native": false,
+        "api_key_id": null,
+        "status": "configured",
+        "language": "en",
+        "last_access_control_sync_error": null,
+        "last_access_control_sync_status": null,
+        "last_sync_status": "canceled",
+        "last_sync_error": null,
+        "last_synced": null,
+        "last_seen": null,
+        "created_at": null,
+        "updated_at": null,
+        "configuration": {
+                "username": {
+                        "label": "Username",
+                        "order": 1,
+                        "type": "str",
+                        "value": "admin"
+                },
+                "password": {
+                        "label": "Password",
+                        "order": 2,
+                        "sensitive": true,
+                        "type": "str",
+                        "value": "abc@123"
+                },
+                "server_ip": {
+                        "label": "SMB IP",
+                        "order": 3,
+                        "type": "str",
+                        "value": "127.0.0.1"
+                },
+                "server_port": {
+                        "display": "numeric",
+                        "label": "SMB port",
+                        "order": 4,
+                        "type": "int",
+                        "value": 445
+                },
+                "drive_path": {
+                        "label": "SMB path",
+                        "order": 5,
+                        "type": "str",
+                        "value": "Folder1"
+                },
+                "use_document_level_security": {
+                    "depends_on": [],
+                    "display": "toggle",
+                    "tooltip": null,
+                    "default_value": false,
+                    "label": "Enable document level security",
+                    "sensitive": false,
+                    "type": "bool",
+                    "required": false,
+                    "options": [],
+                    "validations": [],
+                    "value": false,
+                    "order": 6,
+                    "ui_restrictions": []
+                },
+                "drive_type":{
+                    "display": "dropdown",
+                    "label": "Drive type",
+                    "depends_on": [{"field": "use_document_level_security", "value": true}],
+                    "options": [
+                        {"label": "Windows", "value": "windows"},
+                        {"label": "Linux", "value": "linux"}
+                      ],
+                    "order":7,
                     "type": "str",
-                    "value": "admin"
-            },
-            "password": {
-                    "label": "Password",
-                    "order": 2,
-                    "sensitive": true,
+                    "ui_restrictions": ["advanced"],
+                    "value":"windows"
+                },
+                "identity_mappings": {
+                    "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",
+                    "depends_on": [{"field": "use_document_level_security", "value": true}, {"field": "drive_type", "value": "linux"}],
+                    "order": 8,
                     "type": "str",
-                    "value": "abc@123"
-            },
-            "server_ip": {
-                    "label": "SMB IP",
-                    "order": 3,
-                    "type": "str",
-                    "value": "127.0.0.1"
-            },
-            "server_port": {
-                    "display": "numeric",
-                    "label": "SMB port",
-                    "order": 4,
-                    "type": "int",
-                    "value": 445
-            },
-            "drive_path": {
-                    "label": "SMB path",
-                    "order": 5,
-                    "type": "str",
-                    "value": "Folder1"
-            },
-            "use_document_level_security": {
-                "depends_on": [],
-                "display": "toggle",
-                "tooltip": null,
-                "default_value": false,
-                "label": "Enable document level security",
-                "sensitive": false,
-                "type": "bool",
-                "required": false,
-                "options": [],
-                "validations": [],
-                "value": false,
-                "order": 6,
-                "ui_restrictions": []
-            },
-            "drive_type":{
-                "display": "dropdown",
-                "label": "Drive type",
-                "depends_on": [{"field": "use_document_level_security", "value": true}],
-                "options": [
-                    {"label": "Windows", "value": "windows"},
-                    {"label": "Linux", "value": "linux"}
-                  ],
-                "order":7,
-                "type": "str",
-                "ui_restrictions": ["advanced"],
-                "value":"windows"
-            },
-            "identity_mappings": {
-                "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",
-                "depends_on": [{"field": "use_document_level_security", "value": true},{"field": "drive_type", "value": "linux"}],
-                "order": 8,
-                "type": "str",
-                "required": false,
-                "ui_restrictions": ["advanced"],
-                "value": ""
-            }
-    },
-    "filtering": [
-            {
-                    "domain": "DEFAULT",
-                    "draft": {
-                        "advanced_snippet": {
-                            "updated_at": "2023-01-31T16:41:27.341Z",
-                            "created_at": "2023-01-31T16:38:49.244Z",
-                            "value": {}
-                        },
-                        "rules": [
-                            {
-                                "field": "_",
+                    "required": false,
+                    "ui_restrictions": ["advanced"],
+                    "value": ""
+                }
+        },
+        "filtering": [
+                {
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
                                 "updated_at": "2023-01-31T16:41:27.341Z",
                                 "created_at": "2023-01-31T16:38:49.244Z",
-                                "rule": "regex",
-                                "id": "DEFAULT",
-                                "value": ".*",
-                                "order": 1,
-                                "policy": "include"
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
                             }
-                        ],
-                        "validation": {
-                            "state": "valid",
-                            "errors": []
-                        }
-                    },
-                    "active": {
-                        "advanced_snippet": {
-                            "updated_at": "2023-01-31T16:41:27.341Z",
-                            "created_at": "2023-01-31T16:38:49.244Z",
-                            "value": {}
                         },
-                        "rules": [
-                            {
-                                "field": "_",
+                        "active": {
+                            "advanced_snippet": {
                                 "updated_at": "2023-01-31T16:41:27.341Z",
                                 "created_at": "2023-01-31T16:38:49.244Z",
-                                "rule": "regex",
-                                "id": "DEFAULT",
-                                "value": ".*",
-                                "order": 1,
-                                "policy": "include"
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "field": "_",
+                                    "updated_at": "2023-01-31T16:41:27.341Z",
+                                    "created_at": "2023-01-31T16:38:49.244Z",
+                                    "rule": "regex",
+                                    "id": "DEFAULT",
+                                    "value": ".*",
+                                    "order": 1,
+                                    "policy": "include"
+                                }
+                            ],
+                            "validation": {
+                                "state": "valid",
+                                "errors": []
                             }
-                        ],
-                        "validation": {
-                            "state": "valid",
-                            "errors": []
                         }
-                    }
-            }
+                }
 
-    ],
-    "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-    "pipeline": {
-            "extract_binary_content": true,
-            "name": "ent-search-generic-ingestion",
-            "reduce_whitespace": true,
-            "run_ml_inference": true
-    }
+        ],
+        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
+        "pipeline": {
+                "extract_binary_content": true,
+                "name": "ent-search-generic-ingestion",
+                "reduce_whitespace": true,
+                "run_ml_inference": true
+        }
 }


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1841

This PR addresses following issue:

- Added a configurable field for `Drive type` as discussed in weekly sync with @danajuratoni. This field will be visible when the DLS is enabled and it allows two values `Linux` and `Windows` as the connector supports DLS for Linux and Windows Network Drives only. Further it is kept advanced field as the native connector flows only supports DLS in Windows Network Drive. The support for Linux Network Drive is added via csv path that can only be used via self-managed connector client flow (https://github.com/elastic/connectors/pull/1773 )

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

