### PR TITLE
Fix sharepoint server SSL-related config options

### DIFF
--- a/connectors/sources/sharepoint_server.py
+++ b/connectors/sources/sharepoint_server.py
@@ -95,10 +95,10 @@ class SharepointServerClient:
         self.site_collections = self.configuration["site_collections"]
 
         self.session = None
-        if self.ssl_enabled and self.certificate:
+        if self.certificate:
             self.ssl_ctx = ssl_context(certificate=self.certificate)
         else:
-            self.ssl_ctx = False
+            self.ssl_ctx = None if self.ssl_enabled else False
 
     def set_logger(self, logger_):
         self._logger = logger_
@@ -480,16 +480,16 @@ class SharepointServerDataSource(BaseDataSource):
             },
             "ssl_enabled": {
                 "display": "toggle",
-                "label": "Enable SSL",
+                "label": "Enable SSL certificate verification",
                 "order": 5,
                 "type": "bool",
-                "value": False,
+                "value": True,
             },
             "ssl_ca": {
-                "depends_on": [{"field": "ssl_enabled", "value": True}],
-                "label": "SSL certificate",
+                "label": "Self-signed SSL certificate",
                 "order": 6,
                 "type": "str",
+                "required": False,
             },
             "retry_count": {
                 "default_value": RETRIES,

--- a/tests/sources/test_sharepoint_server.py
+++ b/tests/sources/test_sharepoint_server.py
@@ -158,13 +158,6 @@ async def test_validate_config_for_ssl_enabled_when_ssl_ca_not_empty_does_not_ra
 
 
 @pytest.mark.asyncio
-async def test_validate_config_for_ssl_enabled_when_ssl_ca_empty_raises_error():
-    async with create_sps_source(ssl_enabled=True) as source:
-        with pytest.raises(ConfigurableFieldValueError):
-            await source.validate_config()
-
-
-@pytest.mark.asyncio
 async def test_api_call_for_exception():
     """This function test _api_call when credentials are incorrect"""
     async with create_sps_source(retry_count=0) as source:


### PR DESCRIPTION
Currently in the SharePoint Server 2019 connector, SSL certificate verification is disabled by default when configuring the connector. What's more, if you enable cert verification, you also have to provide a self-signed cert.

Coupling these options together does not make sense. We should:

* always verify SSL certs (self-signed or otherwise) by default, unless explicitly disabled
* not require the addition of a self-signed cert just because we want certificate verification enabled; these two configuration options should be configurable independent of one another

**NB:** if this PR is accepted, we'll need to address the docs and configuration reference items in the list below, too

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] ❗ Considered corresponding documentation changes
- [ ] ❗ Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)
