### PR TITLE
check if DLS is enabled before fetching drive item permissions

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1548,7 +1548,10 @@ class SharepointOnlineDataSource(BaseDataSource):
             drive_item (dict): drive item with or without permissions depending on the config value of `fetch_drive_item_permissions`
         """
 
-        if not self._dls_enabled() or not self.configuration["fetch_drive_item_permissions"]:
+        if (
+            not self._dls_enabled()
+            or not self.configuration["fetch_drive_item_permissions"]
+        ):
             for drive_item in drive_items_batch:
                 yield drive_item
 

--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1548,7 +1548,7 @@ class SharepointOnlineDataSource(BaseDataSource):
             drive_item (dict): drive item with or without permissions depending on the config value of `fetch_drive_item_permissions`
         """
 
-        if not self.configuration["fetch_drive_item_permissions"]:
+        if not self._dls_enabled() or not self.configuration["fetch_drive_item_permissions"]:
             for drive_item in drive_items_batch:
                 yield drive_item
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2656,7 +2656,7 @@ class TestSharepointOnlineDataSource:
 
     @pytest.mark.asyncio
     async def test_drive_items_batch_with_permissions_when_dls_disabled(
-            self,
+        self,
     ):
         async with create_spo_source(use_document_level_security=False) as source:
             drive_id = 1
@@ -2665,7 +2665,7 @@ class TestSharepointOnlineDataSource:
             drive_items_without_permissions = []
 
             async for drive_item_without_permissions in source._drive_items_batch_with_permissions(
-                    drive_id, drive_items_batch, "dummy_site_web_url"
+                drive_id, drive_items_batch, "dummy_site_web_url"
             ):
                 drive_items_without_permissions.append(drive_item_without_permissions)
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -2655,6 +2655,27 @@ class TestSharepointOnlineDataSource:
             )
 
     @pytest.mark.asyncio
+    async def test_drive_items_batch_with_permissions_when_dls_disabled(
+            self,
+    ):
+        async with create_spo_source(use_document_level_security=False) as source:
+            drive_id = 1
+            drive_items_batch = [{"id": "1"}, {"id": "2"}]
+
+            drive_items_without_permissions = []
+
+            async for drive_item_without_permissions in source._drive_items_batch_with_permissions(
+                    drive_id, drive_items_batch, "dummy_site_web_url"
+            ):
+                drive_items_without_permissions.append(drive_item_without_permissions)
+
+            assert len(drive_items_without_permissions) == len(drive_items_batch)
+            assert not any(
+                ACCESS_CONTROL in drive_item
+                for drive_item in drive_items_without_permissions
+            )
+
+    @pytest.mark.asyncio
     async def test_drive_items_batch_with_permissions_for_delta_delete_operation(
         self, patch_sharepoint_client
     ):


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/6456


during 8.12 QA it was noticed that the SPO connector was making permissions-related API calls to Sharepoint, even if Document Level Security was disabled. Turns out one of our functions just wasn't gating its logic sufficiently. 

After this change, I was able to quickly sync our entire test sharepoint instance without seeing any evidence of `/permissions`, `/users` or `/groups` API calls being made when DLS was disabled.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

fixes a bug where the Sharepoint Online connector was making unnecessary API requests when DLS was disabled. This should improve performance if DLS is not enabled for the Sharepoint Online connector.
