### PR TITLE
Add faker dependency to tests.txt requirements file

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -12,3 +12,4 @@ freezegun==1.2.2
 pytest-fail-slow==0.3.0
 pyright==1.1.317
 requests==2.31.0
+faker==18.11.2


### PR DESCRIPTION
Minor tweak: with certain setup the tests will error out because `faker` is not imported. It happens because `faker` dependency was declared only in functional tests requirements file.

This PR explicitly declares `faker` dependency for tests.