### PR TITLE
Make fixtures async

### DIFF
--- a/tests/sources/fixtures/azure_blob_storage/fixture.py
+++ b/tests/sources/fixtures/azure_blob_storage/fixture.py
@@ -34,7 +34,7 @@ def get_num_docs():
     print((CONTAINER_COUNT - CONTAINERS_TO_DELETE) * BLOB_COUNT)
 
 
-def load():
+async def load():
     """Method for generating document for azurite emulator"""
     try:
         blob_service_client = BlobServiceClient.from_connection_string(
@@ -57,7 +57,7 @@ def load():
         print(f"Exception: {exception}")
 
 
-def remove():
+async def remove():
     """Method for removing 2k document for azurite emulator"""
     try:
         blob_service_client = BlobServiceClient.from_connection_string(

--- a/tests/sources/fixtures/dir/fixture.py
+++ b/tests/sources/fixtures/dir/fixture.py
@@ -31,7 +31,7 @@ def get_num_docs():
             print("300")
 
 
-def load():
+async def load():
     if os.path.exists(SYSTEM_DIR):
         teardown()
     print(f"Working in {SYSTEM_DIR}")
@@ -51,7 +51,7 @@ def load():
     os.unlink(repo_zip)
 
 
-def remove():
+async def remove():
     # removing 10 files
     files = []
     for root, __, filenames in os.walk(SYSTEM_DIR):
@@ -64,5 +64,5 @@ def remove():
         os.unlink(files[i])
 
 
-def teardown():
+async def teardown():
     shutil.rmtree(SYSTEM_DIR)

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -202,6 +202,8 @@ async def main(args=None):
     spec.loader.exec_module(module)
     if hasattr(module, args.action):
         func = getattr(module, args.action)
+        if args.action in ("setup", "load", "teardown", "remove"):
+            return await func()
         return func()
     else:
         if action == "get_num_docs":

--- a/tests/sources/fixtures/google_cloud_storage/fixture.py
+++ b/tests/sources/fixtures/google_cloud_storage/fixture.py
@@ -53,7 +53,7 @@ def get_num_docs():
     )
 
 
-def verify():
+async def verify():
     "Method to verify if prerequisites are satisfied for e2e or not"
     storage_emulator_host = os.getenv(key="STORAGE_EMULATOR_HOST", default=None)
     if storage_emulator_host != "http://localhost:4443":
@@ -90,7 +90,7 @@ def generate_files(bucket_name, number_of_files):
     )
 
 
-def load():
+async def load():
     create_connection()
     print("Started loading files on the fake Google Cloud Storage server....")
     if FIRST_BUCKET_FILE_COUNT:
@@ -102,7 +102,7 @@ def load():
     )
 
 
-def remove():
+async def remove():
     """Method for removing random blobs from the fake Google Cloud Storage server"""
     create_connection()
     print("Started removing random blobs from the fake Google Cloud Storage server....")
@@ -117,5 +117,5 @@ def remove():
     )
 
 
-def setup():
-    verify()
+async def setup():
+    await verify()

--- a/tests/sources/fixtures/mongodb/fixture.py
+++ b/tests/sources/fixtures/mongodb/fixture.py
@@ -18,11 +18,7 @@ fake = Faker()
 client = MongoClient("mongodb://admin:justtesting@127.0.0.1:27021")
 
 
-def setup():
-    pass
-
-
-def load():
+async def load():
     def _random_record():
         return {
             "id": bson.ObjectId(),
@@ -45,7 +41,7 @@ def load():
     collection.insert_many(data)
 
 
-def remove():
+async def remove():
     db = client.sample_database
     collection = db.sample_collection
 
@@ -54,7 +50,3 @@ def remove():
 
     query = {"_id": {"$in": doc_ids}}
     collection.delete_many(query)
-
-
-def teardown():
-    pass

--- a/tests/sources/fixtures/mongodb_serverless/fixture.py
+++ b/tests/sources/fixtures/mongodb_serverless/fixture.py
@@ -20,7 +20,7 @@ client = MongoClient("mongodb://admin:justtesting@127.0.0.1:27021")
 OB_STORE = "/tmp/objectstore"
 
 
-def setup():
+async def setup():
     print(f"preparing {OB_STORE}")
     # creating the file storage for es
     if os.path.exists(OB_STORE):
@@ -32,7 +32,7 @@ def setup():
     print(f"{OB_STORE} ready")
 
 
-def load():
+async def load():
     def _random_record():
         return {
             "id": bson.ObjectId(),
@@ -55,7 +55,7 @@ def load():
     collection.insert_many(data)
 
 
-def remove():
+async def remove():
     db = client.sample_database
     collection = db.sample_collection
 
@@ -64,7 +64,3 @@ def remove():
 
     query = {"_id": {"$in": doc_ids}}
     collection.delete_many(query)
-
-
-def teardown():
-    pass

--- a/tests/sources/fixtures/mssql/fixture.py
+++ b/tests/sources/fixtures/mssql/fixture.py
@@ -68,7 +68,7 @@ def inject_lines(table, cursor, lines):
         print(f"Inserted batch #{batch} of {batch_size} documents.")
 
 
-def load():
+async def load():
     """N tables of 10001 rows each. each row is ~ 1024*20 bytes"""
 
     database_sa = pytds.connect(
@@ -95,7 +95,7 @@ def load():
     database.commit()
 
 
-def remove():
+async def remove():
     """Removes 10 random items per table"""
 
     database = pytds.connect(server=HOST, port=PORT, user=USER, password=PASSWORD)

--- a/tests/sources/fixtures/mysql/fixture.py
+++ b/tests/sources/fixtures/mysql/fixture.py
@@ -51,7 +51,7 @@ def inject_lines(table, cursor, lines):
         print(f"Inserting batch #{batch} of {batch_size} documents.")
 
 
-def load():
+async def load():
     """N tables of 10001 rows each. each row is ~ 1024*20 bytes"""
     database = connect(host="127.0.0.1", port=3306, user="root", password="changeme")
     cursor = database.cursor()
@@ -67,7 +67,7 @@ def load():
     database.commit()
 
 
-def remove():
+async def remove():
     """Removes 10 random items per table"""
     database = connect(host="127.0.0.1", port=3306, user="root", password="changeme")
     cursor = database.cursor()

--- a/tests/sources/fixtures/network_drive/fixture.py
+++ b/tests/sources/fixtures/network_drive/fixture.py
@@ -69,12 +69,12 @@ def generate_files():
         raise
 
 
-def load():
+async def load():
     generate_folder()
     generate_files()
 
 
-def remove():
+async def remove():
     """Method for deleting 10 random files from Network Drive server"""
     try:
         smbclient.register_session(server=SERVER, username=USERNAME, password=PASSWORD)

--- a/tests/sources/fixtures/oracle/fixture.py
+++ b/tests/sources/fixtures/oracle/fixture.py
@@ -63,7 +63,7 @@ def inject_lines(table, cursor, lines):
         print(f"Inserted batch #{batch} of {batch_size} documents.")
 
 
-def load():
+async def load():
     """Generate tables and loads table data in the oracle server."""
     """N tables of RECORD_COUNT rows each"""
     connection = oracledb.connect(
@@ -86,7 +86,7 @@ def load():
     connection.commit()
 
 
-def remove():
+async def remove():
     """Removes 10 random items per table"""
     connection = oracledb.connect(
         user=USER, password=PASSWORD, dsn=DSN, encoding=ENCODING

--- a/tests/sources/fixtures/s3/fixture.py
+++ b/tests/sources/fixtures/s3/fixture.py
@@ -40,12 +40,12 @@ def get_num_docs():
     print(FOLDER_COUNT + FILE_COUNT - OBJECT_TO_DELETE_COUNT)
 
 
-def setup():
+async def setup():
     os.environ["AWS_ENDPOINT_URL"] = AWS_ENDPOINT_URL
     os.environ["AWS_PORT"] = str(AWS_PORT)
 
 
-def load():
+async def load():
     """Method for generating 10k document for aws s3 emulator"""
     s3_client = boto3.client(
         "s3",
@@ -82,7 +82,7 @@ def load():
         )
 
 
-def remove():
+async def remove():
     """Method for removing 15 random document from aws s3 emulator"""
     s3_client = boto3.client(
         "s3",


### PR DESCRIPTION
## Fixes failing functional tests

Current builds are failing because PostgreSQL fixture is using event loop to run async postgresql client. With recent change I've made `tests/sources/fixture.py` class async (to reuse code) and it caused this one fixture to fail, because it's running `run_until_complete` on current event loop that is already doing this.

So far the situation is:

1. Postgresql fixture uses async code
2. MongoDB/MySQL connectors use async code, their fixtures do not use async code (should be fixed)
3. PostgreSQL, MSSQL and OracleDB connectors and their fixtures do not use async code (there are manual wrappers), this should be fixed

So for now this async change just makes it work for PostgreSQL's fixture, but it also opens up way for unification of fixtures with connectors for MongoDB/MySQL (they can use same libraries/methods to connect to remote DB and manage it)

This code reflects the modification:

```python
    if hasattr(module, args.action):
        func = getattr(module, args.action)
        if args.action in ("setup", "load", "teardown", "remove"):
            return await func()
        return func()
```

So methods `setup`, `load`, `teardown` and `remove` are async, all others are sync.

If the method is not defined in the fixture, it's not gonna be called at all