### PR TITLE
[Setup] Add logging, when default architecture is set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,15 @@ import sys
 from setuptools import find_packages, setup
 from setuptools._vendor.packaging.markers import Marker
 
+from connectors.logger import logger
+
 try:
     ARCH = os.uname().machine
-except Exception:
+except Exception as e:
     ARCH = "x86_64"
+    logger.info(
+        f"Defaulting to architecture '{ARCH}'. Unable to determine machine architecture due to error: {e}"
+    )
 
 if sys.version_info.major != 3:
     raise ValueError("Requires Python 3")

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,8 @@ import os
 from setuptools import find_packages, setup
 from setuptools._vendor.packaging.markers import Marker
 
-from connectors.utils import ensure_python_3_10_or_higher
 from connectors.logger import logger
-
+from connectors.utils import ensure_python_3_10_or_higher
 
 try:
     ARCH = os.uname().machine


### PR DESCRIPTION
We set the architecture to `x86_64`, if we cannot determine the machine architecture. I think it's useful to log it, if this happens.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
~- [ ] this PR links to all relevant github issues that it fixes or partially addresses~ (there is no issue, just stumbled across this)
~- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue~
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)