### PR TITLE
Make pending_jobs fetch jobs by job types

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -977,7 +977,11 @@ class SyncJobIndex(ESIndex):
         }
         await self.index(job_def)
 
-    async def pending_jobs(self, connector_ids):
+    async def pending_jobs(self, connector_ids, job_types):
+        if not job_types:
+            return
+        if not isinstance(job_types, list):
+            job_types = [str(job_types)]
         query = {
             "bool": {
                 "must": [
@@ -990,6 +994,7 @@ class SyncJobIndex(ESIndex):
                         }
                     },
                     {"terms": {"connector.id": connector_ids}},
+                    {"terms": {"job_type": job_types}},
                 ]
             }
         }

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -187,7 +187,12 @@ class JobExecutionService(BaseService):
                         )
                     else:
                         async for sync_job in self.sync_job_index.pending_jobs(
-                            connector_ids=supported_connector_ids
+                            connector_ids=supported_connector_ids,
+                            job_types=[
+                                JobType.FULL.value,
+                                JobType.INCREMENTAL.value,
+                                JobType.ACCESS_CONTROL.value,
+                            ],
                         ):
                             await self._sync(sync_job)
                 except Exception as e:


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5193

Make the `pending_jobs` method of `SyncJobIndex` to be able to fetch pending jobs by job type. This is to prepare for the PR [Break JobExecutionSerivce to ContentSyncJobExecutionService and AccessControlSyncJobExecutionService](https://github.com/elastic/connectors/pull/1840).

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)