### PR TITLE
Extend a non-blocking Semaphore implementation

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,7 @@ from connectors.utils import (
     ConcurrentTasks,
     InvalidIndexNameError,
     MemQueue,
+    NonBlockingBoundedSemaphore,
     RetryStrategy,
     UnknownRetryStrategyError,
     base64url_to_base64,
@@ -238,6 +239,19 @@ def test_decode_base64_value():
     """This test verify decode_base64_value and decodes base64 encoded data"""
     expected_result = decode_base64_value("ZHVtbXk=".encode("utf-8"))
     assert expected_result == b"dummy"
+
+
+def test_try_acquire():
+    bound_value = 5
+    sem = NonBlockingBoundedSemaphore(bound_value)
+
+    for _ in range(bound_value):
+        assert sem.try_acquire()
+
+    assert not sem.try_acquire()
+
+    sem.release()
+    assert sem.try_acquire()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5193

### What's the change:

This PR introduces a new class `NonBlockingBoundedSemaphore`, which extends `asyncio.BoundedSemaphore`. The new class has a `try_acquire` method, which allows users to acquire the semaphore in non-blocking way, ie. the method will return `False` immediately if it can't acquire a semaphore.

### Why the change:

The new method will be used by `ConcurrentTasks`, in PR #1479, where we introduced a non-blocking `try_put` method, which allows users to put task without being blocked. It's a bit tricky to implement it with the existing `asyncio.BoundedSemaphore` class and it doesn't work as expected under certain edge cases (see discussion in https://github.com/elastic/connectors/pull/1479#discussion_r1383112200). And we found that the most easy and clean way to achieve this was to extend the `asyncio.BoundedSemaphore` class.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)