### PR TITLE
Make oracle configs that require local FS access 'advanced'

### DIFF
--- a/connectors/sources/oracle.py
+++ b/connectors/sources/oracle.py
@@ -344,6 +344,7 @@ class OracleDataSource(BaseDataSource):
                 "order": 9,
                 "type": "str",
                 "value": DEFAULT_PROTOCOL,
+                "ui_restrictions": ["advanced"],
             },
             "oracle_home": {
                 "default_value": DEFAULT_ORACLE_HOME,
@@ -351,6 +352,7 @@ class OracleDataSource(BaseDataSource):
                 "order": 10,
                 "required": False,
                 "type": "str",
+                "ui_restrictions": ["advanced"],
             },
             "wallet_configuration_path": {
                 "default_value": "",
@@ -358,6 +360,7 @@ class OracleDataSource(BaseDataSource):
                 "order": 11,
                 "required": False,
                 "type": "str",
+                "ui_restrictions": ["advanced"],
             },
         }
 

--- a/tests/sources/fixtures/oracle/connector.json
+++ b/tests/sources/fixtures/oracle/connector.json
@@ -85,7 +85,8 @@
                         ],
                         "order": 9,
                         "type": "str",
-                        "value": "TCP"
+                        "value": "TCP",
+                        "ui_restrictions": ["advanced"]
                 },
                 "oracle_home": {
                         "default_value": "",
@@ -93,7 +94,8 @@
                         "order": 10,
                         "required": false,
                         "type": "str",
-                        "value": ""
+                        "value": "",
+                        "ui_restrictions": ["advanced"]
                 },
                 "wallet_configuration_path": {
                         "default_value": "",
@@ -101,7 +103,8 @@
                         "order": 11,
                         "required": false,
                         "type": "str",
-                        "value": ""
+                        "value": "",
+                        "ui_restrictions": ["advanced"]
                 }
         },
         "filtering": [


### PR DESCRIPTION
## part of https://github.com/elastic/enterprise-search-team/issues/6308

Adds the `advanced` UI restriction to `oracle_protocol`, `oracle_home`, and `wallet_configuration_path`. This will prevent Native Connector users from stumbling onto these configs, where they cannot change them or influence the contents of the host for native connectors.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference


## Related Pull Requests

* https://github.com/elastic/ent-search/pull/7801
* TODO

## Release Note

Hides some configurations for the Oracle connector, namely the `Oracle connection protocol`, the `Path to Oracle Home`, and the `Path to SSL Wallet configuration files` as these were not applicable for Native Connectors on Elastic Cloud. These are still configurable directly through the connector's record in `.elastic-connectors` for customers who wish to modify these for their Connector Clients.
