### PR TITLE
Fix job cleanup calling fail with wrong argument

### DIFF
--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -99,7 +99,7 @@ class JobCleanUpService(BaseService):
                 try:
                     connector_id = job.connector_id
 
-                    await job.fail(message=IDLE_JOB_ERROR)
+                    await job.fail(IDLE_JOB_ERROR)
                     marked_count += 1
 
                     try:

--- a/tests/services/test_job_cleanup.py
+++ b/tests/services/test_job_cleanup.py
@@ -79,5 +79,5 @@ async def test_cleanup_jobs(
 
     delete_indices.assert_called_with(indices=[to_be_deleted_index_name])
     delete_jobs.assert_called_with(job_ids=[sync_job.id, another_sync_job.id])
-    sync_job.fail.assert_called_with(message=IDLE_JOB_ERROR)
+    sync_job.fail.assert_called_with(IDLE_JOB_ERROR)
     connector.sync_done.assert_called_with(job=sync_job)


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1969

Recent refactoring changed signature of method `SyncJob.fail` by renaming "message" argument to "error". This caused errors in console - job cleanup failed because of unexpected argument.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
