### PR TITLE
[CLI] API keys authentication

### DIFF
--- a/connectors/cli/auth.py
+++ b/connectors/cli/auth.py
@@ -11,7 +11,12 @@ CONFIG_FILE_PATH = ".cli/config.yml"
 
 class Auth:
     def __init__(self, host, username=None, password=None, api_key=None):
-        elastic_config = {"host": host, "username": username, "password": password, "api_key": api_key}
+        elastic_config = {
+            "host": host,
+            "username": username,
+            "password": password,
+            "api_key": api_key,
+        }
 
         # remove empty values
         self.elastic_config = {k: v for k, v in elastic_config.items() if v is not None}

--- a/connectors/cli/auth.py
+++ b/connectors/cli/auth.py
@@ -10,8 +10,12 @@ CONFIG_FILE_PATH = ".cli/config.yml"
 
 
 class Auth:
-    def __init__(self, host, username, password):
-        self.elastic_config = {"host": host, "username": username, "password": password}
+    def __init__(self, host, username=None, password=None, api_key=None):
+        elastic_config = {"host": host, "username": username, "password": password, "api_key": api_key}
+
+        # remove empty values
+        self.elastic_config = {k: v for k, v in elastic_config.items() if v is not None}
+
         self.es_management_client = ESManagementClient(self.elastic_config)
 
     def authenticate(self):

--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -99,11 +99,15 @@ class Connector:
                 await self.es_management_client.create_content_index(
                     index_name, language
                 )
+
             api_key_id = None
             api_key_encoded = None
             api_key_error = None
             api_key_skipped = False
-            if "api_key" in self.config:
+
+            # Skip creating an API key if the CLI is authenticated with an API key or if the connector is native
+            #
+            if "api_key" in self.config or not is_native:
                 api_key_skipped = True
             else:
                 try:

--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -106,8 +106,7 @@ class Connector:
             api_key_skipped = False
 
             # Skip creating an API key if the CLI is authenticated with an API key or if the connector is native
-            #
-            if "api_key" in self.config or not is_native:
+            if "api_key" in self.config or is_native:
                 api_key_skipped = True
             else:
                 try:

--- a/connectors/cli/index.py
+++ b/connectors/cli/index.py
@@ -3,8 +3,11 @@ import asyncio
 from elasticsearch import ApiError
 
 from connectors.es.management_client import ESManagementClient
-from connectors.protocol import ConnectorIndex
-
+from connectors.protocol import (
+    CONCRETE_CONNECTORS_INDEX,
+    CONCRETE_JOBS_INDEX,
+    ConnectorIndex,
+)
 
 class Index:
     def __init__(self, config):
@@ -55,6 +58,10 @@ class Index:
 
     async def __index_or_connector_exists(self, index_name):
         try:
+            await self.es_management_client.ensure_exists(
+                indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
+            )
+
             index_exists, connector_doc = await asyncio.gather(
                 self.es_management_client.index_exists(index_name),
                 self.connectors_index.get_connector_by_index(index_name),

--- a/connectors/cli/index.py
+++ b/connectors/cli/index.py
@@ -9,6 +9,7 @@ from connectors.protocol import (
     ConnectorIndex,
 )
 
+
 class Index:
     def __init__(self, config):
         self.elastic_config = config

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -61,7 +61,7 @@ def cli(ctx, config):
 
 @click.command(help="Authenticate Connectors CLI with an Elasticsearch instance")
 @click.option("--host", prompt="Elastic host")
-@click.option("--method", type=click.Choice(["basic", "apikey"]), default="basic")
+@click.option("--method", type=click.Choice(["basic", "apikey"]), default="basic", help="Authentication method")
 def login(host, method):
     if method == "basic":
         username = click.prompt("Username")

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -61,10 +61,16 @@ def cli(ctx, config):
 
 @click.command(help="Authenticate Connectors CLI with an Elasticsearch instance")
 @click.option("--host", prompt="Elastic host")
-@click.option("--username", prompt="Username")
-@click.option("--password", prompt="Password", hide_input=True)
-def login(host, username, password):
-    auth = Auth(host, username, password)
+@click.option('--method', prompt="Authentication method", type=click.Choice(['basic', 'apikey']), default='basic')
+def login(host, method):
+    if method == 'basic':
+        username = click.prompt("Username")
+        password = click.prompt("Password", hide_input=True)
+        auth = Auth(host, username, password)
+    else:
+        api_key = click.prompt("API key", hide_input=True)
+        auth = Auth(host, api_key=api_key)
+
     if auth.is_config_present():
         click.confirm(
             click.style(

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -61,9 +61,9 @@ def cli(ctx, config):
 
 @click.command(help="Authenticate Connectors CLI with an Elasticsearch instance")
 @click.option("--host", prompt="Elastic host")
-@click.option('--method', prompt="Authentication method", type=click.Choice(['basic', 'apikey']), default='basic')
+@click.option("--method", type=click.Choice(["basic", "apikey"]), default="basic")
 def login(host, method):
-    if method == 'basic':
+    if method == "basic":
         username = click.prompt("Username")
         password = click.prompt("Password", hide_input=True)
         auth = Auth(host, username, password)
@@ -332,7 +332,7 @@ def create(
         + ", service_type: "
         + click.style(service_type, fg="green")
         + ", api_key: "
-        + click.style(result["api_key"], fg="green")
+        + click.style(result.get("api_key"), fg="green")
         + ") has been created!"
     )
 
@@ -351,7 +351,7 @@ def create(
                 {
                     "connector_id": result["id"],
                     "service_type": service_type,
-                    "api_key": result["api_key"],
+                    "api_key": result.get("api_key"),
                 }
             )
 
@@ -592,7 +592,7 @@ def view_job(obj, job_id, output_format):
         "index_name": job.index_name,
         "job_status": job.status.value,
         "job_type": job.job_type.value,
-        "documents_index,ed": job.indexed_document_count,
+        "documents_indexed": job.indexed_document_count,
         "volume_documents_indexed": job.indexed_document_volume,
         "documents_deleted": job.deleted_document_count,
     }

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -61,7 +61,12 @@ def cli(ctx, config):
 
 @click.command(help="Authenticate Connectors CLI with an Elasticsearch instance")
 @click.option("--host", prompt="Elastic host")
-@click.option("--method", type=click.Choice(["basic", "apikey"]), default="basic", help="Authentication method")
+@click.option(
+    "--method",
+    type=click.Choice(["basic", "apikey"]),
+    default="basic",
+    help="Authentication method",
+)
 def login(host, method):
     if method == "basic":
         username = click.prompt("Username")

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -22,6 +22,9 @@ Connectors CLI is in tech preview.
 2. Provide credentials
 3. The command will create or ask to rewrite an existing configuration file in `./cli/config.yml`
 
+By default, the CLI uses basic authentication method (username, password) however an API key can be used too. 
+Run `./bin/connectors login --method apikey` to authenticate the CLI via your API key. 
+
 When you run any command you can specify a configuration file using `-c` argument.
 Example:
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/6648

These changes add Elasticsearch API keys authentication method. Also, this PR addresses the issue when CLI created API keys for native connectors. 

The new version of `./bin/connector login`

```
Usage: connectors login [OPTIONS]

  Authenticate Connectors CLI with an Elasticsearch instance

Options:
  --host TEXT
  --method [basic|apikey]  Authentication method
  --help                   Show this message and exit.
```

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

## Related Pull Requests
* https://github.com/elastic/connectors/pull/2091

## Release Note
Connectors CLI can authorize with Elasticsearch API keys by running `./bin/connectors login --method apikey`.
