### PR TITLE
Bump idle job threshold to 5 minutes

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -962,7 +962,7 @@ class Connector(ESDocument):
         }
 
 
-IDLE_JOBS_THRESHOLD = 60  # 60 seconds
+IDLE_JOBS_THRESHOLD = 60 * 15  # 15 minutes
 
 
 class SyncJobIndex(ESIndex):

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -962,7 +962,7 @@ class Connector(ESDocument):
         }
 
 
-IDLE_JOBS_THRESHOLD = 60 * 15  # 15 minutes
+IDLE_JOBS_THRESHOLD = 60 * 5  # 5 minutes
 
 
 class SyncJobIndex(ESIndex):


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6413

We've figured out that idle timeout of 1 minute is too small. This PR bumps it to 5 minutes.

Since this change is not connector-specific (Kibana has pieces of this logic too), it's not possible to make it a configuration option.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

- [ ] https://github.com/elastic/kibana/pull/175681

## Release Note

Increased idle job timeout from 1 minute to 5 minutes. Jobs that haven't made any progress for 5 minutes will be marked as "idle" and failed.
