### PR TITLE
Make clean_index method proceed on conflicts

### DIFF
--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -72,6 +72,7 @@ class ESIndex(ESClient):
             index=self.index_name,
             body={"query": {"match_all": {}}},
             ignore_unavailable=True,
+            conflicts="proceed"
         )
 
     async def update(self, doc_id, doc, if_seq_no=None, if_primary_term=None):

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -72,7 +72,7 @@ class ESIndex(ESClient):
             index=self.index_name,
             body={"query": {"match_all": {}}},
             ignore_unavailable=True,
-            conflicts="proceed"
+            conflicts="proceed",
         )
 
     async def update(self, doc_id, doc, if_seq_no=None, if_primary_term=None):


### PR DESCRIPTION
Minor improvement for `clean_index` - added `conflicts=proceed` to not fail the cleaning of the index if conflicts happened during clearing.

Normally conflicts can happen if document was updated while the delete_by_query is executed (this includes ingest pipelines updating a document after it was ingested)