### PR TITLE
[Network Drive] [DLS] Fix precedence for Deny permissions

### DIFF
--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -512,10 +512,11 @@ class NASDataSource(BaseDataSource):
 
         return self.configuration["use_document_level_security"]
 
-    async def _decorate_with_access_control(
-        self, document, file_path, file_type, groups_info
-    ):
+    async def _decorate_with_access_control(self, document, file_path, file_type):
         if self._dls_enabled():
+            groups_info = {}
+            if self.drive_type == WINDOWS:
+                groups_info = await self.fetch_groups_info()
             allow_permissions, deny_permissions = await self.get_entity_permission(
                 file_path=file_path, file_type=file_type, groups_info=groups_info
             )
@@ -685,15 +686,14 @@ class NASDataSource(BaseDataSource):
 
         else:
             matched_paths = (path for path, _, _ in self.get_directory_details)
-            groups_info = await self.fetch_groups_info()
 
             for path in matched_paths:
                 async for file in self.get_files(path=path):
                     if file["type"] == "folder":
                         yield await self._decorate_with_access_control(
-                            file, file.get("path"), file.get("type"), groups_info
+                            file, file.get("path"), file.get("type")
                         ), None
                     else:
                         yield await self._decorate_with_access_control(
-                            file, file.get("path"), file.get("type"), groups_info
+                            file, file.get("path"), file.get("type")
                         ), partial(self.get_content, file)

--- a/tests/sources/fixtures/network_drive/connector.json
+++ b/tests/sources/fixtures/network_drive/connector.json
@@ -74,7 +74,7 @@
                     "order":7,
                     "type": "str",
                     "ui_restrictions": ["advanced"],
-                    "value":"windows"
+                    "value":"linux"
                 },
                 "identity_mappings": {
                     "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",

--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -992,8 +992,8 @@ async def test_list_file_permissions_with_inaccessible_file():
     NASDataSource,
     "list_file_permission",
     return_value=[
-        mock_permission(sid="S-2-21-211-411", ace=0), # User with allow permission
-        mock_permission(sid="S-1-11-10", ace=1), # Group with Deny permission
+        mock_permission(sid="S-2-21-211-411", ace=0),  # User with allow permission
+        mock_permission(sid="S-1-11-10", ace=1),  # Group with Deny permission
     ],
 )
 async def test_deny_permission_has_precedence_over_allow(mock_list_file_permission):

--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -992,8 +992,8 @@ async def test_list_file_permissions_with_inaccessible_file():
     NASDataSource,
     "list_file_permission",
     return_value=[
-        mock_permission(sid="S-2-21-211-411", ace=0),
-        mock_permission(sid="S-1-11-10", ace=1),
+        mock_permission(sid="S-2-21-211-411", ace=0), # User with allow permission
+        mock_permission(sid="S-1-11-10", ace=1), # Group with Deny permission
     ],
 )
 async def test_deny_permission_has_precedence_over_allow(mock_list_file_permission):


### PR DESCRIPTION
## Closes #1963, #1966 

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

The Deny permissions takes precedence over Allow permissions in Windows Network Drive. So the following two cases have been addressed:

1. If a user has Explicit Deny permissions along with another Explicit allow permission, then the user is denied the access. #1966 
2. If a Group has Deny permission but a user of the group has Explicit allow permission, then the user is denied the access. #1963 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
