### PR TITLE
Move _override_es_config to BaseService

### DIFF
--- a/connectors/services/base.py
+++ b/connectors/services/base.py
@@ -142,6 +142,21 @@ class BaseService(metaclass=_Registry):
 
         return connectors
 
+    def _override_es_config(self, connector):
+        es_config = deepcopy(self.es_config)
+        if connector.id not in self.connectors:
+            return es_config
+
+        api_key = self.connectors[connector.id].get("api_key", None)
+        if not api_key:
+            return es_config
+
+        es_config.pop("username", None)
+        es_config.pop("password", None)
+        es_config["api_key"] = api_key
+
+        return es_config
+
 
 class MultiService:
     """Wrapper class to run multiple services against the same config."""

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -3,7 +3,6 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from copy import deepcopy
 
 from connectors.es.client import License
 from connectors.es.index import DocumentNotFoundError
@@ -217,18 +216,3 @@ class JobExecutionService(BaseService):
                 self.sync_job_index.stop_waiting()
                 await self.sync_job_index.close()
         return 0
-
-    def _override_es_config(self, connector):
-        es_config = deepcopy(self.es_config)
-        if connector.id not in self.connectors:
-            return es_config
-
-        api_key = self.connectors[connector.id].get("api_key", None)
-        if not api_key:
-            return es_config
-
-        es_config.pop("username", None)
-        es_config.pop("password", None)
-        es_config["api_key"] = api_key
-
-        return es_config

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -501,31 +501,3 @@ def test_load_max_concurrent_access_control_syncs_from_config():
 )
 def test_load_max_concurrent_access_control_syncs_fallback_on_default():
     assert load_max_concurrent_access_control_syncs({}) == MAX_SIX_CONCURRENT_SYNCS
-
-
-def test_override_es_config():
-    connector_api_key = "connector_api_key"
-    config = {
-        "elasticsearch": {
-            "username": "username",
-            "password": "password",
-            "api_key": "global_api_key",
-        },
-        "service": {"idling": 30},
-        "sources": [],
-        "connectors": [
-            {
-                "connector_id": "foo",
-                "service_type": "bar",
-                "api_key": connector_api_key,
-            }
-        ],
-    }
-
-    service = JobExecutionService(config)
-    connector = Mock()
-    connector.id = "foo"
-    override_config = service._override_es_config(connector)
-    assert "username" not in override_config
-    assert "password" not in override_config
-    assert override_config["api_key"] == connector_api_key


### PR DESCRIPTION
Move the `_override_es_config` method to `BaseService`, because this can be used by other services besides `JobExecutionSerivce`, and `JobExecutionService` will be broken into two service classes by PR https://github.com/elastic/connectors/pull/1840

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)