### PR TITLE
Fix packaging

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -14,7 +14,6 @@ import re
 import shutil
 import ssl
 import subprocess
-import sys
 import time
 import urllib.parse
 from datetime import datetime, timedelta, timezone

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -893,9 +893,3 @@ def shorten_str(string, shorten_by):
     else:
         # keep one more at the front
         return f"{string[:keep + 1]}...{string[-keep:]}"
-
-
-def ensure_python_3_10_or_higher():
-    if sys.version_info < (3, 10):
-        msg = "Requires Python 3.10 or higher."
-        raise ValueError(msg)

--- a/setup.py
+++ b/setup.py
@@ -4,20 +4,24 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import os
+import sys
 
 from setuptools import find_packages, setup
 from setuptools._vendor.packaging.markers import Marker
 
-from connectors.logger import logger
-from connectors.utils import ensure_python_3_10_or_higher
-
 try:
     ARCH = os.uname().machine
+    raise Exception("test")
 except Exception as e:
     ARCH = "x86_64"
-    logger.info(
+    print(
         f"Defaulting to architecture '{ARCH}'. Unable to determine machine architecture due to error: {e}"
     )
+
+def ensure_python_3_10_or_higher():
+    if sys.version_info < (3, 10):
+        msg = "Requires Python 3.10 or higher."
+        raise ValueError(msg)
 
 ensure_python_3_10_or_higher()
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ from setuptools._vendor.packaging.markers import Marker
 
 try:
     ARCH = os.uname().machine
-    raise Exception("test")
 except Exception as e:
     ARCH = "x86_64"
     print(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ try:
     ARCH = os.uname().machine
 except Exception as e:
     ARCH = "x86_64"
-    print(
+    print(  # noqa: T201
         f"Defaulting to architecture '{ARCH}'. Unable to determine machine architecture due to error: {e}"
     )
 

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,9 @@ except Exception as e:
         f"Defaulting to architecture '{ARCH}'. Unable to determine machine architecture due to error: {e}"
     )
 
-def ensure_python_3_10_or_higher():
-    if sys.version_info < (3, 10):
-        msg = "Requires Python 3.10 or higher."
-        raise ValueError(msg)
-
-ensure_python_3_10_or_higher()
+if sys.version_info < (3, 10):
+    msg = "Requires Python 3.10 or higher."
+    raise ValueError(msg)
 
 from connectors import __version__  # NOQA
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,7 +34,6 @@ from connectors.utils import (
     convert_to_b64,
     decode_base64_value,
     deep_merge_dicts,
-    ensure_python_3_10_or_higher,
     evaluate_timedelta,
     filter_nested_dict_by_keys,
     get_base64_value,
@@ -1056,25 +1055,3 @@ async def test_time_to_sleep_between_retries_invalid_strategy():
         time_to_sleep_between_retries("lalala", 1, 1)
 
     assert e is not None
-
-
-@patch("sys.version_info", new=(3, 9))
-def test_ensure_python_3_10_or_higher_raises_for_3_9():
-    with pytest.raises(ValueError):
-        ensure_python_3_10_or_higher()
-
-
-@patch("sys.version_info", new=(3, 10))
-def test_ensure_python_3_10_or_higher_does_not_raise_for_3_10():
-    try:
-        ensure_python_3_10_or_higher()
-    except ValueError:
-        pytest.fail("ValueError raised for Python 3.10")
-
-
-@patch("sys.version_info", new=(3, 11))
-def test_ensure_python_3_10_or_higher_does_not_raise_for_3_11():
-    try:
-        ensure_python_3_10_or_higher()
-    except ValueError:
-        pytest.fail("ValueError raised for Python 3.11")


### PR DESCRIPTION
Fix connectors packaging in Enterprise Search. 

#### This step is failing: 
```
python3 -m pip install .
```

#### Stack trace:
```
Processing ~/projects/connectors-python
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "~/projects/connectors-python/setup.py", line 12, in <module>
          from connectors.logger import logger
        File "~/projects/connectors-python/connectors/logger.py", line 17, in <module>
          import ecs_logging
      ModuleNotFoundError: No module named 'ecs_logging'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

We can't use modules listed in requirements.txt files during `setup.py` execution. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests
* https://github.com/elastic/connectors/pull/2071
* https://github.com/elastic/connectors/pull/2070
