### PR TITLE
Update aiohttp to latest

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.6
+aiohttp==3.9.0
 aiofiles==23.2.1
 elasticsearch[async]==8.8.0
 elastic-transport==8.4.0

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,4 +1,4 @@
-aiohttp==3.9.0
+aiohttp==3.9.1
 aiofiles==23.2.1
 elasticsearch[async]==8.8.0
 elastic-transport==8.4.0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,7 +1,7 @@
 # tests
 black==23.7.0
 ruff==0.0.278
-aioresponses==0.7.4
+aioresponses==0.7.6
 pytest==7.4.0
 pytest-cov==4.1.0
 pytest-asyncio==0.21.1


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1939

Updating aiohttp to 3.9.0 + updating aioresponses to 0.7.6 - aioresponses is used for mocking aiohttp server responses and current version is not compatible with new aiohttp.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)