### PR TITLE
[MySQL] Remove duplicate PK check in advanced sync rules

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -561,12 +561,6 @@ class MySqlDataSource(BaseDataSource):
             )
             return
 
-        if has_duplicates(primary_key_columns):
-            self._logger.warning(
-                f"Skipping custom query for tables {format_list(tables)} as there are multiple primary key columns with the same name. Consider using 'AS' to uniquely identify primary key columns from different tables."
-            )
-            return
-
         last_update_times = list(
             filter(
                 lambda update_time: update_time is not None,

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -23,7 +23,6 @@ from connectors.sources.generic_database import (
 from connectors.utils import (
     CancellableSleeps,
     RetryStrategy,
-    has_duplicates,
     iso_utc,
     retryable,
     ssl_context,


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors/issues/2002

Removes the duplicate primary keys check in advanced sync rules for the MySQL connector to enable JOINs, also when the primary keys of different tables are the same.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)