### PR TITLE
[CI] Update 'connectors-nightly-dockers' to stop trying to install Docker

### DIFF
--- a/.buildkite/publish_docker.sh
+++ b/.buildkite/publish_docker.sh
@@ -5,16 +5,6 @@ set -euo pipefail
 
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install ca-certificates curl gnupg lsb-release -y
-sudo mkdir -p /etc/apt/keyrings
-
-echo "Installing Docker & Docker Compose"
-ARCH=`dpkg --print-architecture`
-RELEASE=`lsb_release -cs`
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-echo "deb [arch=$ARCH signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $RELEASE stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
-sudo systemctl start docker
 
 echo "Starting test task"
 BASEDIR=$(realpath $(dirname $0))
@@ -25,7 +15,6 @@ cd $ROOT
 # docker snapshot publication
 echo "Building the image"
 make docker-build
-
 
 # !!! WARNING be cautious about the following lines, to avoid leaking the secrets in the CI logs
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -176,7 +176,7 @@ spec:
       description: "Connectors Service Nightly Dockers"
       links:
         - title: "Connector Service Nightly Pipeline"
-          url: "https://buildkite.com/elastic/connectors-nightly"
+          url: "https://buildkite.com/elastic/connectors-nightly-dockers"
     spec:
       pipeline_file: ".buildkite/nightly_docker.yml"
       provider_settings:


### PR DESCRIPTION
(ad hoc change)

The `connectors-nightly-docker` build recently started failing when trying to install Docker: https://buildkite.com/elastic/connectors-nightly-dockers/builds/1033

This is likely related to a recent change in the base VM image we're inheriting from. That image already has Docker and Docker Compose installed (and the Docker daemon is already running by default), so I think it should be safe to remove the steps where we install those packages at build time and then start the systemd unit.
