### PR TITLE
Make mongodb work without admin privelege

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -270,8 +270,9 @@ class MongoDataSource(BaseDataSource):
             )
             return
         except OperationFailure:
-            self._logger.warning(f"Unable to access '{configured_database_name}.{configured_collection_name}' as user '{user}'")
-
+            self._logger.warning(
+                f"Unable to access '{configured_database_name}.{configured_collection_name}' as user '{user}'"
+            )
 
         # If it's not accessible, try to make a good user-friendly error message
         try:

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -265,7 +265,9 @@ class MongoDataSource(BaseDataSource):
         collection_valid = True
 
         try:
-            await client[configured_database_name].validate_collection(configured_collection_name)
+            await client[configured_database_name].validate_collection(
+                configured_collection_name
+            )
         except OperationFailure:  # If the collection doesn't exist
             collection_valid = False
 
@@ -292,9 +294,8 @@ class MongoDataSource(BaseDataSource):
             if configured_collection_name not in existing_collection_names:
                 msg = f"Collection '{configured_collection_name}' does not exist within database '{configured_database_name}'. Existing collections: {', '.join(existing_collection_names)}"
                 raise ConfigurableFieldValueError(msg)
-        except OperationFailure:
-                user = self.configuration["user"]
+        except OperationFailure as e:
+            user = self.configuration["user"]
             # This happens if the user has no access to operations to list collection/database names
-                msg = f"Database '{configured_database_name}' or collection '{configured_collection_name}' is not accessible by user '{user}'. Verify that these database and collection exist, and specified user has access to it"
-                raise ConfigurableFieldValueError(msg)
-
+            msg = f"Database '{configured_database_name}' or collection '{configured_collection_name}' is not accessible by user '{user}'. Verify that these database and collection exist, and specified user has access to it"
+            raise ConfigurableFieldValueError(msg) from e

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -258,22 +258,20 @@ class MongoDataSource(BaseDataSource):
 
         client = self.client
 
+        user = self.configuration["user"]
         configured_database_name = self.configuration["database"]
         configured_collection_name = self.configuration["collection"]
 
         # First check if collection is accessible
-        collection_valid = True
-
         try:
             # This works on both standalone and Managed mongo in the same way
             await client[configured_database_name].validate_collection(
                 configured_collection_name
             )
-        except OperationFailure:
-            collection_valid = False
-
-        if collection_valid:
             return
+        except OperationFailure:
+            self._logger.warning(f"Unable to access '{configured_database_name}.{configured_collection_name}' as user '{user}'")
+
 
         # If it's not accessible, try to make a good user-friendly error message
         try:
@@ -302,6 +300,5 @@ class MongoDataSource(BaseDataSource):
             # This happens if the user has no access to operations to list collection/database names
             # Managed MongoDB never gets here, but if we're running against a standalone mongo
             # Then this code can trigger
-            user = self.configuration["user"]
             msg = f"Database '{configured_database_name}' or collection '{configured_collection_name}' is not accessible by user '{user}'. Verify that these database and collection exist, and specified user has access to it"
             raise ConfigurableFieldValueError(msg) from e

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -261,7 +261,13 @@ def future_with_result(result):
 
 
 @pytest.mark.asyncio
-async def test_validate_config_when_database_name_invalid_then_raises_exception():
+@mock.patch(
+    "motor.motor_asyncio.AsyncIOMotorDatabase.validate_collection",
+    side_effect=OperationFailure("Unauthorized"),
+)
+async def test_validate_config_when_database_name_invalid_then_raises_exception(
+    patch_validate_collection,
+):
     server_database_names = ["hello", "world"]
     configured_database_name = "something"
 
@@ -283,7 +289,13 @@ async def test_validate_config_when_database_name_invalid_then_raises_exception(
 
 
 @pytest.mark.asyncio
-async def test_validate_config_when_collection_name_invalid_then_raises_exception():
+@mock.patch(
+    "motor.motor_asyncio.AsyncIOMotorDatabase.validate_collection",
+    side_effect=OperationFailure("Unauthorized"),
+)
+async def test_validate_config_when_collection_name_invalid_then_raises_exception(
+    patch_validate_collection,
+):
     server_database_names = ["hello"]
     server_collection_names = ["first", "second"]
     configured_database_name = "hello"


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1922

This PR makes it possible to use MongoDB connector with user that has _only_ privilege to read from a collection.

Before this PR, privileges to list databases/collections was also needed.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

#### Changes Requiring Extra Attention

Validation logic got more complex and I feel that it can be simplified.

What we do now in steps:

1. Check if collection is accessible by current user
2. If it is, validation is successful
3. If not, try to read list of databases and collections and show the user available dbs/collections in UI
4. If any of operations in 3. fail, we display a message that user has no access to the collection/database and they manually need to ensure that these collection, database exist and user has access to them

Is it getting too complex?

We can safely drop steps 3/4 and always show validation error without availables dbs/collections, code gets much much simpler, but UI gets less user friendly. Would it be worth to delete the code in 3 and 4 to make connector simpler?