### PR TITLE
[8.11] Improve PostgreSQL query for identifying primary keys (#1823)

### DIFF
--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -53,7 +53,11 @@ class PostgreSQLQueries(Queries):
 
     def table_primary_key(self, **kwargs):
         """Query to get the primary key"""
-        return f"SELECT c.column_name FROM information_schema.table_constraints tc JOIN information_schema.constraint_column_usage AS ccu USING (constraint_schema, constraint_name) JOIN information_schema.columns AS c ON c.table_schema = tc.constraint_schema AND tc.table_name = c.table_name AND ccu.column_name = c.column_name WHERE constraint_type = 'PRIMARY KEY' and tc.table_name = '{kwargs['table']}' and tc.constraint_schema = '{kwargs['schema']}'"
+        return (
+            f"SELECT a.attname AS c FROM pg_index i JOIN pg_attribute a ON a.attrelid = i.indrelid "
+            f"AND a.attnum = ANY(i.indkey) WHERE i.indrelid = '{kwargs['schema']}.{kwargs['table']}'::regclass "
+            f"AND i.indisprimary"
+        )
 
     def table_data(self, **kwargs):
         """Query to get the table data"""

--- a/tests/sources/fixtures/postgresql/connector.json
+++ b/tests/sources/fixtures/postgresql/connector.json
@@ -33,14 +33,14 @@
                         "label": "Username",
                         "order": 3,
                         "type": "str",
-                        "value": "admin"
+                        "value": "readonly"
                 },
                 "password": {
                         "label": "Password",
                         "order": 4,
                         "sensitive": true,
                         "type": "str",
-                        "value": "Password_123"
+                        "value": "foobar123"
                 },
                 "database": {
                         "label": "Database",


### PR DESCRIPTION
Manually backporting https://github.com/elastic/connectors/pull/1823 to 8.11 since I missed adding the appropriate labels in the original PR.

```
git cherry-pick 8bbc3f11a6c96bae226e9351c29162899d1d3434
```

cc @artem-shelkovnikov 