### PR TITLE
Mark orphaned idle sync jobs as error

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -1043,8 +1043,22 @@ class SyncJobIndex(ESIndex):
         async for job in self.get_all_docs(query=query, sort=sort):
             yield job
 
-    async def orphaned_jobs(self, connector_ids):
-        query = {"bool": {"must_not": {"terms": {"connector.id": connector_ids}}}}
+    async def orphaned_idle_jobs(self, connector_ids):
+        query = {
+            "bool": {
+                "must_not": {"terms": {"connector.id": connector_ids}},
+                "filter": [
+                    {
+                        "terms": {
+                            "status": [
+                                JobStatus.IN_PROGRESS.value,
+                                JobStatus.CANCELING.value,
+                            ]
+                        }
+                    }
+                ],
+            }
+        }
         async for job in self.get_all_docs(query=query):
             yield job
 
@@ -1068,7 +1082,3 @@ class SyncJobIndex(ESIndex):
 
         async for job in self.get_all_docs(query=query):
             yield job
-
-    async def delete_jobs(self, job_ids):
-        query = {"terms": {"_id": job_ids}}
-        return await self.client.delete_by_query(index=self.index_name, query=query)

--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -33,7 +33,7 @@ class JobCleanUpService(BaseService):
 
         try:
             while self.running:
-                await self._process_orphaned_jobs()
+                await self._process_orphaned_idle_jobs()
                 await self._process_idle_jobs()
                 await self._sleeps.sleep(self.idling)
         finally:
@@ -45,38 +45,34 @@ class JobCleanUpService(BaseService):
                 await self.sync_job_index.close()
         return 0
 
-    async def _process_orphaned_jobs(self):
+    async def _process_orphaned_idle_jobs(self):
         try:
-            logger.debug("Cleaning up orphaned jobs")
-            connector_ids = []
-            existing_content_indices = set()
-            async for connector in self.connector_index.all_connectors():
-                if connector.index_name is not None:
-                    existing_content_indices.add(connector.index_name)
-                connector_ids.append(connector.id)
+            logger.debug("Cleaning up orphaned idle jobs")
+            connector_ids = [
+                connector.id
+                async for connector in self.connector_index.all_connectors()
+            ]
 
-            content_indices = set()
-            job_ids = []
-            async for job in self.sync_job_index.orphaned_jobs(
+            marked_count = total_count = 0
+            async for job in self.sync_job_index.orphaned_idle_jobs(
                 connector_ids=connector_ids
             ):
-                if (
-                    job.index_name is not None
-                    and job.index_name not in existing_content_indices
-                ):
-                    content_indices.add(job.index_name)
-                job_ids.append(job.id)
+                try:
+                    await job.fail(IDLE_JOB_ERROR)
+                    marked_count += 1
+                except Exception as e:
+                    logger.error(
+                        f"Failed to mark orphaned idle job #{job.id} as error: {e}"
+                    )
+                finally:
+                    total_count += 1
 
-            if len(job_ids) == 0:
-                logger.debug("No orphaned jobs found, skipping cleaning")
-                return
-
-            result = await self.sync_job_index.delete_jobs(job_ids=job_ids)
-            if len(result["failures"]) > 0:
-                logger.error(f"Error found when deleting jobs: {result['failures']}")
-            logger.info(
-                f"Successfully deleted {result['deleted']} out of {result['total']} orphaned jobs"
-            )
+            if total_count == 0:
+                logger.debug("No orphaned idle jobs found. Skipping...")
+            else:
+                logger.info(
+                    f"Successfully marked #{marked_count} out of #{total_count} orphaned idle jobs as error."
+                )
         except Exception as e:
             logger.critical(e, exc_info=True)
             self.raise_if_spurious(e)

--- a/tests/services/test_job_cleanup.py
+++ b/tests/services/test_job_cleanup.py
@@ -27,28 +27,28 @@ CONFIG = {
 }
 
 
-def mock_connector(connector_id="1", index_name="index_name"):
+def mock_connector(connector_id="1"):
     connector = Mock()
     connector.id = connector_id
-    connector.index_name = index_name
     connector.sync_done = AsyncMock()
     return connector
 
 
-def mock_sync_job(sync_job_id="1", connector_id="1", index_name="index_name"):
+def mock_sync_job(
+    sync_job_id="1",
+    connector_id="1",
+):
     job = Mock()
     job.job_id = sync_job_id
     job.connector_id = connector_id
-    job.index_name = index_name
     job.fail = AsyncMock()
     job.reload = AsyncMock()
     return job
 
 
 @pytest.mark.asyncio
-@patch("connectors.protocol.SyncJobIndex.delete_jobs")
 @patch("connectors.protocol.SyncJobIndex.idle_jobs")
-@patch("connectors.protocol.SyncJobIndex.orphaned_jobs")
+@patch("connectors.protocol.SyncJobIndex.orphaned_idle_jobs")
 @patch("connectors.protocol.ConnectorIndex.fetch_by_id")
 @patch("connectors.protocol.ConnectorIndex.supported_connectors")
 @patch("connectors.protocol.ConnectorIndex.all_connectors")
@@ -56,25 +56,21 @@ async def test_cleanup_jobs(
     all_connectors,
     supported_connectors,
     connector_fetch_by_id,
-    orphaned_jobs,
+    orphaned_idle_jobs,
     idle_jobs,
-    delete_jobs,
 ):
-    existing_index_name = "foo"
-    to_be_deleted_index_name = "bar"
-    connector = mock_connector(index_name=existing_index_name)
-    sync_job = mock_sync_job(index_name=to_be_deleted_index_name)
-    another_sync_job = mock_sync_job(index_name=existing_index_name)
+    connector = mock_connector()
+    orphaned_idle_sync_job = mock_sync_job()
+    idle_sync_job = mock_sync_job()
 
     all_connectors.return_value = AsyncIterator([connector])
     supported_connectors.return_value = AsyncIterator([connector])
     connector_fetch_by_id.return_value = connector
-    orphaned_jobs.return_value = AsyncIterator([sync_job, another_sync_job])
-    idle_jobs.return_value = AsyncIterator([sync_job])
-    delete_jobs.return_value = {"deleted": 1, "failures": [], "total": 1}
+    orphaned_idle_jobs.return_value = AsyncIterator([orphaned_idle_sync_job])
+    idle_jobs.return_value = AsyncIterator([idle_sync_job])
 
     await create_and_run_service(JobCleanUpService, config=CONFIG, stop_after=0.1)
 
-    delete_jobs.assert_called_with(job_ids=[sync_job.id, another_sync_job.id])
-    sync_job.fail.assert_called_with(IDLE_JOB_ERROR)
-    connector.sync_done.assert_called_with(job=sync_job)
+    orphaned_idle_sync_job.fail.assert_called_with(IDLE_JOB_ERROR)
+    idle_sync_job.fail.assert_called_with(IDLE_JOB_ERROR)
+    connector.sync_done.assert_called_with(job=idle_sync_job)


### PR DESCRIPTION
### What's the change

Instead of deleting orphaned jobs, this PR tries to mark those orphaned (i.e. sync jobs with deleted connectors) idle (sync jobs seeing no update for more than 1 min) sync jobs as `error`.

### Why the change

When a customer deletes a connector in Kibana, it will not delete all the associated sync jobs. Those orphaned sync jobs are kept for audit purporse. If the orphaned sync jobs are idle, we will mark them as `error`

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)