### PR TITLE
Replace more places accessing Elasticsearch client directly with proxied calls

### DIFF
--- a/connectors/cli/auth.py
+++ b/connectors/cli/auth.py
@@ -4,7 +4,7 @@ import os
 import yaml
 from elasticsearch import ApiError
 
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 
 CONFIG_FILE_PATH = ".cli/config.yml"
 

--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -30,8 +30,7 @@ class Connector:
         # TODO move this on top
         try:
             await self.es_management_client.ensure_exists(
-                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
-                expand_wildcards="all",
+                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
             )
 
             return [
@@ -92,8 +91,7 @@ class Connector:
     ):
         try:
             await self.es_management_client.ensure_exists(
-                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
-                expand_wildcards="all",
+                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
             )
             timestamp = iso_utc()
 

--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections import OrderedDict
 
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.es.settings import DEFAULT_LANGUAGE
 from connectors.protocol import (
     CONCRETE_CONNECTORS_INDEX,
@@ -87,9 +87,6 @@ class Connector:
         finally:
             await self.es_management_client.close()
 
-    async def __create_search_index(self, index_name, language):
-        await self.es_management_client.create_content_index(index_name, language)
-
     async def __create_connector(
         self, index_name, service_type, configuration, is_native, language, from_index
     ):
@@ -101,7 +98,9 @@ class Connector:
             timestamp = iso_utc()
 
             if not from_index:
-                await self.__create_search_index(index_name, language)
+                await self.es_management_client.create_content_index(
+                    index_name, language
+                )
 
             api_key = await self.__create_api_key(index_name)
 

--- a/connectors/cli/index.py
+++ b/connectors/cli/index.py
@@ -2,7 +2,7 @@ import asyncio
 
 from elasticsearch import ApiError
 
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.protocol import ConnectorIndex
 
 

--- a/connectors/cli/job.py
+++ b/connectors/cli/job.py
@@ -38,7 +38,6 @@ class Job:
         try:
             await self.es_management_client.ensure_exists(
                 indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
-                expand_wildcards="all",
             )
             job = await self.sync_job_index.fetch_by_id(job_id)
             return job
@@ -65,7 +64,6 @@ class Job:
         try:
             await self.es_management_client.ensure_exists(
                 indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
-                expand_wildcards="all",
             )
             jobs = self.sync_job_index.get_all_docs(
                 query=self.__job_list_query(connector_id, index_name, job_id),

--- a/connectors/cli/job.py
+++ b/connectors/cli/job.py
@@ -37,7 +37,8 @@ class Job:
     async def __async_job(self, job_id):
         try:
             await self.es_management_client.ensure_exists(
-                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
+                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
+                expand_wildcards="all",
             )
             job = await self.sync_job_index.fetch_by_id(job_id)
             return job
@@ -63,7 +64,8 @@ class Job:
     async def __async_list_jobs(self, connector_id, index_name, job_id):
         try:
             await self.es_management_client.ensure_exists(
-                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
+                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
+                expand_wildcards="all",
             )
             jobs = self.sync_job_index.get_all_docs(
                 query=self.__job_list_query(connector_id, index_name, job_id),

--- a/connectors/cli/job.py
+++ b/connectors/cli/job.py
@@ -2,7 +2,7 @@ import asyncio
 
 from elasticsearch import ApiError
 
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.protocol import (
     CONCRETE_CONNECTORS_INDEX,
     CONCRETE_JOBS_INDEX,

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -11,9 +11,16 @@ from enum import Enum
 
 from elastic_transport.client_utils import url_to_node_config
 from elasticsearch import ApiError, AsyncElasticsearch, ConflictError
-from elasticsearch import ConnectionError as ElasticConnectionError
+from elasticsearch import (
+    ConnectionError as ElasticConnectionError,
+)
+from elasticsearch import (
+    NotFoundError as ElasticNotFoundError,
+)
+from elasticsearch.helpers import async_scan
 
 from connectors import __version__
+from connectors.es.settings import TIMESTAMP_FIELD, Mappings, Settings
 from connectors.logger import logger, set_extra_logger
 from connectors.utils import CancellableSleeps
 
@@ -180,18 +187,71 @@ class ESManagementClient(ESClient):
         # initialize ESIndex instance
         super().__init__(config)
 
-    async def ensure_exists(self, indices=None):
+    async def ensure_exists(self, indices=None, expand_wildcards="open"):
         if indices is None:
             indices = []
 
         for index in indices:
-            logger.debug(f"Checking index {index}")
-            if not await self.client.indices.exists(index=index):
+            logger.debug(
+                f"Checking index {index} with expand_wildcards={expand_wildcards}"
+            )
+            if not await self.client.indices.exists(
+                index=index, expand_wildcards=expand_wildcards
+            ):
                 await self.client.indices.create(index=index)
                 logger.debug(f"Created index {index}")
 
-    async def delete_indices(self, indices):
-        await self.client.indices.delete(index=indices, ignore_unavailable=True)
+    async def create_content_index(self, search_index_name, language_code):
+        settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
+        mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
+
+        return await self.client.indices.create(
+            index=search_index_name, mappings=mappings, settings=settings
+        )
+
+    async def ensure_content_index_mappings(self, index, mappings):
+        # open = Match open, non-hidden indices. Also matches any non-hidden data stream.
+        # Content indices are always non-hidden.
+        expand_wildcards = "open"
+        response = await self.client.indices.get_mapping(
+            index=index, expand_wildcards=expand_wildcards
+        )
+
+        existing_mappings = response[index].get("mappings", {})
+        if len(existing_mappings) == 0 and mappings:
+            logger.debug(
+                "Index %s has no mappings or it's empty. Adding mappings...", index
+            )
+            await self.client.indices.put_mapping(
+                index=index,
+                dynamic=mappings.get("dynamic", False),
+                dynamic_templates=mappings.get("dynamic_templates", []),
+                properties=mappings.get("properties", {}),
+                expand_wildcards=expand_wildcards,
+            )
+            logger.debug("Successfully added mappings for index %s", index)
+        else:
+            logger.debug(
+                "Index %s already has mappings, skipping mappings creation", index
+            )
+
+    async def ensure_ingest_pipeline_exists(
+        self, pipeline_id, version, description, processors
+    ):
+        try:
+            await self.client.ingest.get_pipeline(id=pipeline_id)
+        except ElasticNotFoundError:
+            await self.client.ingest.put_pipeline(
+                id=pipeline_id,
+                version=version,
+                description=version,
+                processors=version,
+            )
+
+    async def delete_indices(self, indices, expand_wildcards="open"):
+        await self.client.indices.delete(
+            index=indices, expand_wildcards=expand_wildcards, ignore_unavailable=True
+        )
 
     async def clean_index(self, index_name):
         return await self.client.delete_by_query(
@@ -201,8 +261,40 @@ class ESManagementClient(ESClient):
     async def list_indices(self):
         return await self.client.indices.stats(index="search-*")
 
-    async def index_exists(self, index_name):
-        return await self.client.indices.exists(index=index_name)
+    async def index_exists(self, index_name, expand_wildcards="open"):
+        return await self.client.indices.exists(
+            index=index_name, expand_wildcards=expand_wildcards
+        )
+
+    async def upsert(self, _id, index_name, doc):
+        await self.client.index(
+            id=_id,
+            index=index_name,
+            document=doc,
+        )
+
+    async def yield_existing_documents_metadata(self, index):
+        """Returns an iterator on the `id` and `_timestamp` fields of all documents in an index.
+
+        WARNING
+
+        This function will load all ids in memory -- on very large indices,
+        depending on the id length, it can be quite large.
+
+        300,000 ids will be around 50MiB
+        """
+        logger.debug(f"Scanning existing index {index}")
+        if not self.index_exists(index):
+            return
+
+        async for doc in async_scan(
+            client=self.client, index=index, _source=["id", TIMESTAMP_FIELD]
+        ):
+            source = doc["_source"]
+            doc_id = source.get("id", doc["_id"])
+            timestamp = source.get(TIMESTAMP_FIELD)
+
+            yield doc_id, timestamp
 
 
 def with_concurrency_control(retries=3):

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -14,13 +14,8 @@ from elasticsearch import ApiError, AsyncElasticsearch, ConflictError
 from elasticsearch import (
     ConnectionError as ElasticConnectionError,
 )
-from elasticsearch import (
-    NotFoundError as ElasticNotFoundError,
-)
-from elasticsearch.helpers import async_scan
 
 from connectors import __version__
-from connectors.es.settings import TIMESTAMP_FIELD, Mappings, Settings
 from connectors.logger import logger, set_extra_logger
 from connectors.utils import CancellableSleeps
 
@@ -166,135 +161,6 @@ class ESClient:
 
         await self.close()
         return False
-
-
-class ESManagementClient(ESClient):
-    """
-    Elasticsearch client with methods to manage connector-related indices.
-
-    Additionally to regular methods of ESClient, this client provides methods to work with arbitrary indices,
-    for example allowing to list indices, delete indices, wipe data from indices and such.
-
-    ESClient should be used to provide rich clients that operate on "domains", such as:
-        - specific connector
-        - specific job
-
-    This client, on the contrary, is used to manage a number of indices outside of connector protocol operations.
-    """
-
-    def __init__(self, config):
-        logger.debug(f"ESManagementClient connecting to {config['host']}")
-        # initialize ESIndex instance
-        super().__init__(config)
-
-    async def ensure_exists(self, indices=None, expand_wildcards="open"):
-        if indices is None:
-            indices = []
-
-        for index in indices:
-            logger.debug(
-                f"Checking index {index} with expand_wildcards={expand_wildcards}"
-            )
-            if not await self.client.indices.exists(
-                index=index, expand_wildcards=expand_wildcards
-            ):
-                await self.client.indices.create(index=index)
-                logger.debug(f"Created index {index}")
-
-    async def create_content_index(self, search_index_name, language_code):
-        settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
-        mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
-
-        return await self.client.indices.create(
-            index=search_index_name, mappings=mappings, settings=settings
-        )
-
-    async def ensure_content_index_mappings(self, index, mappings):
-        # open = Match open, non-hidden indices. Also matches any non-hidden data stream.
-        # Content indices are always non-hidden.
-        expand_wildcards = "open"
-        response = await self.client.indices.get_mapping(
-            index=index, expand_wildcards=expand_wildcards
-        )
-
-        existing_mappings = response[index].get("mappings", {})
-        if len(existing_mappings) == 0 and mappings:
-            logger.debug(
-                "Index %s has no mappings or it's empty. Adding mappings...", index
-            )
-            await self.client.indices.put_mapping(
-                index=index,
-                dynamic=mappings.get("dynamic", False),
-                dynamic_templates=mappings.get("dynamic_templates", []),
-                properties=mappings.get("properties", {}),
-                expand_wildcards=expand_wildcards,
-            )
-            logger.debug("Successfully added mappings for index %s", index)
-        else:
-            logger.debug(
-                "Index %s already has mappings, skipping mappings creation", index
-            )
-
-    async def ensure_ingest_pipeline_exists(
-        self, pipeline_id, version, description, processors
-    ):
-        try:
-            await self.client.ingest.get_pipeline(id=pipeline_id)
-        except ElasticNotFoundError:
-            await self.client.ingest.put_pipeline(
-                id=pipeline_id,
-                version=version,
-                description=version,
-                processors=version,
-            )
-
-    async def delete_indices(self, indices, expand_wildcards="open"):
-        await self.client.indices.delete(
-            index=indices, expand_wildcards=expand_wildcards, ignore_unavailable=True
-        )
-
-    async def clean_index(self, index_name):
-        return await self.client.delete_by_query(
-            index=index_name, body={"query": {"match_all": {}}}, ignore_unavailable=True
-        )
-
-    async def list_indices(self):
-        return await self.client.indices.stats(index="search-*")
-
-    async def index_exists(self, index_name, expand_wildcards="open"):
-        return await self.client.indices.exists(
-            index=index_name, expand_wildcards=expand_wildcards
-        )
-
-    async def upsert(self, _id, index_name, doc):
-        await self.client.index(
-            id=_id,
-            index=index_name,
-            document=doc,
-        )
-
-    async def yield_existing_documents_metadata(self, index):
-        """Returns an iterator on the `id` and `_timestamp` fields of all documents in an index.
-
-        WARNING
-
-        This function will load all ids in memory -- on very large indices,
-        depending on the id length, it can be quite large.
-
-        300,000 ids will be around 50MiB
-        """
-        logger.debug(f"Scanning existing index {index}")
-        if not self.index_exists(index):
-            return
-
-        async for doc in async_scan(
-            client=self.client, index=index, _source=["id", TIMESTAMP_FIELD]
-        ):
-            source = doc["_source"]
-            doc_id = source.get("id", doc["_id"])
-            timestamp = source.get(TIMESTAMP_FIELD)
-
-            yield doc_id, timestamp
 
 
 def with_concurrency_control(retries=3):

--- a/connectors/es/management_client.py
+++ b/connectors/es/management_client.py
@@ -1,0 +1,143 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+from elasticsearch import (
+    NotFoundError as ElasticNotFoundError,
+)
+from elasticsearch.helpers import async_scan
+
+from connectors.es.client import ESClient
+from connectors.es.settings import TIMESTAMP_FIELD, Mappings, Settings
+from connectors.logger import logger
+
+
+class ESManagementClient(ESClient):
+    """
+    Elasticsearch client with methods to manage connector-related indices.
+
+    Additionally to regular methods of ESClient, this client provides methods to work with arbitrary indices,
+    for example allowing to list indices, delete indices, wipe data from indices and such.
+
+    ESClient should be used to provide rich clients that operate on "domains", such as:
+        - specific connector
+        - specific job
+
+    This client, on the contrary, is used to manage a number of indices outside of connector protocol operations.
+    """
+
+    def __init__(self, config):
+        logger.debug(f"ESManagementClient connecting to {config['host']}")
+        # initialize ESIndex instance
+        super().__init__(config)
+
+    async def ensure_exists(self, indices=None, expand_wildcards="open"):
+        if indices is None:
+            indices = []
+
+        for index in indices:
+            logger.debug(
+                f"Checking index {index} with expand_wildcards={expand_wildcards}"
+            )
+            if not await self.client.indices.exists(
+                index=index, expand_wildcards=expand_wildcards
+            ):
+                await self.client.indices.create(index=index)
+                logger.debug(f"Created index {index}")
+
+    async def create_content_index(self, search_index_name, language_code):
+        settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
+        mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
+
+        return await self.client.indices.create(
+            index=search_index_name, mappings=mappings, settings=settings
+        )
+
+    async def ensure_content_index_mappings(self, index, mappings):
+        # open = Match open, non-hidden indices. Also matches any non-hidden data stream.
+        # Content indices are always non-hidden.
+        expand_wildcards = "open"
+        response = await self.client.indices.get_mapping(
+            index=index, expand_wildcards=expand_wildcards
+        )
+
+        existing_mappings = response[index].get("mappings", {})
+        if len(existing_mappings) == 0 and mappings:
+            logger.debug(
+                "Index %s has no mappings or it's empty. Adding mappings...", index
+            )
+            await self.client.indices.put_mapping(
+                index=index,
+                dynamic=mappings.get("dynamic", False),
+                dynamic_templates=mappings.get("dynamic_templates", []),
+                properties=mappings.get("properties", {}),
+                expand_wildcards=expand_wildcards,
+            )
+            logger.debug("Successfully added mappings for index %s", index)
+        else:
+            logger.debug(
+                "Index %s already has mappings, skipping mappings creation", index
+            )
+
+    async def ensure_ingest_pipeline_exists(
+        self, pipeline_id, version, description, processors
+    ):
+        try:
+            await self.client.ingest.get_pipeline(id=pipeline_id)
+        except ElasticNotFoundError:
+            await self.client.ingest.put_pipeline(
+                id=pipeline_id,
+                version=version,
+                description=version,
+                processors=version,
+            )
+
+    async def delete_indices(self, indices, expand_wildcards="open"):
+        await self.client.indices.delete(
+            index=indices, expand_wildcards=expand_wildcards, ignore_unavailable=True
+        )
+
+    async def clean_index(self, index_name):
+        return await self.client.delete_by_query(
+            index=index_name, body={"query": {"match_all": {}}}, ignore_unavailable=True
+        )
+
+    async def list_indices(self):
+        return await self.client.indices.stats(index="search-*")
+
+    async def index_exists(self, index_name, expand_wildcards="open"):
+        return await self.client.indices.exists(
+            index=index_name, expand_wildcards=expand_wildcards
+        )
+
+    async def upsert(self, _id, index_name, doc):
+        await self.client.index(
+            id=_id,
+            index=index_name,
+            document=doc,
+        )
+
+    async def yield_existing_documents_metadata(self, index):
+        """Returns an iterator on the `id` and `_timestamp` fields of all documents in an index.
+
+        WARNING
+
+        This function will load all ids in memory -- on very large indices,
+        depending on the id length, it can be quite large.
+
+        300,000 ids will be around 50MiB
+        """
+        logger.debug(f"Scanning existing index {index}")
+        if not self.index_exists(index):
+            return
+
+        async for doc in async_scan(
+            client=self.client, index=index, _source=["id", TIMESTAMP_FIELD]
+        ):
+            source = doc["_source"]
+            doc_id = source.get("id", doc["_id"])
+            timestamp = source.get(TIMESTAMP_FIELD)
+
+            yield doc_id, timestamp

--- a/connectors/es/settings.py
+++ b/connectors/es/settings.py
@@ -8,6 +8,8 @@ from os import path
 
 import yaml
 
+TIMESTAMP_FIELD = "_timestamp"
+
 ENUM_IGNORE_ABOVE = 2048
 
 DATE_FIELD_MAPPING = {"type": "date"}
@@ -274,6 +276,14 @@ class Settings:
         }
 
         return definitions
+
+    @property
+    def auto_expand_replicas(self):
+        return "0-1"
+
+    @property
+    def number_of_shards(self):
+        return 2
 
     def __init__(self, *, language_code=None, analysis_icu=False):
         self._language_data = None

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -24,7 +24,7 @@ import logging
 import time
 from collections import defaultdict
 
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.es.settings import TIMESTAMP_FIELD, Mappings
 from connectors.filtering.basic_rule import BasicRuleEngine, parse
 from connectors.logger import logger, tracer

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -177,17 +177,12 @@ async def upsert_index(es, index):
     this logic.
     """
 
-    if index.startswith("."):
-        expand_wildcards = "hidden"
-    else:
-        expand_wildcards = "open"
-
-    exists = await es.index_exists(index, expand_wildcards)
+    exists = await es.index_exists(index)
 
     if exists:
         logger.debug(f"{index} exists, deleting...")
         logger.debug("Deleting it first")
-        await es.delete_indices([index], expand_wildcards)
+        await es.delete_indices([index])
 
     logger.debug(f"Creating index {index}")
     await es.create_content_index(index, DEFAULT_LANGUAGE)

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -11,7 +11,7 @@ import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 
 from connectors.config import load_config
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.es.settings import DEFAULT_LANGUAGE
 from connectors.logger import set_extra_logger
 from connectors.source import get_source_klass

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -97,7 +97,8 @@ class PreflightCheck:
                 # and located here: https://github.com/elastic/elasticsearch/tree/main/x-pack/plugin/core/template-resources/src/main/resources/entsearch/connector
 
                 await self.es_management_client.ensure_exists(
-                    indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
+                    indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
+                    expand_wildcards="all",
                 )
                 return True
             except Exception as e:

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -98,7 +98,6 @@ class PreflightCheck:
 
                 await self.es_management_client.ensure_exists(
                     indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
-                    expand_wildcards="all",
                 )
                 return True
             except Exception as e:

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -6,7 +6,7 @@
 
 import aiohttp
 
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.logger import logger
 from connectors.protocol import CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX
 from connectors.utils import CancellableSleeps

--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -7,8 +7,8 @@
 A task periodically clean up orphaned and idle jobs.
 """
 
-from connectors.es.client import ESManagementClient
 from connectors.es.index import DocumentNotFoundError
+from connectors.es.management_client import ESManagementClient
 from connectors.logger import logger
 from connectors.protocol import ConnectorIndex, SyncJobIndex
 from connectors.services.base import BaseService

--- a/tests/es/test_client.py
+++ b/tests/es/test_client.py
@@ -4,7 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import base64
-from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
@@ -13,11 +12,9 @@ from elasticsearch import ConflictError, ConnectionError
 
 from connectors.es.client import (
     ESClient,
-    ESManagementClient,
     License,
     with_concurrency_control,
 )
-from tests.commons import AsyncIterator
 
 BASIC_CONFIG = {"username": "elastic", "password": "changeme"}
 API_CONFIG = {"api_key": "foo"}
@@ -235,67 +232,3 @@ class TestESClient:
             # Execute
             assert not await es_client.ping()
             await es_client.close()
-
-
-class TestESManagementClient:
-    @pytest.mark.asyncio
-    async def test_index_exists(self):
-        config = {
-            "username": "elastic",
-            "password": "changeme",
-            "host": "http://nowhere.com:9200",
-        }
-        index_name = "search-mongo"
-        es_management_client = ESManagementClient(config)
-        es_management_client.client = Mock()
-        es_management_client.client.indices.exists = AsyncMock()
-
-        await es_management_client.index_exists(index_name=index_name)
-        es_management_client.client.indices.exists.assert_awaited_with(
-            index=index_name, expand_wildcards="open"
-        )
-
-    @pytest.mark.asyncio
-    async def test_delete_indices(self):
-        config = {
-            "username": "elastic",
-            "password": "changeme",
-            "host": "http://nowhere.com:9200",
-        }
-        indices = ["search-mongo"]
-        es_management_client = ESManagementClient(config)
-        es_management_client.client = Mock()
-        es_management_client.client.indices.delete = AsyncMock()
-
-        await es_management_client.delete_indices(indices=indices)
-        es_management_client.client.indices.delete.assert_awaited_with(
-            index=indices, expand_wildcards="open", ignore_unavailable=True
-        )
-
-    @pytest.mark.asyncio
-    async def test_yield_existing_documents_metadata(self, mock_responses):
-        config = {
-            "username": "elastic",
-            "password": "changeme",
-            "host": "http://nowhere.com:9200",
-        }
-        es_management_client = ESManagementClient(config)
-        es_management_client.client = AsyncMock()
-        es_management_client.client.index_exists = Mock(return_value=True)
-
-        records = [
-            {"_id": "1", "_source": {"_timestamp": str(datetime.now())}},
-            {"_id": "2", "_source": {"_timestamp": str(datetime.now())}},
-        ]
-
-        with mock.patch(
-            "connectors.es.client.async_scan", return_value=AsyncIterator(records)
-        ):
-            ids = []
-            async for doc_id, _ in es_management_client.yield_existing_documents_metadata(
-                "something"
-            ):
-                ids.append(doc_id)
-
-            assert ids == ["1", "2"]
-        await es_management_client.close()

--- a/tests/es/test_client.py
+++ b/tests/es/test_client.py
@@ -4,6 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import base64
+from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
@@ -16,6 +17,7 @@ from connectors.es.client import (
     License,
     with_concurrency_control,
 )
+from tests.commons import AsyncIterator
 
 BASIC_CONFIG = {"username": "elastic", "password": "changeme"}
 API_CONFIG = {"api_key": "foo"}
@@ -249,7 +251,9 @@ class TestESManagementClient:
         es_management_client.client.indices.exists = AsyncMock()
 
         await es_management_client.index_exists(index_name=index_name)
-        es_management_client.client.indices.exists.assert_awaited_with(index=index_name)
+        es_management_client.client.indices.exists.assert_awaited_with(
+            index=index_name, expand_wildcards="open"
+        )
 
     @pytest.mark.asyncio
     async def test_delete_indices(self):
@@ -265,5 +269,33 @@ class TestESManagementClient:
 
         await es_management_client.delete_indices(indices=indices)
         es_management_client.client.indices.delete.assert_awaited_with(
-            index=indices, ignore_unavailable=True
+            index=indices, expand_wildcards="open", ignore_unavailable=True
         )
+
+    @pytest.mark.asyncio
+    async def test_yield_existing_documents_metadata(self, mock_responses):
+        config = {
+            "username": "elastic",
+            "password": "changeme",
+            "host": "http://nowhere.com:9200",
+        }
+        es_management_client = ESManagementClient(config)
+        es_management_client.client = AsyncMock()
+        es_management_client.client.index_exists = Mock(return_value=True)
+
+        records = [
+            {"_id": "1", "_source": {"_timestamp": str(datetime.now())}},
+            {"_id": "2", "_source": {"_timestamp": str(datetime.now())}},
+        ]
+
+        with mock.patch(
+            "connectors.es.client.async_scan", return_value=AsyncIterator(records)
+        ):
+            ids = []
+            async for doc_id, _ in es_management_client.yield_existing_documents_metadata(
+                "something"
+            ):
+                ids.append(doc_id)
+
+            assert ids == ["1", "2"]
+        await es_management_client.close()

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -5,42 +5,159 @@
 #
 from datetime import datetime
 from unittest import mock
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
+import pytest_asyncio
+from elasticsearch import (
+    NotFoundError as ElasticNotFoundError,
+)
 
 from connectors.es.management_client import ESManagementClient
 from tests.commons import AsyncIterator
 
 
 class TestESManagementClient:
-    @pytest.mark.asyncio
-    async def test_index_exists(self):
+    @pytest_asyncio.fixture
+    def es_management_client(self):
         config = {
             "username": "elastic",
             "password": "changeme",
             "host": "http://nowhere.com:9200",
         }
-        index_name = "search-mongo"
         es_management_client = ESManagementClient(config)
-        es_management_client.client = Mock()
-        es_management_client.client.indices.exists = AsyncMock()
 
-        await es_management_client.index_exists(index_name=index_name)
-        es_management_client.client.indices.exists.assert_awaited_with(
+        es_management_client.client = AsyncMock()
+
+        yield es_management_client
+
+    @pytest.mark.asyncio
+    async def test_ensure_exists_when_no_indices_passed(self, es_management_client):
+        await es_management_client.ensure_exists()
+
+        es_management_client.client.indices.exists.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ensure_exists_when_indices_passed(self, es_management_client):
+        index_name = "search-mongo"
+        es_management_client.client.indices.exists.return_value = False
+
+        await es_management_client.ensure_exists([index_name])
+
+        es_management_client.client.indices.exists.assert_called_with(
             index=index_name, expand_wildcards="open"
+        )
+        es_management_client.client.indices.create.assert_called_with(index=index_name)
+
+    @pytest.mark.asyncio
+    async def test_create_content_index(self, es_management_client):
+        index_name = "search-mongo"
+        lang_code = "en"
+        await es_management_client.create_content_index(index_name, lang_code)
+
+        es_management_client.client.indices.create.assert_called_with(
+            index=index_name, mappings=ANY, settings=ANY
         )
 
     @pytest.mark.asyncio
-    async def test_delete_indices(self):
-        config = {
-            "username": "elastic",
-            "password": "changeme",
-            "host": "http://nowhere.com:9200",
+    async def test_ensure_content_index_mappings_when_mappings_exist(
+        self, es_management_client
+    ):
+        index_name = "something"
+        mappings = {}
+        existing_mappings_response = {index_name: {"mappings": ["something"]}}
+
+        es_management_client.client.indices.get_mapping = AsyncMock(
+            return_value=existing_mappings_response
+        )
+
+        await es_management_client.ensure_content_index_mappings(index_name, mappings)
+        es_management_client.client.indices.put_mapping.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ensure_content_index_mappings_when_mappings_do_not_exist(
+        self, es_management_client
+    ):
+        index_name = "something"
+        mappings = {
+            "dynamic": True,
+            "dynamic_templates": ["something"],
+            "properties": "something_else",
         }
+        existing_mappings_response = {index_name: {"mappings": {}}}
+
+        es_management_client.client.indices.get_mapping = AsyncMock(
+            return_value=existing_mappings_response
+        )
+
+        await es_management_client.ensure_content_index_mappings(index_name, mappings)
+        es_management_client.client.indices.put_mapping.assert_awaited_with(
+            index=index_name,
+            dynamic=mappings["dynamic"],
+            dynamic_templates=mappings["dynamic_templates"],
+            properties=mappings["properties"],
+            expand_wildcards=ANY,
+        )
+
+    @pytest.mark.asyncio
+    async def test_ensure_content_index_mappings_when_mappings_do_not_exist_but_no_mappings_provided(
+        self, es_management_client
+    ):
+        index_name = "something"
+        mappings = None
+        existing_mappings_response = {index_name: {"mappings": {}}}
+
+        es_management_client.client.indices.get_mapping = AsyncMock(
+            return_value=existing_mappings_response
+        )
+
+        await es_management_client.ensure_content_index_mappings(index_name, mappings)
+        es_management_client.client.indices.put_mapping.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ensure_ingest_pipeline_exists_when_pipeline_do_not_exist(
+        self, es_management_client
+    ):
+        pipeline_id = 1
+        version = 2
+        description = "that's a pipeline"
+        processors = ["something"]
+
+        es_management_client.client.ingest.get_pipeline.side_effect = (
+            ElasticNotFoundError("1", "2", "3")
+        )
+
+        await es_management_client.ensure_ingest_pipeline_exists(
+            pipeline_id, version, description, processors
+        )
+
+        es_management_client.client.ingest.put_pipeline.assert_awaited_with(
+            id=pipeline_id,
+            version=version,
+            description=description,
+            processors=processors,
+        )
+
+    @pytest.mark.asyncio
+    async def test_ensure_ingest_pipeline_exists_when_pipeline_exists(
+        self, es_management_client
+    ):
+        pipeline_id = 1
+        version = 2
+        description = "that's a pipeline"
+        processors = ["something"]
+
+        es_management_client.client.ingest.get_pipeline = AsyncMock()
+
+        await es_management_client.ensure_ingest_pipeline_exists(
+            pipeline_id, version, description, processors
+        )
+
+        es_management_client.client.ingest.put_pipeline.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_indices(self, es_management_client):
         indices = ["search-mongo"]
-        es_management_client = ESManagementClient(config)
-        es_management_client.client = Mock()
         es_management_client.client.indices.delete = AsyncMock()
 
         await es_management_client.delete_indices(indices=indices)
@@ -49,15 +166,78 @@ class TestESManagementClient:
         )
 
     @pytest.mark.asyncio
-    async def test_yield_existing_documents_metadata(self, mock_responses):
-        config = {
-            "username": "elastic",
-            "password": "changeme",
-            "host": "http://nowhere.com:9200",
-        }
-        es_management_client = ESManagementClient(config)
-        es_management_client.client = AsyncMock()
-        es_management_client.client.index_exists = Mock(return_value=True)
+    async def test_index_exists(self, es_management_client):
+        index_name = "search-mongo"
+        es_management_client.client.indices.exists = AsyncMock()
+
+        await es_management_client.index_exists(index_name=index_name)
+        es_management_client.client.indices.exists.assert_awaited_with(
+            index=index_name, expand_wildcards="open"
+        )
+
+    @pytest.mark.asyncio
+    async def test_clean_index(self, es_management_client):
+        index_name = "search-mongo"
+        es_management_client.client.indices.exists = AsyncMock()
+
+        await es_management_client.clean_index(index_name=index_name)
+        es_management_client.client.delete_by_query.assert_awaited_with(
+            index=index_name, body=ANY, ignore_unavailable=ANY
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_indices(self, es_management_client):
+        await es_management_client.list_indices()
+
+        es_management_client.client.indices.stats.assert_awaited_with(index="search-*")
+
+    @pytest.mark.asyncio
+    async def test_index_exists(self, es_management_client):
+        index_name = "search-mongo"
+        es_management_client.client.indices.exists = AsyncMock(return_value=True)
+
+        assert await es_management_client.index_exists(index_name=index_name) is True
+
+    @pytest.mark.asyncio
+    async def test_upsert(self, es_management_client):
+        _id = "123"
+        index_name = "search-mongo"
+        document = {"something": "something"}
+
+        await es_management_client.upsert(_id, index_name, document)
+
+        assert await es_management_client.client.index(
+            id=_id, index=index_name, doc=document
+        )
+
+    @pytest.mark.asyncio
+    async def test_yield_existing_documents_metadata_when_index_does_not_exist(
+        self, es_management_client, mock_responses
+    ):
+        es_management_client.index_exists = AsyncMock(return_value=False)
+
+        records = [
+            {"_id": "1", "_source": {"_timestamp": str(datetime.now())}},
+            {"_id": "2", "_source": {"_timestamp": str(datetime.now())}},
+        ]
+
+        with mock.patch(
+            "connectors.es.management_client.async_scan",
+            return_value=AsyncIterator(records),
+        ):
+            ids = []
+            async for doc_id, _ in es_management_client.yield_existing_documents_metadata(
+                "something"
+            ):
+                ids.append(doc_id)
+
+            assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_yield_existing_documents_metadata_when_index_exists(
+        self, es_management_client, mock_responses
+    ):
+        es_management_client.index_exists = AsyncMock(return_value=True)
 
         records = [
             {"_id": "1", "_source": {"_timestamp": str(datetime.now())}},
@@ -75,4 +255,3 @@ class TestESManagementClient:
                 ids.append(doc_id)
 
             assert ids == ["1", "2"]
-        await es_management_client.close()

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -1,0 +1,78 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+from datetime import datetime
+from unittest import mock
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from connectors.es.management_client import ESManagementClient
+from tests.commons import AsyncIterator
+
+
+class TestESManagementClient:
+    @pytest.mark.asyncio
+    async def test_index_exists(self):
+        config = {
+            "username": "elastic",
+            "password": "changeme",
+            "host": "http://nowhere.com:9200",
+        }
+        index_name = "search-mongo"
+        es_management_client = ESManagementClient(config)
+        es_management_client.client = Mock()
+        es_management_client.client.indices.exists = AsyncMock()
+
+        await es_management_client.index_exists(index_name=index_name)
+        es_management_client.client.indices.exists.assert_awaited_with(
+            index=index_name, expand_wildcards="open"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_indices(self):
+        config = {
+            "username": "elastic",
+            "password": "changeme",
+            "host": "http://nowhere.com:9200",
+        }
+        indices = ["search-mongo"]
+        es_management_client = ESManagementClient(config)
+        es_management_client.client = Mock()
+        es_management_client.client.indices.delete = AsyncMock()
+
+        await es_management_client.delete_indices(indices=indices)
+        es_management_client.client.indices.delete.assert_awaited_with(
+            index=indices, expand_wildcards="open", ignore_unavailable=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_yield_existing_documents_metadata(self, mock_responses):
+        config = {
+            "username": "elastic",
+            "password": "changeme",
+            "host": "http://nowhere.com:9200",
+        }
+        es_management_client = ESManagementClient(config)
+        es_management_client.client = AsyncMock()
+        es_management_client.client.index_exists = Mock(return_value=True)
+
+        records = [
+            {"_id": "1", "_source": {"_timestamp": str(datetime.now())}},
+            {"_id": "2", "_source": {"_timestamp": str(datetime.now())}},
+        ]
+
+        with mock.patch(
+            "connectors.es.management_client.async_scan",
+            return_value=AsyncIterator(records),
+        ):
+            ids = []
+            async for doc_id, _ in es_management_client.yield_existing_documents_metadata(
+                "something"
+            ):
+                ids.append(doc_id)
+
+            assert ids == ["1", "2"]
+        await es_management_client.close()

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -44,9 +44,7 @@ class TestESManagementClient:
 
         await es_management_client.ensure_exists([index_name])
 
-        es_management_client.client.indices.exists.assert_called_with(
-            index=index_name, expand_wildcards="open"
-        )
+        es_management_client.client.indices.exists.assert_called_with(index=index_name)
         es_management_client.client.indices.create.assert_called_with(index=index_name)
 
     @pytest.mark.asyncio
@@ -96,7 +94,6 @@ class TestESManagementClient:
             dynamic=mappings["dynamic"],
             dynamic_templates=mappings["dynamic_templates"],
             properties=mappings["properties"],
-            expand_wildcards=ANY,
         )
 
     @pytest.mark.asyncio
@@ -162,7 +159,7 @@ class TestESManagementClient:
 
         await es_management_client.delete_indices(indices=indices)
         es_management_client.client.indices.delete.assert_awaited_with(
-            index=indices, expand_wildcards="open", ignore_unavailable=True
+            index=indices, ignore_unavailable=True
         )
 
     @pytest.mark.asyncio
@@ -171,9 +168,7 @@ class TestESManagementClient:
         es_management_client.client.indices.exists = AsyncMock()
 
         await es_management_client.index_exists(index_name=index_name)
-        es_management_client.client.indices.exists.assert_awaited_with(
-            index=index_name, expand_wildcards="open"
-        )
+        es_management_client.client.indices.exists.assert_awaited_with(index=index_name)
 
     @pytest.mark.asyncio
     async def test_clean_index(self, es_management_client):

--- a/tests/services/test_job_cleanup.py
+++ b/tests/services/test_job_cleanup.py
@@ -47,7 +47,7 @@ def mock_sync_job(sync_job_id="1", connector_id="1", index_name="index_name"):
 
 @pytest.mark.asyncio
 @patch("connectors.protocol.SyncJobIndex.delete_jobs")
-@patch("connectors.es.client.ESManagementClient.delete_indices")
+@patch("connectors.es.management_client.ESManagementClient.delete_indices")
 @patch("connectors.protocol.SyncJobIndex.idle_jobs")
 @patch("connectors.protocol.SyncJobIndex.orphaned_jobs")
 @patch("connectors.protocol.ConnectorIndex.fetch_by_id")

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -20,7 +20,7 @@ from argparse import ArgumentParser
 from elastic_transport import ConnectionTimeout
 from elasticsearch import ApiError
 
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.logger import set_extra_logger
 from connectors.utils import (
     RetryStrategy,

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -454,7 +454,7 @@ def test_index_list_one_index():
     indices = {"indices": {"test_index": {"primaries": {"docs": {"count": 10}}}}}
 
     with patch(
-        "connectors.es.client.ESManagementClient.list_indices",
+        "connectors.es.management_client.ESManagementClient.list_indices",
         AsyncMock(return_value=indices),
     ):
         result = runner.invoke(cli, ["index", "list"])
@@ -468,7 +468,7 @@ def test_index_clean():
     runner = CliRunner()
     index_name = "test_index"
     with patch(
-        "connectors.es.client.ESManagementClient.clean_index",
+        "connectors.es.management_client.ESManagementClient.clean_index",
         AsyncMock(return_value=True),
     ) as mocked_method:
         result = runner.invoke(cli, ["index", "clean", index_name])
@@ -483,7 +483,7 @@ def test_index_clean_error():
     runner = CliRunner()
     index_name = "test_index"
     with patch(
-        "connectors.es.client.ESManagementClient.clean_index",
+        "connectors.es.management_client.ESManagementClient.clean_index",
         side_effect=ApiError(500, meta="meta", body="error"),
     ):
         result = runner.invoke(cli, ["index", "clean", index_name])
@@ -497,7 +497,7 @@ def test_index_delete():
     runner = CliRunner()
     index_name = "test_index"
     with patch(
-        "connectors.es.client.ESManagementClient.delete_indices",
+        "connectors.es.management_client.ESManagementClient.delete_indices",
         AsyncMock(return_value=None),
     ) as mocked_method:
         result = runner.invoke(cli, ["index", "delete", index_name])
@@ -512,7 +512,7 @@ def test_delete_index_error():
     runner = CliRunner()
     index_name = "test_index"
     with patch(
-        "connectors.es.client.ESManagementClient.delete_indices",
+        "connectors.es.management_client.ESManagementClient.delete_indices",
         side_effect=ApiError(500, meta="meta", body="error"),
     ):
         result = runner.invoke(cli, ["index", "delete", index_name])

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -17,17 +17,13 @@ FIXTURES_DIR = os.path.abspath(os.path.join(HERE, "fixtures"))
 
 def mock_index_creation(index, mock_responses, hidden=True):
     url = f"http://nowhere.com:9200/{index}"
-    if hidden:
-        url += "?expand_wildcards=hidden"
-    else:
-        url += "?expand_wildcards=open"
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.head(
         url,
         headers=headers,
     )
     mock_responses.delete(
-        f"{url}&ignore_unavailable=true",
+        f"{url}?ignore_unavailable=true",
         headers=headers,
     )
     mock_responses.put(
@@ -76,7 +72,7 @@ async def test_upsert_index(mock_responses):
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
     )
     mock_responses.head(
-        "http://nowhere.com:9200/search-new-index?expand_wildcards=open",
+        "http://nowhere.com:9200/search-new-index",
         headers=headers,
         status=404,
     )
@@ -91,11 +87,11 @@ async def test_upsert_index(mock_responses):
     await upsert_index(es, "search-new-index")
 
     mock_responses.head(
-        "http://nowhere.com:9200/search-new-index?expand_wildcards=open",
+        "http://nowhere.com:9200/search-new-index",
         headers=headers,
     )
     mock_responses.delete(
-        "http://nowhere.com:9200/search-new-index?expand_wildcards=open&ignore_unavailable=true",
+        "http://nowhere.com:9200/search-new-index?ignore_unavailable=true",
         headers=headers,
     )
     mock_responses.put(

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.kibana import main, upsert_index
 
 HERE = os.path.dirname(__file__)

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 
-from connectors.es.sink import SyncOrchestrator
+from connectors.es.client import ESManagementClient
 from connectors.kibana import main, upsert_index
 
 HERE = os.path.dirname(__file__)
@@ -27,7 +27,7 @@ def mock_index_creation(index, mock_responses, hidden=True):
         headers=headers,
     )
     mock_responses.delete(
-        url,
+        f"{url}&ignore_unavailable=true",
         headers=headers,
     )
     mock_responses.put(
@@ -86,7 +86,7 @@ async def test_upsert_index(mock_responses):
         headers=headers,
     )
 
-    es = SyncOrchestrator(config)
+    es = ESManagementClient(config)
 
     await upsert_index(es, "search-new-index")
 
@@ -95,7 +95,7 @@ async def test_upsert_index(mock_responses):
         headers=headers,
     )
     mock_responses.delete(
-        "http://nowhere.com:9200/search-new-index?expand_wildcards=open",
+        "http://nowhere.com:9200/search-new-index?expand_wildcards=open&ignore_unavailable=true",
         headers=headers,
     )
     mock_responses.put(
@@ -114,4 +114,4 @@ async def test_upsert_index(mock_responses):
         headers=headers,
     )
 
-    await upsert_index(es, "search-new-index", docs=[{"_id": "2"}, {"_id": "3"}])
+    await upsert_index(es, "search-new-index")

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -38,9 +38,7 @@ def mock_es_info(mock_responses, healthy=True, repeat=False):
 
 def mock_index_exists(mock_responses, index, exist=True, repeat=False):
     status = 200 if exist else 404
-    mock_responses.head(
-        f"{host}/{index}?expand_wildcards=all", status=status, repeat=repeat
-    )
+    mock_responses.head(f"{host}/{index}", status=status, repeat=repeat)
 
 
 def mock_index(mock_responses, index, doc_id, repeat=False):

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -38,7 +38,9 @@ def mock_es_info(mock_responses, healthy=True, repeat=False):
 
 def mock_index_exists(mock_responses, index, exist=True, repeat=False):
     status = 200 if exist else 404
-    mock_responses.head(f"{host}/{index}", status=status, repeat=repeat)
+    mock_responses.head(
+        f"{host}/{index}?expand_wildcards=all", status=status, repeat=repeat
+    )
 
 
 def mock_index(mock_responses, index, doc_id, repeat=False):

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -60,7 +60,7 @@ async def test_prepare_content_index_raise_error_when_index_creation_failed(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
     )
     mock_responses.head(
-        f"http://nowhere.com:9200/{index_name}?expand_wildcards=open",
+        f"http://nowhere.com:9200/{index_name}",
         headers=headers,
         status=404,
     )
@@ -90,7 +90,7 @@ async def test_prepare_content_index_create_index(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
     )
     mock_responses.head(
-        f"http://nowhere.com:9200/{index_name}?expand_wildcards=open",
+        f"http://nowhere.com:9200/{index_name}",
         headers=headers,
         status=404,
     )
@@ -126,16 +126,16 @@ async def test_prepare_content_index(mock_responses):
     mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
 
     mock_responses.head(
-        "http://nowhere.com:9200/search-new-index?expand_wildcards=open",
+        "http://nowhere.com:9200/search-new-index",
         headers=headers,
     )
     mock_responses.get(
-        "http://nowhere.com:9200/search-new-index/_mapping?expand_wildcards=open",
+        "http://nowhere.com:9200/search-new-index/_mapping",
         headers=headers,
         payload={"search-new-index": {"mappings": {}}},
     )
     mock_responses.put(
-        "http://nowhere.com:9200/search-new-index/_mapping?expand_wildcards=open",
+        "http://nowhere.com:9200/search-new-index/_mapping",
         headers=headers,
         payload=mappings,
         body='{"acknowledged": True}',
@@ -159,7 +159,7 @@ def set_responses(mock_responses, ts=None):
         ts = datetime.datetime.now().isoformat()
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.head(
-        "http://nowhere.com:9200/search-some-index?expand_wildcards=open",
+        "http://nowhere.com:9200/search-some-index",
         headers=headers,
     )
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -14,7 +14,7 @@ import pytest
 from elasticsearch import BadRequestError
 
 from connectors.es import Mappings
-from connectors.es.client import ESManagementClient
+from connectors.es.management_client import ESManagementClient
 from connectors.es.sink import (
     OP_DELETE,
     OP_INDEX,
@@ -625,7 +625,9 @@ async def setup_extractor(
         ),
     ],
 )
-@mock.patch("connectors.es.client.ESManagementClient.yield_existing_documents_metadata")
+@mock.patch(
+    "connectors.es.management_client.ESManagementClient.yield_existing_documents_metadata"
+)
 @pytest.mark.asyncio
 async def test_get_docs(
     yield_existing_documents_metadata,
@@ -919,7 +921,9 @@ async def test_get_docs_incrementally(
         ),
     ],
 )
-@mock.patch("connectors.es.client.ESManagementClient.yield_existing_documents_metadata")
+@mock.patch(
+    "connectors.es.management_client.ESManagementClient.yield_existing_documents_metadata"
+)
 @pytest.mark.asyncio
 async def test_get_access_control_docs(
     yield_existing_documents_metadata,

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -14,7 +14,7 @@ import pytest
 from elasticsearch import BadRequestError
 
 from connectors.es import Mappings
-from connectors.es.settings import Settings
+from connectors.es.client import ESManagementClient
 from connectors.es.sink import (
     OP_DELETE,
     OP_INDEX,
@@ -68,19 +68,14 @@ async def test_prepare_content_index_raise_error_when_index_creation_failed(
         f"http://nowhere.com:9200/{index_name}",
         payload={"_id": "1"},
         headers=headers,
+        status=400,
     )
 
     es = SyncOrchestrator(config)
 
-    with mock.patch.object(
-        es.client.indices,
-        "create",
-        side_effect=[BadRequestError(message="test", body=None, meta=None)],
-    ):
-        with pytest.raises(BadRequestError):
-            await es.prepare_content_index(index_name)
-
-        await es.close()
+    with pytest.raises(BadRequestError):
+        await es.prepare_content_index(index_name)
+    await es.close()
 
 
 @pytest.mark.asyncio
@@ -88,6 +83,7 @@ async def test_prepare_content_index_create_index(
     mock_responses,
 ):
     index_name = "search-new-index"
+    language_code = "jp"
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     headers = {"X-Elastic-Product": "Elasticsearch"}
     mock_responses.post(
@@ -109,24 +105,16 @@ async def test_prepare_content_index_create_index(
     create_index_result = asyncio.Future()
     create_index_result.set_result({"acknowledged": True})
 
-    mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
-
-    settings = Settings(analysis_icu=False).to_hash()
-
     with mock.patch.object(
-        es.client.indices, "create", return_value=create_index_result
+        es.es_management_client,
+        "create_content_index",
+        return_value=create_index_result,
     ) as create_index_mock:
-        await es.prepare_content_index(index_name)
+        await es.prepare_content_index(index_name, language_code)
 
         await es.close()
 
-        expected_params = {
-            "index": index_name,
-            "mappings": mappings,
-            "settings": settings,
-        }
-
-        create_index_mock.assert_called_with(**expected_params)
+        create_index_mock.assert_called_with(index_name, language_code)
 
 
 @pytest.mark.asyncio
@@ -150,30 +138,20 @@ async def test_prepare_content_index(mock_responses):
         "http://nowhere.com:9200/search-new-index/_mapping?expand_wildcards=open",
         headers=headers,
         payload=mappings,
+        body='{"acknowledged": True}',
     )
 
     es = SyncOrchestrator(config)
-    put_mappings_result = asyncio.Future()
-    put_mappings_result.set_result({"acknowledged": True})
+    index_name = "search-new-index"
     with mock.patch.object(
-        es.client.indices,
-        "put_mapping",
-        return_value=put_mappings_result,
+        es.es_management_client,
+        "ensure_content_index_mappings",
     ) as put_mapping_mock:
-        index_name = "search-new-index"
         await es.prepare_content_index(index_name)
 
         await es.close()
 
-        expected_params = {
-            "index": index_name,
-            "dynamic": mappings["dynamic"],
-            "dynamic_templates": mappings["dynamic_templates"],
-            "properties": mappings["properties"],
-            "expand_wildcards": "open",
-        }
-
-        put_mapping_mock.assert_called_with(**expected_params)
+        put_mapping_mock.assert_called_with(index_name, mappings)
 
 
 def set_responses(mock_responses, ts=None):
@@ -255,21 +233,6 @@ def set_responses(mock_responses, ts=None):
         },
         headers=headers,
     )
-
-
-@pytest.mark.asyncio
-async def test_get_existing_ids(mock_responses):
-    config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
-    set_responses(mock_responses)
-
-    es = SyncOrchestrator(config)
-    extractor = Extractor(es.client, None, "search-some-index")
-    ids = []
-    async for doc_id, _ in extractor._get_existing_ids():
-        ids.append(doc_id)
-
-    assert ids == ["1", "2"]
-    await es.close()
 
 
 @pytest.mark.asyncio
@@ -413,11 +376,16 @@ async def setup_extractor(
     sync_rules_enabled=False,
     content_extraction_enabled=False,
 ):
+    config = {
+        "username": "elastic",
+        "password": "changeme",
+        "host": "http://nowhere.com:9200",
+    }
     # filtering content doesn't matter as the BasicRuleEngine behavior is mocked
     filter_mock = Mock()
     filter_mock.get_active_filter = Mock(return_value={})
     extractor = Extractor(
-        None,
+        ESManagementClient(config),
         queue,
         INDEX,
         filter_=filter_mock,
@@ -657,10 +625,10 @@ async def setup_extractor(
         ),
     ],
 )
-@mock.patch("connectors.es.sink.Extractor._get_existing_ids")
+@mock.patch("connectors.es.client.ESManagementClient.yield_existing_documents_metadata")
 @pytest.mark.asyncio
 async def test_get_docs(
-    get_existing_ids,
+    yield_existing_documents_metadata,
     existing_docs,
     docs_from_source,
     doc_should_ingest,
@@ -674,7 +642,7 @@ async def test_get_docs(
 ):
     lazy_downloads = await lazy_downloads_mock()
 
-    get_existing_ids.return_value = AsyncIterator(
+    yield_existing_documents_metadata.return_value = AsyncIterator(
         [(doc["_id"], doc["_timestamp"]) for doc in existing_docs]
     )
 
@@ -951,10 +919,10 @@ async def test_get_docs_incrementally(
         ),
     ],
 )
-@mock.patch("connectors.es.sink.Extractor._get_existing_ids")
+@mock.patch("connectors.es.client.ESManagementClient.yield_existing_documents_metadata")
 @pytest.mark.asyncio
 async def test_get_access_control_docs(
-    get_existing_ids,
+    yield_existing_documents_metadata,
     existing_docs,
     docs_from_source,
     expected_queue_operations,
@@ -962,7 +930,7 @@ async def test_get_access_control_docs(
     expected_total_docs_created,
     expected_total_docs_deleted,
 ):
-    get_existing_ids.return_value = AsyncIterator(
+    yield_existing_documents_metadata.return_value = AsyncIterator(
         [(doc["_id"], doc["_timestamp"]) for doc in existing_docs]
     )
 
@@ -1084,7 +1052,13 @@ def test_bulk_populate_stats(res, expected_result):
 
 @pytest.mark.asyncio
 async def test_batch_bulk_with_retry():
-    client = Mock()
+    config = {
+        "username": "elastic",
+        "password": "changeme",
+        "host": "http://nowhere.com:9200",
+    }
+    client = ESManagementClient(config)
+    client.client = AsyncMock()
     sink = Sink(
         client=client,
         queue=None,
@@ -1097,10 +1071,10 @@ async def test_batch_bulk_with_retry():
 
     with mock.patch.object(asyncio, "sleep"):
         # first call raises exception, and the second call succeeds
-        client.bulk = AsyncMock(side_effect=[Exception(), {"items": []}])
+        client.client.bulk = AsyncMock(side_effect=[Exception(), {"items": []}])
         await sink._batch_bulk([], {OP_INDEX: {}, OP_UPSERT: {}, OP_DELETE: {}})
 
-        assert client.bulk.await_count == 2
+        assert client.client.bulk.await_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -158,6 +158,11 @@ def set_responses(mock_responses, ts=None):
     if ts is None:
         ts = datetime.datetime.now().isoformat()
     headers = {"X-Elastic-Product": "Elasticsearch"}
+    mock_responses.head(
+        "http://nowhere.com:9200/search-some-index?expand_wildcards=open",
+        headers=headers,
+    )
+
     mock_responses.get(
         "http://nowhere.com:9200/search-some-index",
         payload={"_id": "1"},


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6412

This PR changes more places to use rich Elasticsearch clients instead of direct calls to python Elasticsearch client.

Example methods that were introduced or changed with this PR:
- `ESManagementClient.ensure_exists` method got "expand_wildcards" argument that's default to `open` - some places use "all", but most of the places use "open". "open" is also more conservative, thus the choice
- `ESManagementClient.create_content_index` - new method to create content index. Normally kibana does it, but in some cases (mostly CI or CLI) we wanna create the index ourselves. _This method is just extracted from the original place that was calling non-rich Elasticsearch client with no changes_
- `ESManagementClient.ensure_content_index_mappings` - new method to ensure that content index has our search mappings. _This method is just extracted from the original place that was calling non-rich Elasticsearch client with no changes_
- `ESManagementClient.ensure_ingest_pipeline_exists` - new method to ensure that ingest pipeline with provided id exists, if not it's created with provided arguments. Used by `kibana.py`. _This method is just extracted from the original place that was calling non-rich Elasticsearch client with no changes_
- `ESManagementClient.delete_indices` - new method to delete indices. Used by `kibana.py`. _This method is just extracted from the original place that was calling non-rich Elasticsearch client with no changes_
- `ESManagementClient.upsert` - new method to upsert a record into target index. Used by `kibana.py`. _This method is just extracted from the original place that was calling non-rich Elasticsearch client with no changes_
- `ESManagementClient.yield_existing_documents_metadata` - formely `Extractor._get_existing_ids`

There is still one change I haven't moved - it's call to `bulk`, I will address it in later PR(s).

All other changes faciliate the changes outlined above.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
