### PR TITLE
Move common functions to test_base.py

### DIFF
--- a/tests/services/test_job_cleanup.py
+++ b/tests/services/test_job_cleanup.py
@@ -4,13 +4,13 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
-import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from connectors.services.job_cleanup import IDLE_JOB_ERROR, JobCleanUpService
 from tests.commons import AsyncIterator
+from tests.services.test_base import create_and_run_service
 
 CONFIG = {
     "elasticsearch": {
@@ -25,10 +25,6 @@ CONFIG = {
     },
     "native_service_types": ["mongodb"],
 }
-
-
-def create_service():
-    return JobCleanUpService(CONFIG)
 
 
 def mock_connector(connector_id="1", index_name="index_name"):
@@ -47,14 +43,6 @@ def mock_sync_job(sync_job_id="1", connector_id="1", index_name="index_name"):
     job.fail = AsyncMock()
     job.reload = AsyncMock()
     return job
-
-
-async def run_service_with_stop_after(service, stop_after):
-    async def _terminate():
-        await asyncio.sleep(stop_after)
-        service.stop()
-
-    await asyncio.gather(service.run(), _terminate())
 
 
 @pytest.mark.asyncio
@@ -87,8 +75,7 @@ async def test_cleanup_jobs(
     idle_jobs.return_value = AsyncIterator([sync_job])
     delete_jobs.return_value = {"deleted": 1, "failures": [], "total": 1}
 
-    service = create_service()
-    await run_service_with_stop_after(service, 0.1)
+    await create_and_run_service(JobCleanUpService, config=CONFIG, stop_after=0.1)
 
     delete_indices.assert_called_with(indices=[to_be_deleted_index_name])
     delete_jobs.assert_called_with(job_ids=[sync_job.id, another_sync_job.id])

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -3,13 +3,11 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import asyncio
 import os
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from connectors.config import load_config
 from connectors.es.client import License
 from connectors.es.index import DocumentNotFoundError
 from connectors.protocol import JobStatus, JobType
@@ -19,6 +17,7 @@ from connectors.services.job_execution import (
     load_max_concurrent_content_syncs,
 )
 from tests.commons import AsyncIterator
+from tests.services.test_base import create_and_run_service
 
 MAX_FIVE_CONCURRENT_SYNCS = 5
 MAX_SIX_CONCURRENT_SYNCS = 6
@@ -26,39 +25,6 @@ MAX_SIX_CONCURRENT_SYNCS = 6
 HERE = os.path.dirname(__file__)
 FIXTURES_DIR = os.path.abspath(os.path.join(HERE, "..", "fixtures"))
 CONFIG_FILE = os.path.join(FIXTURES_DIR, "config.yml")
-
-
-def create_service(config_file):
-    config = load_config(config_file)
-    service = JobExecutionService(config)
-    service.idling = 0.05
-
-    return service
-
-
-async def run_service_with_stop_after(service, stop_after=0):
-    def _stop_running_service_without_cancelling():
-        service.running = False
-
-    async def _terminate():
-        if stop_after == 0:
-            # so we actually want the service
-            # to run current loop without interruption
-            asyncio.get_event_loop().call_soon(_stop_running_service_without_cancelling)
-        else:
-            # but if stop_after is provided we want to
-            # interrupt the service after the timeout
-            await asyncio.sleep(stop_after)
-            service.stop()
-
-        await asyncio.sleep(0)
-
-    await asyncio.gather(service.run(), _terminate())
-
-
-async def create_and_run_service(config_file=CONFIG_FILE, stop_after=0):
-    service = create_service(config_file)
-    await run_service_with_stop_after(service, stop_after)
 
 
 @pytest.fixture(autouse=True)
@@ -161,7 +127,7 @@ async def test_no_connector(connector_index_mock, concurrent_tasks_mocks, set_en
     content_syncs_tasks_mock, access_control_syncs_tasks_mock = concurrent_tasks_mocks
 
     connector_index_mock.supported_connectors.return_value = AsyncIterator([])
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -179,7 +145,7 @@ async def test_no_pending_jobs(
     connector = mock_connector()
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([])
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -205,7 +171,7 @@ async def test_job_execution_content_sync_job_and_access_control_sync_job(
         [content_sync_job, access_control_sync_job]
     )
 
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
     access_control_syncs_tasks_mock.put.assert_awaited_once_with(
@@ -230,7 +196,7 @@ async def test_job_execution_content_sync_job(
     content_sync_job = mock_sync_job()
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([content_sync_job])
 
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_awaited_once_with(sync_job_runner_mock.execute)
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -255,7 +221,7 @@ async def test_job_execution_access_control_sync_job(
         [access_control_sync_job]
     )
 
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     access_control_syncs_tasks_mock.put.assert_awaited_once_with(
         sync_job_runner_mock.execute
@@ -276,7 +242,7 @@ async def test_job_execution_with_unsupported_source(
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     sync_job = mock_sync_job(service_type="mysql")
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -300,7 +266,7 @@ async def test_job_execution_with_connector_not_found(
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator(
         [content_sync_job, access_control_sync_job]
     )
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -321,7 +287,7 @@ async def test_job_execution_with_premium_connector(
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
     sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_awaited_once_with(
@@ -352,7 +318,7 @@ async def test_job_execution_with_premium_connector_with_insufficient_license(
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator(
         [content_sync_job, access_control_sync_job]
     )
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     # Access control sync job should not be executed (license insufficient)
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -376,7 +342,7 @@ async def test_content_job_execution_with_connector_still_syncing(
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
     sync_job = mock_sync_job()
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -400,7 +366,7 @@ async def test_access_control_job_execution_with_connector_still_syncing(
     connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
     sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -428,7 +394,7 @@ async def test_access_control_job_execution_with_insufficient_license(
 
     sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -456,7 +422,7 @@ async def test_access_control_job_execution_with_dls_feature_flag_disabled(
     sync_job = mock_sync_job(job_type=JobType.ACCESS_CONTROL)
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
 
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()
@@ -482,7 +448,7 @@ async def test_job_execution_with_unknown_job_type(
     sync_job = mock_sync_job(job_type=JobType.UNSET)
     sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
 
-    await create_and_run_service()
+    await create_and_run_service(JobExecutionService)
 
     content_syncs_tasks_mock.put.assert_not_awaited()
     access_control_syncs_tasks_mock.put.assert_not_awaited()

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -3,15 +3,12 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-import asyncio
-import os
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from elasticsearch import ConflictError
 
-from connectors.config import load_config
 from connectors.es.client import License
 from connectors.es.index import DocumentNotFoundError
 from connectors.protocol import (
@@ -25,45 +22,9 @@ from connectors.protocol import (
 from connectors.services.job_scheduling import JobSchedulingService
 from connectors.source import DataSourceConfiguration
 from tests.commons import AsyncIterator
+from tests.services.test_base import create_and_run_service
 
-HERE = os.path.dirname(__file__)
-FIXTURES_DIR = os.path.abspath(os.path.join(HERE, "..", "fixtures"))
-CONFIG_FILE = os.path.join(FIXTURES_DIR, "config.yml")
 JOB_TYPES = [JobType.FULL, JobType.ACCESS_CONTROL]
-IDLING = 0.05
-
-
-def create_service(config_file):
-    config = load_config(config_file)
-    service = JobSchedulingService(config)
-    service.idling = IDLING
-
-    return service
-
-
-async def run_service_with_stop_after(service, stop_after=0):
-    def _stop_running_service_without_cancelling():
-        service.running = False
-
-    async def _terminate():
-        if stop_after == 0:
-            # so we actually want the service
-            # to run current loop without interruption
-            asyncio.get_event_loop().call_soon(_stop_running_service_without_cancelling)
-        else:
-            # but if stop_after is provided we want to
-            # interrupt the service after the timeout
-            await asyncio.sleep(stop_after)
-            service.stop()
-
-        await asyncio.sleep(0)
-
-    await asyncio.gather(service.run(), _terminate())
-
-
-async def create_and_run_service(config_file=CONFIG_FILE, stop_after=0):
-    service = create_service(config_file)
-    await run_service_with_stop_after(service, stop_after)
 
 
 @pytest.fixture(autouse=True)
@@ -140,7 +101,7 @@ def mock_connector(
 @pytest.mark.asyncio
 async def test_no_connector(connector_index_mock, sync_job_index_mock, set_env):
     connector_index_mock.supported_connectors.return_value = AsyncIterator([])
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     sync_job_index_mock.create.assert_not_awaited()
 
@@ -153,7 +114,7 @@ async def test_connector_ready_to_sync(
 ):
     connector = mock_connector(next_sync=datetime.utcnow())
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
@@ -191,7 +152,7 @@ async def test_connector_ready_to_sync_with_race_condition(
         body={},
     )
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
@@ -205,7 +166,7 @@ async def test_connector_sync_disabled(
 ):
     connector = mock_connector(next_sync=None)
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
@@ -223,7 +184,7 @@ async def test_connector_scheduled_access_control_sync_with_dls_feature_disabled
         next_sync=datetime.utcnow(), document_level_security_enabled=False
     )
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
@@ -250,7 +211,7 @@ async def test_connector_scheduled_access_control_sync_with_insufficient_license
         return_value=(False, License.BASIC)
     )
 
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
@@ -290,7 +251,7 @@ async def test_connector_scheduled_incremental_sync(
         document_level_security_enabled=False,
     )
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
@@ -324,7 +285,7 @@ async def test_connector_not_configured(
 ):
     connector = mock_connector(status=connector_status)
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_awaited()
@@ -350,7 +311,7 @@ async def test_connector_prepare_failed(
 ):
     connector = mock_connector(prepare_exception=prepare_exception())
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service()
+    await create_and_run_service(JobSchedulingService)
 
     connector.prepare.assert_awaited()
     connector.heartbeat.assert_not_awaited()
@@ -373,7 +334,7 @@ async def test_run_when_sync_fails_then_continues_service_execution(
     # 0.15 is a bit arbitrary here
     # It should be enough to make the loop execute a couple of times
     # but is there a better way to tell service to execute loop a couple of times?
-    await create_and_run_service(stop_after=0.15)
+    await create_and_run_service(JobSchedulingService, stop_after=0.15)
 
     # assert that service tried to call connector heartbeat for all connectors
     connector.heartbeat.assert_awaited()


### PR DESCRIPTION
There are some repeated codes in `tests/services/*`. This PR moves those functions to `tests/services/test_base.py`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)