### PR TITLE
[CLI] Add a command to show specific job informaton

### DIFF
--- a/connectors/cli/job.py
+++ b/connectors/cli/job.py
@@ -48,13 +48,13 @@ class Job:
     async def __async_start(self, connector_id, job_type):
         try:
             connector = await self.connector_index.fetch_by_id(connector_id)
-            await self.sync_job_index.create(
+            job_id = await self.sync_job_index.create(
                 connector=connector,
                 trigger_method=JobTriggerMethod.ON_DEMAND,
                 job_type=JobType(job_type),
             )
 
-            return True
+            return job_id
         finally:
             await self.sync_job_index.close()
             await self.connector_index.close()

--- a/connectors/cli/job.py
+++ b/connectors/cli/job.py
@@ -31,6 +31,20 @@ class Job:
     def start(self, connector_id, job_type):
         return asyncio.run(self.__async_start(connector_id, job_type))
 
+    def job(self, job_id):
+        return asyncio.run(self.__async_job(job_id))
+
+    async def __async_job(self, job_id):
+        try:
+            await self.es_client.ensure_exists(
+                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
+            )
+            job = await self.sync_job_index.fetch_by_id(job_id)
+            return job
+        finally:
+            await self.sync_job_index.close()
+            await self.es_client.close()
+
     async def __async_start(self, connector_id, job_type):
         try:
             connector = await self.connector_index.fetch_by_id(connector_id)

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -431,17 +431,30 @@ def job(obj):
 @click.command(help="Start a sync job.")
 @click.pass_obj
 @click.option("-i", help="Connector ID", required=True)
+
 @click.option(
     "-t",
     help="Job type",
     type=click.Choice(["full", "incremental", "access_control"], case_sensitive=False),
     required=True,
 )
-def start(obj, i, t):
+@click.option(
+    "-o",
+    "--format",
+    "output_format",
+    default="text",
+    help="Output format",
+    type=click.Choice(["json", "text"]),
+)
+def start(obj, i, t, output_format):
     job_cli = Job(config=obj["config"]["elasticsearch"])
-    click.echo("Starting a job...")
-    if job_cli.start(connector_id=i, job_type=t):
-        click.echo(click.style("The job has been started.", fg="green"))
+    job_id = job_cli.start(connector_id=i, job_type=t)
+
+    if job:
+        if output_format == "json":
+            click.echo(json.dumps({"id": job_id}, indent=4))
+        else:
+            click.echo("The job " + click.style(job_id, fg="green") + " has been started.")
     else:
         click.echo("")
         click.echo(

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -431,7 +431,6 @@ def job(obj):
 @click.command(help="Start a sync job.")
 @click.pass_obj
 @click.option("-i", help="Connector ID", required=True)
-
 @click.option(
     "-t",
     help="Job type",
@@ -454,7 +453,9 @@ def start(obj, i, t, output_format):
         if output_format == "json":
             click.echo(json.dumps({"id": job_id}, indent=4))
         else:
-            click.echo("The job " + click.style(job_id, fg="green") + " has been started.")
+            click.echo(
+                "The job " + click.style(job_id, fg="green") + " has been started."
+            )
     else:
         click.echo("")
         click.echo(

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -525,6 +525,49 @@ def cancel(obj, job_id):
 
 job.add_command(cancel)
 
+
+@click.command(help="Show information about a job", name="view")
+@click.pass_obj
+@click.argument("job_id")
+@click.option(
+    "-o",
+    "--format",
+    "output_format",
+    default="text",
+    help="Output format",
+    type=click.Choice(["json", "text"]),
+)
+def view_job(obj, job_id, output_format):
+    job_cli = Job(config=obj["config"]["elasticsearch"])
+    job = job_cli.job(job_id=job_id)
+    result = {
+        "job_id": job.id,
+        "connector_id": job.connector_id,
+        "index_name": job.index_name,
+        "job_status": job.status.value,
+        "job_type": job.job_type.value,
+        "documents_index,ed": job.indexed_document_count,
+        "volume_documents_indexed": job.indexed_document_volume,
+        "documents_deleted": job.deleted_document_count,
+    }
+    if job:
+        if output_format == "json":
+            click.echo(json.dumps(result, indent=4))
+        else:
+            click.echo(tabulate(result.items()))
+    else:
+        click.echo("")
+        click.echo(
+            click.style(
+                "Something went wrong. Please try again later or check your credentials",
+                fg="red",
+            ),
+            err=True,
+        )
+
+
+job.add_command(view_job)
+
 cli.add_command(job)
 
 

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -995,7 +995,9 @@ class SyncJobIndex(ESIndex):
             "created_at": iso_utc(),
             "last_seen": iso_utc(),
         }
-        await self.index(job_def)
+        api_response = await self.index(job_def)
+
+        return api_response['_id']
 
     async def pending_jobs(self, connector_ids, job_types):
         if not job_types:

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -997,7 +997,7 @@ class SyncJobIndex(ESIndex):
         }
         api_response = await self.index(job_def)
 
-        return api_response['_id']
+        return api_response["_id"]
 
     async def pending_jobs(self, connector_ids, job_types):
         if not job_types:

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -652,7 +652,7 @@ def test_job_list_one_job():
 def test_job_start():
     runner = CliRunner()
     connector_id = "test_connector_id"
-    job_id = 'test_job_id'
+    job_id = "test_job_id"
 
     with patch(
         "connectors.protocol.connectors.SyncJobIndex.create",

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -652,15 +652,16 @@ def test_job_list_one_job():
 def test_job_start():
     runner = CliRunner()
     connector_id = "test_connector_id"
+    job_id = 'test_job_id'
 
     with patch(
         "connectors.protocol.connectors.SyncJobIndex.create",
-        AsyncMock(return_value=True),
+        AsyncMock(return_value=job_id),
     ) as patched_create:
         result = runner.invoke(cli, ["job", "start", "-i", connector_id, "-t", "full"])
 
         patched_create.assert_called_once()
-        assert "The job has been started" in result.output
+        assert f"The job {job_id} has been started" in result.output
         assert result.exit_code == 0
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/6465

Very often it's required to get information about a specific job. This PR adds a new command `job view {JOB_ID}` that shows information. 

Also, I added `--format` option to display the output in different formats like text or JSON. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)


## Release Note

We have added a new command `connector job view {JOB_ID} --format {text|json}`.
