### PR TITLE
Bump Dockerfile base image to python:3.11.6-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3.10
+FROM python:3.11.6-slim
 COPY . /app
 WORKDIR /app
-RUN make clean install
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y make build-essential && \
+    rm -rf /var/lib/apt/lists/*
+RUN make clean install PYTHON=python3.11

--- a/Dockerfile.ftest
+++ b/Dockerfile.ftest
@@ -1,5 +1,9 @@
-FROM python:3.10
+FROM python:3.11.6-slim
 COPY . /connectors
 WORKDIR /connectors
-RUN make clean install
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y make build-essential && \
+    rm -rf /var/lib/apt/lists/*
+RUN make clean install PYTHON=python3.11
 RUN bin/pip install -r requirements/ftest.txt


### PR DESCRIPTION
Bump Dockerfile to use `python:3.11.6-slim` for its base image to reduce the number of vulnerable libraries/packages installed with the image.

I've left 3.10 as the minimum version for the project.

Note: This relates to an internal developer productivity issue; I will link from there to this issue.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
