### PR TITLE
Fix failing SPO test that checks incremental sync

### DIFF
--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2377,11 +2377,11 @@ class TestSharepointOnlineDataSource:
         assert len(docs) == sum(
             [
                 len(self.site_collections),
-                sum([len(i) for i in self.drive_items_delta]),
+                sum(len(i) for i in self.drive_items_delta),
                 len(self.site_drives),
                 len(self.site_pages),
                 len(self.site_lists),
-                len(self.site_list_items) - 1,  # one is too old
+                len(self.site_list_items) - 2,  # one is too old, one is always ignored
                 len(self.site_list_item_attachments),
             ]
         )


### PR DESCRIPTION
Fixes failing CI/main.

For some reason, [test](https://buildkite.com/elastic/connectors/builds/10359#018b94cd-e3fb-4cb0-be79-ac3ae5ddc88a) was expecting more list items returned than there were returned:

```
FAILED tests/sources/test_sharepoint_online.py::TestSharepointOnlineDataSource::test_get_docs_incrementally - AssertionError: assert 11 == 12
--
  | +  where 11 = len([{'_id': 'https://test.sharepoint.com', 'lastModifiedDateTime': '2023-11-02T10:53:17Z', 'object_type': 'site_collection', 'siteCollection': {'hostname': 'test.sharepoint.com'}, ...}, {'_id': '1', 'id': '1', 'lastModifiedDateTime': '2023-11-02T10:53:17Z', 'name': 'site-1', ...}, {'_id': '2', 'id': '2', 'lastModifiedDateTime': '2023-11-02T10:53:17Z', 'object_type': 'site_drive'}, {'_id': '6', '_timestamp': None, 'deleted': {'state': 'deleted'}, 'id': '6', ...}, {'_id': '3', '_timestamp': '2023-10-04T10:52:55Z', 'id': '3', 'lastModifiedDateTime': '2023-10-04T10:52:55Z', ...}, {'_id': '4', '_timestamp': '2023-11-02T10:52:55Z', 'id': '4', 'lastModifiedDateTime': '2023-11-02T10:52:55Z', ...}, ...])
  | +  and   12 = sum([1, 4, 1, 1, 1, 2, ...])
```

I have no idea why it worked before, but it should have failed from the start as assertion was including item that should have never been ingested.

When checking the test, the source is supposed to return [3 list items](https://github.com/elastic/connectors/blob/main/tests/sources/test_sharepoint_online.py#L1929):

```
    @property
    def site_list_items(self):
        return [
            {
                "id": "6",
                "contentType": {"name": "Item"},
                "fields": {"Attachments": ""},
                "lastModifiedDateTime": self.month_ago,
            },
            {
                "id": "7",
                "contentType": {"name": "Web Template Extensions"},
                "fields": {},
                "lastModifiedDateTime": self.day_ago,
            },  # Will be ignored!!!
            {
                "id": "8",
                "contentType": {"name": "Something without attachments"},
                "fields": {},
                "lastModifiedDateTime": self.two_months_ago,
            },
        ]
```

List item with id `7` is always ignored - this is "Web Template Extensions" list that has no useful info for us and is just a list containing some internal SPO stuff.

So there are 2 items left: with id=6 and id=8. Test setup tries to sync with a [timestamp cursor](https://github.com/elastic/connectors/blob/main/tests/sources/test_sharepoint_online.py#L2353) which is set to be a month ago: `sync_cursor = {"site_drives": {}, "cursor_timestamp": self.month_ago}`.

So because of that, item with id=8 should always be ignored, as it has `"lastModifiedDateTime": self.two_months_ago`.

Therefore I'm fixing what I'm fixing in the calculation (see the PR):

```python
        assert len(docs) == sum(
            [
                len(self.site_collections),
                sum(len(i) for i in self.drive_items_delta),
                len(self.site_drives),
                len(self.site_pages),
                len(self.site_lists),
                len(self.site_list_items) - 2,  # one is too old, one is always ignored <<<<<<<<<<<< THIS LINE WAS 1, not 2
                len(self.site_list_item_attachments),
            ]
        )
```


However, I'm not sure how it ever worked, any thoughts?
