### PR TITLE
Make MemQueue used in sync configurable via config options

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -134,6 +134,19 @@
 #
 ##  Retry interval between failed bulk attempts
 #elasticsearch.bulk.retry_interval: 10
+#
+#
+##  Minimal interval of time between MemQueue checks for being full
+#elasticsearch.bulk.mem_queue.refresh_interval: 1
+#
+#
+##  Maximal interval of time during which MemQueue does not dequeue a single document
+##  For example, if no documents were sent to Elasticsearch within 60 seconds because of
+##  Elasticsearch being overloaded, then an error will be raised.
+##  This mechanism exists to be a circuit-breaker for stuck jobs and stuck Elasticsearch.
+#elasticsearch.bulk.mem_queue.refresh_timeout: 60
+#
+#
 ## ------------------------------- Service ----------------------------------
 #
 ##  Connector service/framework related configurations

--- a/config.yml
+++ b/config.yml
@@ -110,6 +110,17 @@
 #elasticsearch.bulk.queue_max_mem_size: 25
 #
 #
+##  Minimal interval of time between MemQueue checks for being full
+#elasticsearch.bulk.queue_refresh_interval: 1
+#
+#
+##  Maximal interval of time during which MemQueue does not dequeue a single document
+##  For example, if no documents were sent to Elasticsearch within 60 seconds because of
+##  Elasticsearch being overloaded, then an error will be raised.
+##  This mechanism exists to be a circuit-breaker for stuck jobs and stuck Elasticsearch.
+#elasticsearch.bulk.queue_refresh_timeout: 60
+#
+#
 ##  The max size in MB of a bulk request.
 ##    When the next request being prepared reaches that size, the query is
 ##    emitted even if `chunk_size` is not yet reached.
@@ -134,17 +145,6 @@
 #
 ##  Retry interval between failed bulk attempts
 #elasticsearch.bulk.retry_interval: 10
-#
-#
-##  Minimal interval of time between MemQueue checks for being full
-#elasticsearch.bulk.mem_queue.refresh_interval: 1
-#
-#
-##  Maximal interval of time during which MemQueue does not dequeue a single document
-##  For example, if no documents were sent to Elasticsearch within 60 seconds because of
-##  Elasticsearch being overloaded, then an error will be raised.
-##  This mechanism exists to be a circuit-breaker for stuck jobs and stuck Elasticsearch.
-#elasticsearch.bulk.mem_queue.refresh_timeout: 60
 #
 #
 ## ------------------------------- Service ----------------------------------

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -59,6 +59,8 @@ def _default_config():
             "bulk": {
                 "queue_max_size": 1024,
                 "queue_max_mem_size": 25,
+                "queue_refresh_interval": 1,
+                "queue_refresh_timeout": 600,
                 "display_every": 100,
                 "chunk_size": 1000,
                 "max_concurrency": 5,
@@ -66,7 +68,6 @@ def _default_config():
                 "max_retries": DEFAULT_ELASTICSEARCH_MAX_RETRIES,
                 "retry_interval": DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,
                 "concurrent_downloads": 10,
-                "mem_queue": {"refresh_interval": 1, "refresh_timeout": 600},
             },
             "max_retries": DEFAULT_ELASTICSEARCH_MAX_RETRIES,
             "retry_interval": DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -1,4 +1,3 @@
-#
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
@@ -67,6 +66,7 @@ def _default_config():
                 "max_retries": DEFAULT_ELASTICSEARCH_MAX_RETRIES,
                 "retry_interval": DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,
                 "concurrent_downloads": 10,
+                "mem_queue": {"refresh_interval": 1, "refresh_timeout": 600},
             },
             "max_retries": DEFAULT_ELASTICSEARCH_MAX_RETRIES,
             "retry_interval": DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -789,8 +789,19 @@ class SyncOrchestrator:
         retry_interval = options.get(
             "retry_interval", DEFAULT_ELASTICSEARCH_RETRY_INTERVAL
         )
+        mem_queue_refresh_timeout = options.get("mem_queue", {}).get(
+            "refresh_timeout", 600
+        )
+        mem_queue_refresh_interval = options.get("mem_queue", {}).get(
+            "refresh_interval", 1
+        )
 
-        stream = MemQueue(maxsize=queue_size, maxmemsize=queue_mem_size * 1024 * 1024)
+        stream = MemQueue(
+            maxsize=queue_size,
+            maxmemsize=queue_mem_size * 1024 * 1024,
+            refresh_timeout=mem_queue_refresh_timeout,
+            refresh_interval=mem_queue_refresh_interval,
+        )
 
         # start the fetcher
         self._extractor = Extractor(

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -790,7 +790,7 @@ class SyncOrchestrator:
             "retry_interval", DEFAULT_ELASTICSEARCH_RETRY_INTERVAL
         )
         mem_queue_refresh_timeout = options.get("mem_queue", {}).get(
-            "refresh_timeout", 600
+            "refresh_timeout", 60
         )
         mem_queue_refresh_interval = options.get("mem_queue", {}).get(
             "refresh_interval", 1

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -789,12 +789,8 @@ class SyncOrchestrator:
         retry_interval = options.get(
             "retry_interval", DEFAULT_ELASTICSEARCH_RETRY_INTERVAL
         )
-        mem_queue_refresh_timeout = options.get("mem_queue", {}).get(
-            "refresh_timeout", 60
-        )
-        mem_queue_refresh_interval = options.get("mem_queue", {}).get(
-            "refresh_interval", 1
-        )
+        mem_queue_refresh_timeout = options.get("queue_refresh_timeout", 60)
+        mem_queue_refresh_interval = options.get("queue_refresh_interval", 1)
 
         stream = MemQueue(
             maxsize=queue_size,


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6413

We see that some use-cases of connectors cause heavy load on Elasticsearch. Because of that, ingestion mechanisms do not pick up items from the MemQueue and the job fails. Settings for MemQueue are hardcoded and this PR makes them configurable.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Contributed any configuration settings changes to the configuration reference

## Release Note

Made Memory Queue configurable - it's possible to avoid `QueueFull` errors in overloaded environments with this setting.