### PR TITLE
Remove timestamp optimization for full syncs

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -420,22 +420,8 @@ class Extractor:
                     continue
 
                 if doc_id in existing_ids:
-                    # pop out of existing_ids
-                    ts = existing_ids.pop(doc_id)
-
-                    # If the doc has a timestamp, we can use it to see if it has
-                    # been modified. This reduces the bulk size a *lot*
-                    #
-                    # Some backends do not know how to do this, so it's optional.
-                    # For these, we update the docs in any case.
-                    if TIMESTAMP_FIELD in doc and ts == doc[TIMESTAMP_FIELD]:
-                        # cancel the download
-                        if (
-                            self.content_extraction_enabled
-                            and lazy_download is not None
-                        ):
-                            await lazy_download(doit=False)
-                        continue
+                    # pop out of existing_ids, so they do not get deleted
+                    existing_ids.pop(doc_id)
 
                     self.total_docs_updated += 1
                 else:

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -481,14 +481,18 @@ async def setup_extractor(
             total_downloads(0),
         ),
         (
-            # doc 1 is present, data source also has doc 1 with the same timestamp -> nothing happens
+            # doc 1 is present, data source also has doc 1 with the same timestamp -> doc one is updated
             [DOC_ONE],
             [(DOC_ONE, None, "index")],
             NO_FILTERING,
             SYNC_RULES_ENABLED,
             CONTENT_EXTRACTION_ENABLED,
-            [end_docs_operation()],
-            updated(0),
+            [
+                # update happens through overwriting
+                index_operation(DOC_ONE),
+                end_docs_operation(),
+            ],
+            updated(1),
             created(0),
             deleted(0),
             total_downloads(0),
@@ -584,17 +588,17 @@ async def setup_extractor(
             total_downloads(1),
         ),
         (
-            # doc 1 present, data source has doc 1 -> no lazy download if timestamps are the same for the docs
+            # doc 1 present, data source has doc 1 -> lazy download occurs
             [DOC_ONE],
             [(DOC_ONE, lazy_download_fake(DOC_ONE), "index")],
             NO_FILTERING,
             SYNC_RULES_ENABLED,
             CONTENT_EXTRACTION_ENABLED,
-            [end_docs_operation()],
-            updated(0),
+            [index_operation(DOC_ONE), end_docs_operation()],
+            updated(1),
             created(0),
             deleted(0),
-            total_downloads(0),
+            total_downloads(1),
         ),
         (
             # doc 1 present, data source has doc 1 with different timestamp


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1372

When connectors were first being built, there was an assumption that a distinction between "full" and "incremental" syncs would not be needed. We hoped to only have one sync type, and to have it be capable of doing full table scans on its first run, but only partial scans thereafter.

In reality, this has not worked, and we've begun to introduce new sync types, specifically the Incremental sync. At the same time, we've received more and more reports that this optimization is actually a hiderance to customers working to move into production. While it was intended to save time, it in fact takes more, as every code, pipeline, or configuration change requires data to be deleted, modified, or a new index to be started from scratch. This friction was not intended or anticipated, and is considered to be a bug.

In the unlikely event that a customer is relying on this optimization, the diff is quite simple and can be added back from a fork as a stop-gap until we are able to deliver Incremental Syncs to all our connectors.

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

* Earlier approach to solve this issue, that was closed after team discussion on the overall value of this feature and the complexity/value involved in making the behavior configurable: https://github.com/elastic/connectors/pull/1883

## Release Note

Addressed a bug where full syncs would not fully-resync data as expected, which caused friction when upgrading, making customized code changes, or modifying ingest pipelines. The fix may result in increased full sync times, as more documents may now be downloaded and indexed.

(Note to the docs team - please link this PR in the release note, so that users can easily revert it on a fork in the event that the performance impacts for them outweigh the value of fixing the bug).
