### PR TITLE
[CLI] Remove blink=True

### DIFF
--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -112,9 +112,9 @@ def list_connectors(obj):
         table_rows = []
         for connector in connectors:
             formatted_connector = [
-                click.style(connector.id, blink=True, fg="green"),
-                click.style(connector.index_name, blink=True, fg="white"),
-                click.style(connector.service_type, blink=True, fg="white"),
+                click.style(connector.id, fg="green"),
+                click.style(connector.index_name, fg="white"),
+                click.style(connector.service_type, fg="white"),
                 click.style(connector.status.value, fg="white"),
                 click.style(connector.last_sync_status.value, fg="white"),
             ]
@@ -150,17 +150,17 @@ def validate_language(ctx, param, value):
 @click.command(help="Creates a new connector and a search index")
 @click.option(
     "--index-name",
-    prompt=f"{click.style('?', blink=True, fg='green')} Index name",
+    prompt=f"{click.style('?', fg='green')} Index name",
     help="Name of the index. If the connector will be native, `search-` will be prepended to the index name.",
 )
 @click.option(
     "--service-type",
-    prompt=f"{click.style('?', blink=True, fg='green')} Service type",
+    prompt=f"{click.style('?', fg='green')} Service type",
     type=click.Choice(list(_default_config()["sources"].keys()), case_sensitive=False),
 )
 @click.option(
     "--index-language",
-    prompt=f"{click.style('?', blink=True, fg='green')} Index language (leave empty for universal) {language_keys}",
+    prompt=f"{click.style('?', fg='green')} Index language (leave empty for universal) {language_keys}",
     default="",
     callback=validate_language,
 )
@@ -232,7 +232,7 @@ def create(
                 raise click.Abort()
 
         return click.prompt(
-            f"{click.style('?', blink=True, fg='green')} {item['label']}",
+            f"{click.style('?', fg='green')} {item['label']}",
             default=item.get("value", None),
             hide_input=True if item.get("sensitive") is True else False,
         )
@@ -358,7 +358,7 @@ def list_indices(obj):
     table_rows = []
     for index in indices:
         formatted_index = [
-            click.style(index, blink=True, fg="white"),
+            click.style(index, fg="white"),
             click.style(indices[index]["primaries"]["docs"]["count"]),
         ]
         table_rows.append(formatted_index)
@@ -484,14 +484,14 @@ def list_jobs(obj, connector_id):
     table_rows = []
     for job in jobs:
         formatted_job = [
-            click.style(job.id, blink=True, fg="green"),
-            click.style(job.connector_id, blink=True, fg="white"),
-            click.style(job.index_name, blink=True, fg="white"),
-            click.style(job.status.value, blink=True, fg="white"),
-            click.style(job.job_type.value, blink=True, fg="white"),
-            click.style(job.indexed_document_count, blink=True, fg="white"),
-            click.style(job.indexed_document_volume, blink=True, fg="white"),
-            click.style(job.deleted_document_count, blink=True, fg="white"),
+            click.style(job.id, fg="green"),
+            click.style(job.connector_id, fg="white"),
+            click.style(job.index_name, fg="white"),
+            click.style(job.status.value, fg="white"),
+            click.style(job.job_type.value, fg="white"),
+            click.style(job.indexed_document_count, fg="white"),
+            click.style(job.indexed_document_volume, fg="white"),
+            click.style(job.deleted_document_count, fg="white"),
         ]
         table_rows.append(formatted_job)
 


### PR DESCRIPTION
This PR removes `blink=True` that we accidentally added during the first phase of deployment. 


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
