### PR TITLE
[SPO] Adding OData__UIVersionString document version field

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -940,6 +940,9 @@ class SharepointOnlineClient:
                         "Modified": site_page.get("Modified"),
                         "EditorId": site_page.get("EditorId"),
                         "odata.id": site_page.get("odata.id"),
+                        "OData__UIVersionString": site_page.get(
+                            "OData__UIVersionString"
+                        ),
                     }
         except NotFound:
             # I'm not sure if site can have no pages, but given how weird API is I put this here


### PR DESCRIPTION
This PR adds the `OData__UIVersionString` to the documents. This field is useful to filter out drafts using sync rules.

When this option enabled:

![image](https://github.com/elastic/connectors/assets/8575569/5e253ccf-4478-47b9-ac38-7e8ed61f59ca)

Files can have versions. 

0.1 means unpublished draft
After published becomes 1.0
Then I save a new draft and becomes 1.1

![image](https://github.com/elastic/connectors/assets/8575569/0a8ff7fd-10c2-49b6-9d0b-a236b9a8b18b)

Sync rule to exclude drafts (everything that doesn't end with 0): `^(?!.*\.0$).*$`

## Checklists

#### Pre-Review Checklist
- [ ] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [ ] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference