### PR TITLE
Add max_file_download_size config and expose to DataSource

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -157,6 +157,10 @@
 #service.max_concurrent_access_control_syncs: 1
 #
 #
+##  The maximum size (in bytes) of files that the framework should be willing
+##    to download and/or process.
+#service.max_file_download_size: 10485760
+#
 ##  The interval (in seconds) to run job cleanup task.
 #service.job_cleanup_interval: 300
 #

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -10,7 +10,7 @@ from envyaml import EnvYAML
 
 from connectors.logger import logger
 
-
+DEFAULT_MAX_FILE_SIZE = 10485760 # 10MB
 def load_config(config_file):
     logger.info(f"Loading config from {config_file}")
     yaml_config = EnvYAML(config_file, flatten=False).export()
@@ -77,6 +77,7 @@ def _default_config():
             "max_errors_span": 600,
             "max_concurrent_content_syncs": 1,
             "max_concurrent_access_control_syncs": 1,
+            "max_file_download_size": DEFAULT_MAX_FILE_SIZE,
             "job_cleanup_interval": 300,
             "log_level": "INFO",
         },
@@ -177,3 +178,29 @@ def _merge_dicts(hsh1, hsh2):
             yield (k, hsh1[k])
         else:
             yield (k, hsh2[k])
+
+class DataSourceFrameworkConfig:
+    """
+    The configs that will be exposed to DataSource instances.
+    This abstraction prevents DataSource instances from having access to all configuration, while also
+    preventing them from requiring substantial changes to access new configs that may be added.
+    """
+
+    def __init__(self, max_file_size):
+        """
+        Should not be called directly. Use the Builder.
+        """
+        self.max_file_size = max_file_size
+
+
+    class Builder:
+        def __init__(self):
+            self.max_file_size = DEFAULT_MAX_FILE_SIZE
+
+        def with_max_file_size(self, max_file_size):
+            self.max_file_size = max_file_size
+            return self
+
+        def build(self):
+            return DataSourceFrameworkConfig(self.max_file_size)
+

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -85,6 +85,7 @@ class JobExecutionService(BaseService):
             sync_job=sync_job,
             connector=connector,
             es_config=self._override_es_config(connector),
+            service_config=self.service_config
         )
         if not self.sync_job_pool.try_put(sync_job_runner.execute):
             sync_job.log_debug(

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -21,6 +21,7 @@ from aiofiles.os import remove
 from aiofiles.tempfile import NamedTemporaryFile
 from bson import Decimal128
 
+from connectors.config import DataSourceFrameworkConfig
 from connectors.content_extraction import ContentExtraction
 from connectors.filtering.validation import (
     BasicRuleAgainstSchemaValidator,
@@ -38,7 +39,6 @@ from connectors.utils import (
 )
 
 CHUNK_SIZE = 1024 * 64  # 64KB default SSD page size
-FILE_SIZE_LIMIT = 10485760  # ~10 Megabytes
 CURSOR_SYNC_TIMESTAMP = "cursor_timestamp"
 
 DEFAULT_CONFIGURATION = {
@@ -406,6 +406,9 @@ class BaseDataSource:
             self.extraction_service = None
             self.download_dir = None
 
+        # this will be overwritten by set_framework_config()
+        self.framework_config = DataSourceFrameworkConfig.Builder().build()
+
     def __str__(self):
         return f"Datasource `{self.__class__.name}`"
 
@@ -418,6 +421,10 @@ class BaseDataSource:
         # if there are internal class (e.g. Client class) to which the logger need to be set,
         # this method needs to be implemented
         pass
+
+    def set_framework_config(self, framework_config):
+        """Called by the framework, this exposes framework-wide configuration to be used by the DataSource"""
+        self.framework_config = framework_config
 
     @classmethod
     def get_simple_configuration(cls):
@@ -711,11 +718,11 @@ class BaseDataSource:
         return True
 
     def is_file_size_within_limit(self, file_size, filename):
-        if file_size > FILE_SIZE_LIMIT and not self.configuration.get(
+        if file_size > self.framework_config.max_file_size and not self.configuration.get(
             "use_text_extraction_service"
         ):
             self._logger.warning(
-                f"File size {file_size} of file {filename} is larger than {FILE_SIZE_LIMIT} bytes. Discarding file content."
+                f"File size {file_size} of file {filename} is larger than {self.framework_config.max_file_size} bytes. Discarding file content."
             )
             return False
 

--- a/connectors/sources/box.py
+++ b/connectors/sources/box.py
@@ -37,7 +37,6 @@ ENDPOINTS = {
 }
 RETRIES = 3
 RETRY_INTERVAL = 2
-FILE_SIZE_LIMIT = 10485760
 CHUNK_SIZE = 1024
 FETCH_LIMIT = 1000
 QUEUE_MEM_SIZE = 5 * 1024 * 1024  # ~ 5 MB
@@ -391,9 +390,9 @@ class BoxDataSource(BaseDataSource):
             )
             return False
 
-        if attachment_size > FILE_SIZE_LIMIT:
+        if attachment_size > self.framework_config.max_file_size:
             self._logger.warning(
-                f"File size {attachment_size} of file {attachment_name} is larger than {FILE_SIZE_LIMIT} bytes. Discarding file content"
+                f"File size {attachment_size} of file {attachment_name} is larger than {self.framework_config.max_file_size} bytes. Discarding file content"
             )
             return False
         return True

--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -58,7 +58,6 @@ GET_GROUP_MEMBERS = 'Get-LocalGroupMember -Name "{name}" | Select-Object Name, S
 SECURITY_INFO_DACL = 0x00000004
 
 MAX_CHUNK_SIZE = 65536
-DEFAULT_FILE_SIZE_LIMIT = 10485760
 RETRIES = 3
 RETRY_INTERVAL = 2
 
@@ -463,9 +462,9 @@ class NASDataSource(BaseDataSource):
         ):
             return
 
-        if int(file["size"]) > DEFAULT_FILE_SIZE_LIMIT:
+        if int(file["size"]) > self.framework_config.max_file_size:
             self._logger.warning(
-                f"File size {file['size']} of {file['title']} bytes is larger than {DEFAULT_FILE_SIZE_LIMIT} bytes. Discarding the file content"
+                f"File size {file['size']} of {file['title']} bytes is larger than {self.framework_config.max_file_size} bytes. Discarding the file content"
             )
             return
 

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -86,12 +86,14 @@ def create_runner(
     sync_job = mock_sync_job(job_type=job_type, index_name=index_name)
     connector = mock_connector()
     es_config = {}
+    service_config = {}
 
     return SyncJobRunner(
         source_klass=source_klass,
         sync_job=sync_job,
         connector=connector,
         es_config=es_config,
+        service_config=service_config,
     )
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/4716

Adds a new config, `service.max_file_download_size` that defaults to 10MB.

Also, adds a new abstraction for specific framework configs that we want to expose to the DataSource instances, without exposing all of our YAML configs. This PR exposes only the new `max_file_size`, but can be easily updated to expose more.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

## Release Note

`service.max_file_download_size` can now be set in the `config.yml` to control how large of files the framework will attempt to download. This config is only used for connectors that are not using the Data Extraction Service.
