### PR TITLE
[Salesforce] Add custom object support with different API Names

### DIFF
--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -276,7 +276,7 @@ class SalesforceClient:
         custom_objects = []
 
         for sobject in response.get("sobjects", []):
-            if sobject.get("custom"):
+            if sobject.get("custom") and sobject.get("name")[-3:] == "__c":
                 custom_objects.append(sobject.get("name"))
         return custom_objects
 


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/1859

This problem is faced while the API name (which is used in SOQL query to fetch data) is different in the Salesforce edition. I also noticed that the `/sobjects` endpoint provides the custom objects with the suffix `__c`, `__e` and might be some others, so we filter out the custom objects having just `__c` as a suffix in object API name.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally