### PR TITLE
give CTA if no connectors are configured

### DIFF
--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -150,10 +150,13 @@ class PreflightCheck:
             logger.warning(
                 "Please update your config.yml to configure at least one connector"
             )
+            logger.info(
+                "Using Kibana or the connectors CLI, create a connector. You will then be provided with the necessary fields (connector_id, service_type, api_key) to add to your config.yml"
+            )
 
         # Unset configuration
         if not configured_native_types and not configured_connectors:
-            logger.error("You must configure at least one connector")
+            logger.error("You must configure at least one connector. ")
             return False
 
         # Default configuration


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/###

See: https://elastic.slack.com/archives/C01795T48LQ/p1704910889935649?thread_ts=1704851023.342089&cid=C01795T48LQ

The connectors process exits if no connectors are configured, but it doesn't really tell you where to get the necessary information for configuration. This could help.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
