### PR TITLE
Ensure that Exceptions with empty error messages at least state the exception

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -300,9 +300,17 @@ class SyncJob(ESDocument):
             JobStatus.COMPLETED, None, ingestion_stats, connector_metadata
         )
 
-    async def fail(self, message, ingestion_stats=None, connector_metadata=None):
+    async def fail(self, error, ingestion_stats=None, connector_metadata=None):
+        if isinstance(error, str):
+            message = error
+        elif isinstance(error, Exception):
+            message = f"{error.__class__.__name__}"
+            if str(error):
+                message += f": {str(error)}"
+        else:
+            message = str(error)
         await self._terminate(
-            JobStatus.ERROR, str(message), ingestion_stats, connector_metadata
+            JobStatus.ERROR, message, ingestion_stats, connector_metadata
         )
 
     async def cancel(self, ingestion_stats=None, connector_metadata=None):

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -849,7 +849,6 @@ async def test_sync_job_done():
 )
 async def test_sync_job_fail(error, expected_message):
     source = {"_id": "1"}
-    input_error = error
     index = Mock()
     index.update = AsyncMock(return_value=1)
     expected_doc_source_update = {

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -838,20 +838,29 @@ async def test_sync_job_done():
 
 
 @pytest.mark.asyncio
-async def test_sync_job_fail():
+@pytest.mark.parametrize(
+    "error, expected_message",
+    [
+        ("something wrong", "something wrong"),
+        (Exception(), "Exception"),
+        (Exception("something wrong"), "Exception: something wrong"),
+        (123, "123"),
+    ],
+)
+async def test_sync_job_fail(error, expected_message):
     source = {"_id": "1"}
-    message = "something wrong"
+    input_error = error
     index = Mock()
     index.update = AsyncMock(return_value=1)
     expected_doc_source_update = {
         "last_seen": ANY,
         "completed_at": ANY,
         "status": JobStatus.ERROR.value,
-        "error": message,
+        "error": expected_message,
     }
 
     sync_job = SyncJob(elastic_index=index, doc_source=source)
-    await sync_job.fail(message)
+    await sync_job.fail(error)
 
     index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1603

Sometimes, an Exception is raised that has no `message` property. This is common for errors like `NoneTypeError`, `NotFound` or any internal exception we use like:
```
class SomeError(Exception)
  pass
...

raise SomeError() 
```

Our Extractor sets the `fetch_error` to be the instance of the caught exception, and we log it, but the connector sync job was getting updated with `str(e)`, which ends up being the empty string for these types of exceptions.

This PR adds some conditionals to attempt to generate a good error message based on what is passed to the `fail` function.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Fixes a bug where some sync jobs might fail with an empty error message
