### PR TITLE
Add search-productivity-team to connectors Buildkite pipelines

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -55,6 +55,7 @@ spec:
         everyone:
           access_level: "READ_ONLY"
         ingestion-team: {}
+        search-productivity-team: {}
 
 ############################# Nightly Test Suites #############################
 # Declare daily/nightly tests pipeline
@@ -110,6 +111,7 @@ spec:
         everyone:
           access_level: "READ_ONLY"
         ingestion-team: {}
+        search-productivity-team: {}
 
 
 ############################# Nightly Test Suites #############################
@@ -150,6 +152,7 @@ spec:
         everyone:
           access_level: "READ_ONLY"
         ingestion-team: {}
+        search-productivity-team: {}
 
 ############################# Nightly Test Suites #############################
 ---
@@ -204,3 +207,4 @@ spec:
         everyone:
           access_level: "READ_ONLY"
         ingestion-team: {}
+        search-productivity-team: {}


### PR DESCRIPTION
### Description
In order to be compliant with Search Developer Productivity charter and be able to work with Search CI pipelines, it's required to grant @elastic/search-productivity-team permissions to connectors Buildkite pipelines.

This PR is dedicated to granting Search Developer Productivity team permissions to all connectors Buildkite pipelines