### PR TITLE
[GitHub] Fix scopes related issue

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -1198,15 +1198,15 @@ class GitHubDataSource(BaseDataSource):
         )
 
         scopes = headers.get("X-OAuth-Scopes", "")
-        scopes = [scope.strip() for scope in scopes.split(",")]
-        required_scopes = ["repo", "user", "read:org"]
+        scopes = {scope.strip() for scope in scopes.split(",")}
+        required_scopes = {"repo", "user", "read:org"}
 
         for scope in ["write:org", "admin:org"]:
             if scope in scopes:
-                scopes.append("read:org")
+                scopes.add("read:org")
 
-        if set(required_scopes).issubset(scopes):
-            extra_scopes = set(scopes) - set(required_scopes)
+        if required_scopes.issubset(scopes):
+            extra_scopes = scopes - required_scopes
             if extra_scopes:
                 self._logger.warning(
                     "The provided token has higher privileges than required. It is advisable to run the connector with least privielged token. Required scopes are 'repo', 'user', and 'read:org'."

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -1196,9 +1196,25 @@ class GitHubDataSource(BaseDataSource):
         _, headers = await self.github_client.post(  # pyright: ignore
             query_data=query_data, need_headers=True
         )
-        if "repo" not in headers.get("X-OAuth-Scopes"):  # pyright: ignore
-            msg = "Configured token does not have required rights to fetch the content"
+
+        scopes = headers.get("X-OAuth-Scopes", "")
+        scopes = [scope.strip() for scope in scopes.split(",")]
+        required_scopes = ["repo", "user", "read:org"]
+
+        for scope in ["write:org", "admin:org"]:
+            if scope in scopes:
+                scopes.append("read:org")
+
+        if set(required_scopes).issubset(scopes):
+            extra_scopes = set(scopes) - set(required_scopes)
+            if extra_scopes:
+                self._logger.warning(
+                    "The provided token has higher privileges than required. It is advisable to run the connector with least privielged token. Required scopes are 'repo', 'user', and 'read:org'."
+                )
+        else:
+            msg = "Configured token does not have required rights to fetch the content. Required scopes are 'repo', 'user', and 'read:org'."
             raise ConfigurableFieldValueError(msg)
+
         if self.github_client.repos != [WILDCARD]:
             invalid_repos = await self.get_invalid_repos()
             if invalid_repos:

--- a/tests/sources/fixtures/github/fixture.py
+++ b/tests/sources/fixtures/github/fixture.py
@@ -236,7 +236,7 @@ class GitHubAPI:
         if "viewer{login}" in query:
             mock_data = make_response({"data": {"viewer": {"login": "demo_repo"}}})
             mock_data.status_code = 200
-            mock_data.headers["X-OAuth-Scopes"] = ["repo"]
+            mock_data.headers["X-OAuth-Scopes"] = "repo, user, read:org"
         elif "repositories" in query:
             start_index, end_index, subset_nodes = self.get_index_metadata(
                 variables, repos_data

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -616,7 +616,7 @@ async def test_validate_config_with_insufficient_scope(scopes):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_with_extra_scopes_token():
+async def test_validate_config_with_extra_scopes_token(patch_logger):
     async with create_github_source() as source:
         source.github_client.post = AsyncMock(
             return_value=(
@@ -624,7 +624,10 @@ async def test_validate_config_with_extra_scopes_token():
                 {"X-OAuth-Scopes": "user, repo, admin:org"},
             )
         )
-        assert await source.validate_config() is None
+        await source.validate_config()
+        patch_logger.assert_present(
+            "The provided token has higher privileges than required. It is advisable to run the connector with least privielged token. Required scopes are 'repo', 'user', and 'read:org'."
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -587,12 +587,23 @@ async def test_ping_with_unsuccessful_connection():
 
 
 @pytest.mark.asyncio
+async def test_validate_config_with_invalid_token_then_raise():
+    async with create_github_source() as source:
+        with patch.object(
+            source.github_client,
+            "post",
+            side_effect=UnauthorizedException(),
+        ):
+            with pytest.raises(UnauthorizedException):
+                await source.validate_config()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "scopes",
     ["", "repo", "manage_runner:org, delete:packages, admin:public_key"],
 )
-@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
-async def test_validate_config_with_invalid_token_then_raise(scopes):
+async def test_validate_config_with_insufficient_scope(scopes):
     async with create_github_source() as source:
         source.github_client.post = AsyncMock(
             return_value=({"user": "username"}, {"X-OAuth-Scopes": scopes})

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -601,6 +601,18 @@ async def test_validate_config_with_invalid_token_then_raise():
 
 
 @pytest.mark.asyncio
+async def test_validate_config_with_extra_scopes_token():
+    async with create_github_source() as source:
+        source.github_client.post = AsyncMock(
+            return_value=(
+                {"user": "username"},
+                {"X-OAuth-Scopes": "user, repo, admin:org"},
+            )
+        )
+        assert await source.validate_config() is None
+
+
+@pytest.mark.asyncio
 @patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
 async def test_validate_config_with_inaccessible_repositories_then_raise():
     async with create_github_source() as source:

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -587,11 +587,15 @@ async def test_ping_with_unsuccessful_connection():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scopes",
+    ["", "repo", "manage_runner:org, delete:packages, admin:public_key"],
+)
 @patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
-async def test_validate_config_with_invalid_token_then_raise():
+async def test_validate_config_with_invalid_token_then_raise(scopes):
     async with create_github_source() as source:
         source.github_client.post = AsyncMock(
-            return_value=({"user": "username"}, {"X-OAuth-Scopes": ""})
+            return_value=({"user": "username"}, {"X-OAuth-Scopes": scopes})
         )
         with pytest.raises(
             ConfigurableFieldValueError,


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1983

Connector throws an error in the case of admin:org and write:org scopes. Now add admin:org and write:org to valid scopes and add a warning if the connector finds higher privileges than required.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
