### PR TITLE
[Network Drive] Handle smb connection timeout

### DIFF
--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -15,7 +15,7 @@ import fastjsonschema
 import smbclient
 import winrm
 from requests.exceptions import ConnectionError
-from smbprotocol.exceptions import SMBException, SMBOSError
+from smbprotocol.exceptions import SMBConnectionClosed, SMBException, SMBOSError
 from smbprotocol.file_info import (
     InfoType,
 )
@@ -395,6 +395,12 @@ class NASDataSource(BaseDataSource):
             ),
         )
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+        skipped_exceptions=[SMBOSError, SMBException],
+    )
     async def get_files(self, path):
         """Fetches the metadata of the files and folders present on given path
 
@@ -407,6 +413,12 @@ class NASDataSource(BaseDataSource):
             files = await loop.run_in_executor(
                 executor=None, func=partial(smbclient.scandir, path, port=self.port)
             )
+        except SMBConnectionClosed as exception:
+            self._logger.exception(
+                f"Connection got closed. Error {exception}. Registering new session"
+            )
+            await loop.run_in_executor(executor=None, func=self.create_connection)
+            raise
         except (SMBOSError, SMBException) as exception:
             self._logger.exception(
                 f"Error while scanning the path {path}. Error {exception}"
@@ -703,7 +715,7 @@ class NASDataSource(BaseDataSource):
         else:
             matched_paths = (path for path, _, _ in self.get_directory_details)
             groups_info = {}
-            if self.drive_type == WINDOWS:
+            if self.drive_type == WINDOWS and self._dls_enabled():
                 groups_info = await self.fetch_groups_info()
 
             for path in matched_paths:


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2078

This PR introduces following changes:
- Add retry mechanism in case of SMB timeouts.
- Ensure fetch_groups_info is only called when dls is enabled to prevent unnecessary network calls

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] ~Considered corresponding documentation changes~
- [ ] ~Contributed any configuration settings changes to the configuration reference~
- [ ] ~if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)~

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] ~Security-related changes (encryption, TLS, SSRF, etc)~
- [ ] ~New external service dependencies added.~

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
The Connection to Network Drive would be re-established and request would be retried in case SMBConnectionClosed error is raised due to timeout while fetching files.
