### PR TITLE
Add all_sync_jobs method

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -1035,3 +1035,7 @@ class SyncJobIndex(ESIndex):
     async def delete_jobs(self, job_ids):
         query = {"terms": {"_id": job_ids}}
         return await self.client.delete_by_query(index=self.index_name, query=query)
+
+    async def all_sync_jobs(self):
+        async for sync_job in self.get_all_docs():
+            yield sync_job

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -2059,6 +2059,21 @@ async def test_idle_jobs(get_all_docs, set_env):
     assert jobs[0] == job
 
 
+@pytest.mark.asyncio
+@patch("connectors.protocol.SyncJobIndex.get_all_docs")
+async def test_all_sync_jobs(get_all_docs, set_env):
+    job = Mock()
+    get_all_docs.return_value = AsyncIterator([job])
+    config = load_config(CONFIG)
+
+    sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    jobs = [job async for job in sync_job_index.all_sync_jobs()]
+
+    get_all_docs.assert_called_once()
+    assert len(jobs) == 1
+    assert jobs[0] == job
+
+
 @pytest.mark.parametrize(
     "filtering, should_advanced_rules_be_present",
     [


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6169

This PR adds a method `all_sync_jobs` method to `SyncJobIndex`, which will be used to build telemetry data in subsequent PRs.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)