### PR TITLE
[8.10] [SPO] Fix bugs when handling drive_items in incremental sync (#1827)

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1616,16 +1616,31 @@ class SharepointOnlineDataSource(BaseDataSource):
 
             return
 
-        ids_to_items = {
-            drive_item["id"]: drive_item for drive_item in drive_items_batch
+        def _is_item_deleted(drive_item):
+            return self.drive_item_operation(drive_item) == OP_DELETE
+
+        # Don't fetch access controls for deleted drive items
+        deleted_drive_items = [
+            drive_item
+            for drive_item in drive_items_batch
+            if _is_item_deleted(drive_item)
+        ]
+        for drive_item in deleted_drive_items:
+            yield drive_item
+
+        # Fetch access controls only for upserts
+        upsert_ids_to_items = {
+            drive_item["id"]: drive_item
+            for drive_item in drive_items_batch
+            if not _is_item_deleted(drive_item)
         }
-        drive_items_ids = list(ids_to_items.keys())
+        upsert_drive_items_ids = list(upsert_ids_to_items.keys())
 
         async for permissions_response in self.client.drive_items_permissions_batch(
-            drive_id, drive_items_ids
+            drive_id, upsert_drive_items_ids
         ):
             drive_item_id = permissions_response.get("id")
-            drive_item = ids_to_items.get(drive_item_id)
+            drive_item = upsert_ids_to_items.get(drive_item_id)
             permissions = permissions_response.get("body", {}).get("value", [])
 
             if drive_item:
@@ -1753,7 +1768,10 @@ class SharepointOnlineDataSource(BaseDataSource):
                     site, site_access_control
                 ), None, OP_INDEX
 
-                async for site_drive in self.site_drives(site, check_timestamp=True):
+                # Edit operation on a drive_item doesn't update the
+                # lastModifiedDateTime of the parent site_drive. Therfore, we
+                # set check_timestamp to False when iterating over site_drives.
+                async for site_drive in self.site_drives(site, check_timestamp=False):
                     yield self._decorate_with_access_control(
                         site_drive, site_access_control
                     ), None, OP_INDEX

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2654,7 +2654,8 @@ class TestSharepointOnlineDataSource:
     async def test_drive_items_batch_with_permissions_for_delta_delete_operation(
         self, patch_sharepoint_client
     ):
-        async with create_spo_source(use_document_level_security=True) as source:
+        async with create_source(SharepointOnlineDataSource) as source:
+            set_dls_enabled(source, True)
             drive_id = 1
             drive_item_ids = ["1", "2"]
             drive_items_batch = [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[SPO] Fix bugs when handling drive_items in incremental sync (#1827)](https://github.com/elastic/connectors/pull/1827)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)