### PR TITLE
Update user agent string for the ES client

### DIFF
--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -87,7 +87,7 @@ class ESClient:
         self.initial_backoff_duration = config.get("initial_backoff_duration", 5)
         self.backoff_multiplier = config.get("backoff_multiplier", 2)
         options["headers"] = config.get("headers", {})
-        options["headers"]["user-agent"] = f"elastic-connectors-python-{__version__}"
+        options["headers"]["user-agent"] = f"elastic-connectors-{__version__}"
         self.client = AsyncElasticsearch(**options)
         self._keep_waiting = True
 


### PR DESCRIPTION
Following up on a renaming of the repo from `connectors-python` to `connectors`. 

In this change I rename user agent string used by ES client.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
