### PR TITLE
Revert Changes to Connectors CLI Config Loading and Use Separate Configuration for Stack Scripts

### DIFF
--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -24,7 +24,6 @@ from connectors.cli.connector import Connector
 from connectors.cli.index import Index
 from connectors.cli.job import Job
 from connectors.config import _default_config
-from connectors.config import load_config as configuration_loader
 from connectors.es.settings import Settings
 
 __all__ = ["main"]
@@ -32,7 +31,7 @@ __all__ = ["main"]
 
 def load_config(ctx, config):
     if config:
-        return configuration_loader(config.name)
+        return yaml.safe_load(config)
     elif os.path.isfile(CONFIG_FILE_PATH):
         with open(CONFIG_FILE_PATH, "r") as f:
             return yaml.safe_load(f.read())

--- a/scripts/stack/README.md
+++ b/scripts/stack/README.md
@@ -52,6 +52,10 @@ ELASTICSEARCH_VERSION=8.11.2 KIBANA_VERSION=8.11.2 CONNECTORS_VERSION=8.11.2.0 .
 
 Once the stack is running, you can monitor the logs from the Connectors instance by running:
 ```bash
+./scripts/stack/view-connectors-logs.sh
+```
+or:
+```bash
 docker-compose -f ./scripts/stack/docker/docker-compose.yml logs -f elastic-connectors
 ```
 

--- a/scripts/stack/configure-connectors.sh
+++ b/scripts/stack/configure-connectors.sh
@@ -22,6 +22,18 @@ pushd $PROJECT_ROOT
     if [[ "${CONFIG_FILE:-}" == "" ]]; then
         CONFIG_FILE="${PROJECT_ROOT}/scripts/stack/connectors-config/config.yml"
     fi
+    CLI_CONFIG="${PROJECT_ROOT}/scripts/stack/connectors-config/cli_config.yml"
+
+    # ensure our Connectors CLI config exists and has the correct information
+    if [ ! -f "$CLI_CONFIG" ]; then
+        cliConfigText='
+elasticsearch:
+    host: http://localhost:9200
+    password: '"${ELASTIC_PASSWORD}"'
+    username: elastic
+'
+        echo "${cliConfigText}" > "$CLI_CONFIG"
+    fi
 
     CONNECTORS_EXE="${PROJECT_ROOT}/bin/connectors"
     if [ ! -f "$CONNECTORS_EXE" ]; then
@@ -39,7 +51,7 @@ pushd $PROJECT_ROOT
     while [ $keep_configuring == true ]; do
         echo
         echo "Currently configured connectors:"
-        $CONNECTORS_EXE --config "$CONFIG_FILE" connector list
+        $CONNECTORS_EXE --config "$CLI_CONFIG" connector list
         echo
         while true; do
             read -p "Do you want to set up a new connector? (y/N) " yn
@@ -51,7 +63,7 @@ pushd $PROJECT_ROOT
         done
 
         if [ $keep_configuring == true ]; then
-            $CONNECTORS_EXE --config "${CONFIG_FILE}" connector create --connector-service-config "$CONFIG_FILE" --update-config
+            $CONNECTORS_EXE --config "${CLI_CONFIG}" connector create --connector-service-config "$CONFIG_FILE" --update-config
         fi
     done
 popd

--- a/scripts/stack/copy-config.sh
+++ b/scripts/stack/copy-config.sh
@@ -26,6 +26,7 @@ cp "$CONFIG_PATH" "$script_config"
 echo "copied config from $CONFIG_PATH to $config_dir"
 
 if [[ "$is_example_config" == true ]]; then
+    export CONFIG_FILE="$script_config"
     sed_cmd="sed -i"
     if [[ "$MACHINE_OS" == "MacOS" || "$MACHINE_OS" == "FreeBSD" ]]; then
         sed_cmd="sed -i -e"

--- a/scripts/stack/run-stack.sh
+++ b/scripts/stack/run-stack.sh
@@ -51,7 +51,7 @@ if [[ "${bypass_config:-}" == false ]]; then
   done
   if [ $run_configurator == "yes" ]; then
     source ./copy-config.sh
-    source ./configure-connectors.sh $SECURE_STATE_DIR
+    source ./configure-connectors.sh
   fi
 fi
 


### PR DESCRIPTION
## Follow on to: https://github.com/elastic/connectors/pull/1947

Reverts the changes to the `connectors_cli.py` configuration loading in favour of the original method. Updates the scripts to use a separate configuration for the CLI used in the Connectors configuration script to connect to the Elasticsearch instance.

## Checklists
#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
