### PR TITLE
Raise an error if our ES client fails to execute a _search

### DIFF
--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -123,9 +123,11 @@ class ESIndex(ESClient):
                     seq_no_primary_term=True,
                 )
             except ApiError as e:
-                logger.critical(f"The server returned {e.status_code}")
-                logger.critical(e.body, exc_info=True)
-                return
+                logger.error(
+                    f"Elasticsearch returned {e.status_code} for 'GET {self.index_name}/_search' with body:"
+                )
+                logger.error(e.body, exc_info=True)
+                raise
 
             hits = resp["hits"]["hits"]
             total = resp["hits"]["total"]["value"]


### PR DESCRIPTION
## related to https://github.com/elastic/enterprise-search-team/issues/6075

We have a theory that we've been hitting some bugs when ES is unhealthy and returns non-200 responses for `_search` requests. This PR changes our client behavior to raise the ApiError if we hit one, instead of implicitly returning an empty result set for the executed search.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)


## Related Pull Requests

- see also: https://github.com/elastic/connectors/pull/2038

## Release Note

Fixes a bug where Elasticsearch health issues might be passed over. Previously, if Elasticsearch returned a 500 error when connectors executed a `_search`, this error was not propagated correctly.