### PR TITLE
Treat inability to create mappings as warning instead of breaking error

### DIFF
--- a/connectors/es/management_client.py
+++ b/connectors/es/management_client.py
@@ -50,10 +50,8 @@ class ESManagementClient(ESClient):
                 logger.debug(f"Created index {index}")
 
     async def create_content_index(self, search_index_name, language_code):
-        settings = Settings(language_code=language_code,
-                            analysis_icu=False).to_hash()
-        mappings = Mappings.default_text_fields_mappings(
-            is_connectors_index=True)
+        settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
+        mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
 
         return await self._retrier.execute_with_retry(
             partial(
@@ -83,16 +81,15 @@ class ESManagementClient(ESClient):
                             self.client.indices.put_mapping,
                             index=index,
                             dynamic=mappings.get("dynamic", False),
-                            dynamic_templates=mappings.get(
-                                "dynamic_templates", []),
+                            dynamic_templates=mappings.get("dynamic_templates", []),
                             properties=mappings.get("properties", {}),
                         )
                     )
-                    logger.debug(
-                        "Successfully added mappings for index %s", index)
+                    logger.debug("Successfully added mappings for index %s", index)
                 except Exception as e:
                     logger.warning(
-                        f"Could not create mappings for index {index}, encountered error {e}")
+                        f"Could not create mappings for index {index}, encountered error {e}"
+                    )
             else:
                 logger.debug(
                     "Index %s has no mappings but no mappings are provided, skipping mappings creation"
@@ -122,8 +119,7 @@ class ESManagementClient(ESClient):
 
     async def delete_indices(self, indices):
         await self._retrier.execute_with_retry(
-            partial(self.client.indices.delete,
-                    index=indices, ignore_unavailable=True)
+            partial(self.client.indices.delete, index=indices, ignore_unavailable=True)
         )
 
     async def clean_index(self, index_name):


### PR DESCRIPTION
Instead of crashing/breaking if we try to add mappings to an index and fail, we log an error and continue. This is particularly important for stateless where in the current state adding mappings will always fail because we don't have the corresponding settings.

Partially addresses: https://github.com/elastic/connectors/issues/2095

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
