### PR TITLE
Validate configurable fields every loop of job scheduling service

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -88,9 +88,19 @@ class JobSchedulingService(BaseService):
             raise DataSourceError(msg)
 
         source_klass = get_source_klass(self.source_list[connector.service_type])
+        data_source = source_klass(connector.configuration)
+        data_source.set_logger(connector.logger)
+
+        connector.log_debug("Validating configuration")
+        try:
+            data_source.validate_config_fields()
+            await data_source.validate_config()
+        except Exception as e:
+            connector.log_error(e, exc_info=True)
+            await connector.error(e)
+            return
+
         if connector.features.sync_rules_enabled():
-            data_source = source_klass(connector.configuration)
-            data_source.set_logger(connector.logger)
             try:
                 await connector.validate_filtering(validator=data_source)
             finally:

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -343,3 +343,32 @@ async def test_run_when_sync_fails_then_continues_service_execution(
     # assert that service did not crash and kept asking index for connectors
     # we don't have a good criteria of what a "crashed service is"
     assert connector_index_mock.supported_connectors.call_count > 1
+
+
+@pytest.mark.asyncio
+@patch("connectors.services.job_scheduling.get_source_klass")
+async def test_run_when_connector_fields_are_invalid(
+    get_source_klass_mock, connector_index_mock, set_env
+):
+    error_message = "Something invalid is in config!"
+    actual_error = Exception(error_message)
+
+    data_source_mock = Mock()
+
+    def _source_klass(config):
+        return data_source_mock
+
+    get_source_klass_mock.return_value = _source_klass
+
+    data_source_mock.validate_config_fields = Mock()
+    data_source_mock.validate_config = AsyncMock(side_effect=[actual_error])
+    data_source_mock.close = AsyncMock()
+
+    connector = mock_connector(next_sync=datetime.utcnow())
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    await create_and_run_service(JobSchedulingService, stop_after=0.15)
+
+    data_source_mock.validate_config_fields.assert_called()
+    data_source_mock.validate_config.assert_awaited_once()
+
+    connector.error.assert_awaited_with(actual_error)


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5678

Adding logic to run validation for content source configuration with every loop of scheduler service.

Before, configurable fields would be validated only when a sync job is ran, but now we're gonna run validation every time `job_scheduling_service` runs (every 30 seconds). That will actually expose errors in configurations to the customer eariler.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Now configurations of connectors are validated periodically, exposing validation errors without need to run a sync.
