### PR TITLE
Update Elasticsearch client to 8.11

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,7 +1,7 @@
 aiohttp==3.8.6
 aiofiles==23.2.1
-elasticsearch[async]==8.8.0
-elastic-transport==8.4.0
+elasticsearch[async]==8.11.1
+elastic-transport==8.11.0
 pyyaml==6.0
 envyaml==1.10.211231
 ecs-logging==2.0.0


### PR DESCRIPTION
This PR updates `elasticsearch` client to latest + updates `elastic-transport` to latest