### PR TITLE
Make test fixture retry 429 errors

### DIFF
--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -147,6 +147,14 @@ async def _wait_for_connectors_index(es_client):
 async def _fetch_connector_metadata(es_client):
     # There's only one connector, so we just fetch it always
     response = await es_client.client.search(index=CONNECTORS_INDEX, size=1)
+    total_connectors = response["hits"]["total"]["value"]
+    if total_connectors == 0:
+        msg = "No connectors found in the deployment"
+        raise Exception(msg)
+    elif total_connectors > 1:
+        msg = f"Found {total_connectors} connectors in the deployment, expected only 1"
+        raise Exception(msg)
+
     connector = response["hits"]["hits"][0]
 
     connector_id = connector["_id"]


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6412

This PR changes functional tests fixture to handle 429 errors from Elasticsearch. This change for now is isolated to fixture.py. In subsequent PRs I'm planning to do the following:

1. Make retry a part of ESClient class and retry transparently
2. Get rid of places calling `ESClient.client` and make `ESClient` a rich client.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
