### PR TITLE
Ignore errors when Sink or Extractor is forcibly canceled

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -195,6 +195,7 @@ class Sink:
                     f"Sink did not stop within {CANCELATION_TIMEOUT} seconds of cancelation, force-canceling the task."
                 )
                 return
+            raise
 
     async def _run(self):
         """Creates batches of bulk calls given a queue of items.


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1985

### What's the change

1. Changed the log level to `warning` when a sync job is forcibly canceled
2. Ignore any error thrown in `Sink` or `Extractor` class if the `Sink` or `Extractor` object is forcibly canceled

### Why the change

In the last release, we [Forcibly cancel a sync job after waiting for 5 seconds](https://github.com/elastic/connectors/pull/1683). This should not be treated as `ERROR`, therefore we want to log it at `warning` level.

When we forcibly cancel the `Sink` or `Extractor` task, it will throw a `ForceCanceledError`. But sometimes there can be other errors thrown due to task cancellation, and be caught first. Before we log those errors as `critical`, we want to check if the task is forcibly canceled. If so, we will ignore those errors, and instead log a `warning` message that the task is forcibly canceled.


## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)