### PR TITLE
[8.11] [GitHub] Add missing re-raise on ClientResponseError (#1806)

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -641,6 +641,8 @@ class GitHubClient:
                 raise UnauthorizedException(
                     "Your Github token is either expired or revoked. Please check again."
                 ) from exception
+            else:
+                raise
         except Exception:
             raise
 

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -607,6 +607,25 @@ async def test_post_with_unauthorized():
 
 
 @pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+async def test_post_with_error_not_found():
+    async with create_github_source() as source:
+        source.github_client._get_session.post = Mock(
+            side_effect=ClientResponseError(
+                status=404,
+                request_info=aiohttp.RequestInfo(
+                    real_url="", method=None, headers=None, url=""
+                ),
+                history=None,
+            )
+        )
+        with pytest.raises(Exception):
+            await source.github_client.post(
+                {"variable": {"owner": "demo_user"}, "query": "QUERY"}
+            )
+
+
+@pytest.mark.asyncio
 async def test_paginated_api_call():
     expected_response = MOCK_RESPONSE_REPO
     async with create_github_source() as source:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[GitHub] Add missing re-raise on ClientResponseError (#1806)](https://github.com/elastic/connectors/pull/1806)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)