### PR TITLE
[CLI] Support non-native connectors

### DIFF
--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -83,7 +83,7 @@ class Connector:
                 )
 
             return await asyncio.gather(
-                self.__create_search_index(index_name, language),
+                # self.__create_search_index(index_name, language),
                 self.__create_connector(
                     index_name, service_type, configuration, is_native, language
                 ),
@@ -115,6 +115,8 @@ class Connector:
                 indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
             )
             timestamp = iso_utc()
+
+            await self.__create_search_index(index_name, language)
 
             api_key = await self.__create_api_key(index_name)
 

--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -1,6 +1,7 @@
 import asyncio
-from collections import OrderedDict
 import re
+from collections import OrderedDict
+
 from connectors.es.client import ESClient
 from connectors.es.settings import DEFAULT_LANGUAGE, Mappings, Settings
 from connectors.protocol import (
@@ -82,11 +83,8 @@ class Connector:
                     index_name, service_type, configuration, is_native, language
                 )
 
-            return await asyncio.gather(
-                # self.__create_search_index(index_name, language),
-                self.__create_connector(
-                    index_name, service_type, configuration, is_native, language
-                ),
+            return await self.__create_connector(
+                index_name, service_type, configuration, is_native, language
             )
         except Exception as e:
             raise e
@@ -153,7 +151,7 @@ class Connector:
             }
 
             connector = await self.connector_index.index(doc)
-            return { "id": connector["_id"], "api_key": api_key["encoded"] }
+            return {"id": connector["_id"], "api_key": api_key["encoded"]}
         finally:
             await self.connector_index.close()
 
@@ -213,15 +211,17 @@ class Connector:
 
     async def __create_api_key(self, name):
         acl_index_name = re.sub(r"^(?:search-)?(.*)$", r".search-acl-filter-\1", name)
-        metadata = {
-            "created_by": "Connectors CLI"
-        }
-        role_descriptors={
+        metadata = {"created_by": "Connectors CLI"}
+        role_descriptors = {
             f"{name}-connector-role": {
                 "cluster": ["monitor"],
                 "index": [
                     {
-                        "names": [name, acl_index_name, f"{CONCRETE_CONNECTORS_INDEX}*"],
+                        "names": [
+                            name,
+                            acl_index_name,
+                            f"{CONCRETE_CONNECTORS_INDEX}*",
+                        ],
                         "privileges": ["all"],
                     },
                 ],
@@ -231,7 +231,7 @@ class Connector:
             return await self.es_client.client.security.create_api_key(
                 name=f"{name}-connector",
                 role_descriptors=role_descriptors,
-                metadata=metadata
+                metadata=metadata,
             )
         finally:
             await self.es_client.close()

--- a/connectors/cli/index.py
+++ b/connectors/cli/index.py
@@ -1,5 +1,7 @@
 import asyncio
+
 from elasticsearch import ApiError
+
 from connectors.es import ESClient
 
 

--- a/connectors/cli/index.py
+++ b/connectors/cli/index.py
@@ -1,7 +1,5 @@
 import asyncio
-
 from elasticsearch import ApiError
-
 from connectors.es import ESClient
 
 

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -255,11 +255,20 @@ def create(obj, index_name, service_type, index_language, is_native, from_index)
         "Connector (name: "
         + click.style(index_name, fg="green")
         + ", ID: "
-        + click.style(result[1], fg="green")
+        + click.style(result[1]["id"], fg="green")
         + ", service_type: "
         + click.style(service_type, fg="green")
+        + ", api_key: "
+        + click.style(result[1]["api_key"], fg="green")
         + ") has been created!"
     )
+
+    # "connectors:
+# -
+#   connector_id: "S7W0NIwBKBm_hdQY_C7k"
+#   service_type: "sharepoint_online"
+#   api_key: "VExXMU5Jd0JLQm1faGRRWURDNmw6WnZ5VUJYdVRRc1NHWV9FT0FhcVM4Zw==""
+
     if not is_native:
         # TODO configure API key here
         click.echo(

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -16,7 +16,7 @@ import os
 import click
 import yaml
 from tabulate import tabulate
-
+import json
 from connectors import __version__  # NOQA
 from connectors.cli.auth import CONFIG_FILE_PATH, Auth
 from connectors.cli.connector import Connector
@@ -176,13 +176,35 @@ def validate_language(ctx, param, value):
     is_flag=True,
     help="Create a connector from an index that already exists. Each index can only have one connector. All current docs for the index will be deleted during the first sync.",
 )
+@click.option(
+    "--from_file",
+    type=click.Path(exists=True),
+    help="Use a JSON file to supply the connector configuration.",
+)
+@click.option(
+    "--update-config",
+    default=False,
+    is_flag=True,
+    help="Update the config file with the new non-connector.",
+)
+@click.option(
+    "--connector-service-config",
+    type=click.Path(exists=True),
+    default="config.yml",
+    help="Path to the connector service config file. Used in combination with --update-config flag.",
+)
 @click.pass_obj
-def create(obj, index_name, service_type, index_language, is_native, from_index):
+def create(obj, index_name, service_type, index_language, is_native, from_index, from_file, update_config, connector_service_config):
     if is_native:
         index_name = f"search-{index_name}"
         click.echo(
             f"Prepending {click.style('search-', fg='green')} to index name because it will be a native connector. New index name is {click.style(index_name, fg='green')}."
         )
+
+    connector_configuration = {}
+    if from_file:
+        with open(from_file) as fd:
+            connector_configuration = json.load(fd)
 
     index = Index(config=obj["config"]["elasticsearch"])
     connector = Connector(obj["config"]["elasticsearch"])
@@ -191,6 +213,13 @@ def create(obj, index_name, service_type, index_language, is_native, from_index)
     )
 
     def prompt():
+        if from_file:
+            if key in connector_configuration:
+                return connector_configuration[key]["value"]
+            else:
+                click.echo(f"{item['label']} is not found in {from_file}")
+                raise click.Abort()
+
         return click.prompt(
             f"{click.style('?', blink=True, fg='green')} {item['label']}",
             default=item.get("value", None),
@@ -255,25 +284,35 @@ def create(obj, index_name, service_type, index_language, is_native, from_index)
         "Connector (name: "
         + click.style(index_name, fg="green")
         + ", ID: "
-        + click.style(result[1]["id"], fg="green")
+        + click.style(result[0]["id"], fg="green")
         + ", service_type: "
         + click.style(service_type, fg="green")
         + ", api_key: "
-        + click.style(result[1]["api_key"], fg="green")
+        + click.style(result[0]["api_key"], fg="green")
         + ") has been created!"
     )
 
-    # "connectors:
-# -
-#   connector_id: "S7W0NIwBKBm_hdQY_C7k"
-#   service_type: "sharepoint_online"
-#   api_key: "VExXMU5Jd0JLQm1faGRRWURDNmw6WnZ5VUJYdVRRc1NHWV9FT0FhcVM4Zw==""
-
     if not is_native:
-        # TODO configure API key here
-        click.echo(
-            "This connector still requires an API key. Please configure this in Kibana."
-        )
+        if not update_config:
+            return
+        else:
+            service_config = yaml.safe_load(open(connector_service_config))
+            if not service_config:
+                service_config = {}
+
+            if "connectors" not in service_config:
+                service_config["connectors"] = []
+
+            service_config["connectors"].append({
+                "connector_id": result[0]["id"],
+                "service_type": service_type,
+                "api_key": result[0]["api_key"]
+            })
+
+            with open(connector_service_config, "w") as f:
+                yaml.dump(service_config, f)
+
+            click.echo(f"New connector has been added to {connector_service_config}")
 
 
 connector.add_command(create)

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -1,7 +1,9 @@
+import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import yaml
 from click.testing import CliRunner
 from elasticsearch import ApiError
 
@@ -236,6 +238,10 @@ def test_connector_create_with_native_flags(
     "connectors.cli.index.Index.index_or_connector_exists",
     MagicMock(return_value=[True, False]),
 )
+@patch(
+    "connectors.cli.connector.Connector._Connector__create_api_key",
+    AsyncMock(return_value={"id": "new_api_key_id", "encoded": "encoded_api_key"}),
+)
 def test_connector_create_from_index(patch_click_confirm):
     runner = CliRunner()
 
@@ -321,6 +327,108 @@ def test_connector_create_fails_when_index_or_connector_exists(
             assert result.exit_code == 1
 
             assert expected_error in result.output
+
+
+@patch(
+    "connectors.cli.connector.Connector._Connector__create_api_key",
+    AsyncMock(return_value={"id": "new_api_key_id", "encoded": "encoded_api_key"}),
+)
+@patch(
+    "connectors.cli.index.Index.index_or_connector_exists",
+    MagicMock(return_value=[False, False]),
+)
+def test_connector_create_from_file():
+    runner = CliRunner()
+
+    # configuration for the MongoDB connector
+    input_params = "\n".join(
+        [
+            "test-connector",
+            "mongodb",
+            "en",
+        ]
+    )
+
+    with patch(
+        "connectors.protocol.connectors.ConnectorIndex.index",
+        AsyncMock(return_value={"_id": "new_connector_id"}),
+    ) as patched_create:
+        with runner.isolated_filesystem():
+            with open("mongodb.json", "w") as f:
+                f.write(
+                    json.dumps(
+                        {
+                            "host": "localhost",
+                            "user": "test",
+                            "password": "test",
+                            "database": "test",
+                            "collection": "test",
+                            "direct_connection": False,
+                        }
+                    )
+                )
+            result = runner.invoke(
+                cli,
+                ["connector", "create", "--from_file", "mongodb.json"],
+                input=input_params,
+            )
+
+            patched_create.assert_called_once()
+            assert result.exit_code == 0
+
+            assert "has been created" in result.output
+
+
+@patch(
+    "connectors.cli.connector.Connector._Connector__create_api_key",
+    AsyncMock(return_value={"id": "new_api_key_id", "encoded": "encoded_api_key"}),
+)
+@patch(
+    "connectors.cli.index.Index.index_or_connector_exists",
+    MagicMock(return_value=[False, False]),
+)
+def test_connector_create_and_update_the_service_config():
+    runner = CliRunner()
+    connector_id = "new_connector_id"
+    service_type = "mongodb"
+
+    # configuration for the MongoDB connector
+    input_params = "\n".join(
+        [
+            "test_connector",
+            service_type,
+            "en",
+            "http://localhost/",
+            "username",
+            "password",
+            "database",
+            "collection",
+            "False",
+        ]
+    )
+
+    with patch(
+        "connectors.protocol.connectors.ConnectorIndex.index",
+        AsyncMock(return_value={"_id": connector_id}),
+    ) as patched_create:
+        with runner.isolated_filesystem():
+            with open("config.yml", "w") as f:
+                f.write(yaml.dump({}))
+
+            result = runner.invoke(
+                cli, ["connector", "create", "--update-config"], input=input_params
+            )
+            config = yaml.load(open("config.yml"), Loader=yaml.FullLoader)[
+                "connectors"
+            ][0]
+
+            patched_create.assert_called_once()
+            assert os.path.exists("config.yml") is True
+            assert config["api_key"] == "encoded_api_key"
+            assert config["connector_id"] == connector_id
+            assert config["service_type"] == service_type
+            assert result.exit_code == 0
+            assert "has been created" in result.output
 
 
 def test_index_help_page():


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6245

This PR adds: 

* Generate API keys for non-native connectors
* Update config.yml automatically when a new connectors is added
* Pass connector configuration using a json file

### New help page
```
Usage: connectors connector create [OPTIONS]

  Creates a new connector and a search index

Options:
  --index_name TEXT               Name of the index. If the connector will be
                                  native, `search-` will be prepended to the
                                  index name.
  --service_type [azure_blob_storage|confluence|dir|dropbox|github|gmail|google_cloud_storage|google_drive|jira|mongodb|mssql|mysql|network_drive|onedrive|oracle|outlook|postgresql|s3|salesforce|servicenow|sharepoint_online|sharepoint_server|slack|microsoft_teams|zoom|box]
  --index_language TEXT
  --native                        Create a native connector rather than a
                                  connector client.
  --from_index                    Create a connector from an index that
                                  already exists. Each index can only have one
                                  connector. All current docs for the index
                                  will be deleted during the first sync.
  --from_file PATH                Use a JSON file to supply the connector
                                  configuration.
  --update-config                 Update the config file with the new non-
                                  connector.
  --connector-service-config PATH
                                  Path to the connector service config file.
                                  Used in combination with --update-config
                                  flag.
  --help                          Show this message and exit.
```


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

