### PR TITLE
Make bin/connectors index without arguments output help

### DIFF
--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -336,7 +336,7 @@ cli.add_command(connector)
 
 
 # Index group
-@click.group(invoke_without_command=True, help="Search indices management")
+@click.group(invoke_without_command=False, help="Search indices management")
 @click.pass_obj
 def index(obj):
     pass


### PR DESCRIPTION
Minor fix:

Calling `bin/connectors index` outputs nothing for me:

```
artemshelkovnikov-m2@Work-M2 connectors-py % bin/connectors index
artemshelkovnikov-m2@Work-M2 connectors-py %
```

With this change, it will display help for `index` command exactly in same way it does it for job/connector:

```
artemshelkovnikov-m2@Work-M2 connectors-py % bin/connectors index
Usage: connectors index [OPTIONS] COMMAND [ARGS]...

  Search indices management

Options:
  --help  Show this message and exit.

Commands:
  clean   Remove all documents from the index
  delete  Delete an index
  list    Show all indices
```