### PR TITLE
Make full sync timestamp optimizations configurable

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -188,6 +188,18 @@
 #service.enable_full_sync_download_ts_optimization: true
 #
 #
+##  Service settings that must have different settings for certain sources.
+##    Each object in this collection must specify a `source` (e.g. "sharepoint_online") as well as the configurations
+##    to override.
+##    The supported configurations for overriding are:
+##      - enable_full_sync_meta_ts_optimization
+##      - enable_full_sync_download_ts_optimization
+##    Example:
+##    service.source_overrides:
+##      - source: sharepoint_online
+##        enable_full_sync_meta_ts_optimization: false
+##        enable_full_sync_download_ts_optimization: false
+#service.source_overrides: []
 ## ------------------------------- Extraction Service ----------------------------------
 #
 ##  Local extraction service-related configurations.

--- a/config.yml
+++ b/config.yml
@@ -171,6 +171,23 @@
 #service.log_level: INFO
 #
 #
+##  Whether Full Syncs should skip indexing records where their timestamp has not been updated since the last full sync.
+##    Enabling this behavior may reduce execution time of subsequent Full Syncs, but also prevents all documents from
+##    being synced on each Full Sync.
+##    This can be frustrating if upgrading connector versions, or making changes to ingest pipelines, as your index's
+##    content may only be partially updated.
+#service.enable_full_sync_meta_ts_optimization: false
+#
+#
+##  Whether Full Syncs should skip downloading binary content for records where their timestamp has not been updated
+##    since the last full sync.
+##    Disabling this behavior may increase execution time of subsequent Full Syncs, but also ensures that the full
+##    content of files will always be re-processed on Full Syncs.
+##    By default, only metadata will be consistently re-synced each Full Sync
+##    (see service.enable_full_sync_meta_ts_optimization)
+#service.enable_full_sync_download_ts_optimization: true
+#
+#
 ## ------------------------------- Extraction Service ----------------------------------
 #
 ##  Local extraction service-related configurations.

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -81,6 +81,7 @@ def _default_config():
             "log_level": "INFO",
             "enable_full_sync_meta_ts_optimization": False,
             "enable_full_sync_download_ts_optimization": True,
+            "source_overrides": [],
         },
         "sources": {
             "azure_blob_storage": "connectors.sources.azure_blob_storage:AzureBlobStorageDataSource",

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -79,6 +79,8 @@ def _default_config():
             "max_concurrent_access_control_syncs": 1,
             "job_cleanup_interval": 300,
             "log_level": "INFO",
+            "enable_full_sync_meta_ts_optimization": False,
+            "enable_full_sync_download_ts_optimization": True,
         },
         "sources": {
             "azure_blob_storage": "connectors.sources.azure_blob_storage:AzureBlobStorageDataSource",

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -78,6 +78,7 @@ class JobExecutionService(BaseService):
             sync_job=sync_job,
             connector=connector,
             es_config=self._override_es_config(connector),
+            service_config=self.service_config,
         )
         await self.content_syncs.put(sync_job_runner.execute)
 
@@ -93,6 +94,7 @@ class JobExecutionService(BaseService):
             sync_job=sync_job,
             connector=connector,
             es_config=self._override_es_config(connector),
+            service_config=self.service_config,
         )
         await self.access_control_syncs.put(sync_job_runner.execute)
 

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -134,9 +134,7 @@ class SyncJobRunner:
             bulk_options = self.bulk_options.copy()
             self.data_provider.tweak_bulk_options(bulk_options)
 
-            self.elastic_server = SyncOrchestrator(
-                self.es_config, self.service_config, self.sync_job.logger
-            )
+            self.elastic_server = SyncOrchestrator(self.es_config, self.sync_job.logger)
 
             if job_type in [JobType.INCREMENTAL, JobType.FULL]:
                 self.sync_job.log_info(f"Executing {job_type.value} sync")

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -481,14 +481,14 @@ async def setup_extractor(
             total_downloads(0),
         ),
         (
-            # doc 1 is present, data source also has doc 1 with the same timestamp -> nothing happens
+            # doc 1 is present, data source also has doc 1 with the same timestamp -> doc 1 is updated
             [DOC_ONE],
             [(DOC_ONE, None, "index")],
             NO_FILTERING,
             SYNC_RULES_ENABLED,
             CONTENT_EXTRACTION_ENABLED,
-            [end_docs_operation()],
-            updated(0),
+            [index_operation(DOC_ONE), end_docs_operation()],
+            updated(1),
             created(0),
             deleted(0),
             total_downloads(0),
@@ -584,14 +584,14 @@ async def setup_extractor(
             total_downloads(1),
         ),
         (
-            # doc 1 present, data source has doc 1 -> no lazy download if timestamps are the same for the docs
+            # doc 1 present, data source has doc 1 -> no lazy download (only meta update) if timestamps are the same for the docs
             [DOC_ONE],
             [(DOC_ONE, lazy_download_fake(DOC_ONE), "index")],
             NO_FILTERING,
             SYNC_RULES_ENABLED,
             CONTENT_EXTRACTION_ENABLED,
-            [end_docs_operation()],
-            updated(0),
+            [index_operation(DOC_ONE), end_docs_operation()],
+            updated(1),
             created(0),
             deleted(0),
             total_downloads(0),

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -86,12 +86,14 @@ def create_runner(
     sync_job = mock_sync_job(job_type=job_type, index_name=index_name)
     connector = mock_connector()
     es_config = {}
+    service_config = {}
 
     return SyncJobRunner(
         source_klass=source_klass,
         sync_job=sync_job,
         connector=connector,
         es_config=es_config,
+        service_config=service_config,
     )
 
 

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -746,3 +746,21 @@ async def test_sync_job_runner_sets_features_for_data_provider():
     await sync_job_runner.execute()
 
     assert sync_job_runner.data_provider.set_features.called
+
+
+@pytest.mark.parametrize(
+    "service_type, foo, baz",
+    [("skip", "bar", "qux"), ("dip", "qux", "qux")],
+)
+@pytest.mark.asyncio
+async def test_lookup_service_config(service_type, foo, baz):
+    sync_job_runner = create_runner()
+    sync_job_runner.service_config = {
+        "foo": "bar",
+        "baz": "qux",
+        "source_overrides": [{"source": "dip", "foo": "qux"}],
+    }
+    sync_job_runner.connector.service_type = service_type
+
+    assert sync_job_runner._lookup_service_config("foo", None) == foo
+    assert sync_job_runner._lookup_service_config("baz", None) == baz


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/1372

One way we could make full syncs be able to fully reset data. This implementation uses two new configs in the YAML file to separately configure
- if metadata should be updated on Full syncs even when the timestamp shows it hasn't changed (`service.enable_full_sync_meta_ts_optimization`)
- if binary downloads should be done on Full syncs even when the timestamp shows it hasn't been changed (`service.enable_full_sync_download_ts_optimization`)


It also provides a new configuration section for source-specific configuration overrides (`service.source_overrides`). The structure for this is an array of objects, like:
```
service:
  source_overrides:
    - source: source_1
       config_key_1: overwritten_val_1
       config_key_2: overwritten_val_2
     - source: source_2
       config_key_1: overwritten_val_3
       config_key_2: overwritten_val_4
```

The only supported keys for config overwriting right now are the new ts_optimization fields

This change is not, strictly speaking, backwards compatible, and may adversely impact performance of full syncs. However, it also makes upgrading and iterating on ingest pipeline changes significantly easier, and provides an escape hatch for opting back in to the backwards-compatible behavior.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## Related pull requests
- [ ] cloud allow-list PR TODO
- [ ] ent-search config for native connectors TODO

## Release Note

Introduces two new configs, `service.enable_full_sync_meta_ts_optimization` (default is `false`) and `service.enable_full_sync_download_ts_optimization` (default is `true`). This change causes full syncs to always send all metadata documents to Elasticsearch, even if no obvious data change was detected. This is helpful for ensure that code changes are applied to all documents with a full sync, whether that code change comes from a Connectors upgrade or a change to your ingest pipelines. Also provides a config `service.source_overrides` where you can configure specific settings depending on the connector source type.
