### PR TITLE
[PostgreSQL] Remove duplicate PK check in advanced sync rules

### DIFF
--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -34,7 +34,6 @@ from connectors.sources.generic_database import (
 from connectors.utils import (
     RetryStrategy,
     get_pem_format,
-    has_duplicates,
     iso_utc,
     retryable,
 )
@@ -516,12 +515,6 @@ class PostgreSQLDataSource(BaseDataSource):
         if not primary_key_columns:
             self._logger.warning(
                 f"Skipping tables {', '.join(tables)} from database {self.database} since no primary key is associated with them. Assign primary key to the tables to index it in the next sync interval."
-            )
-            return
-
-        if has_duplicates(primary_key_columns):
-            self._logger.warning(
-                f"Skipping custom query for tables {', '.join(tables)} as there are multiple tables with same primary key column name."
             )
             return
 


### PR DESCRIPTION
## Related to https://github.com/elastic/connectors/issues/2002

Removes the duplicate primary keys check in advanced sync rules for the PostgreSQL connector to enable JOINs, also when the primary keys of different tables are the same.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)