### PR TITLE
fix acl query template

### DIFF
--- a/connectors/access_control.py
+++ b/connectors/access_control.py
@@ -5,6 +5,26 @@
 #
 
 ACCESS_CONTROL = "_allow_access_control"
+DLS_QUERY = """{
+                    "bool": {
+                        "should": [
+                            {
+                                "bool": {
+                                    "must_not": {
+                                        "exists": {
+                                            "field": "_allow_access_control"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                }
+                            }
+                        ]
+                    }
+                }"""
 
 
 def prefix_identity(prefix, identity):
@@ -27,26 +47,7 @@ def es_access_control_query(access_control):
         "query": {
             "template": {
                 "params": {"access_control": filtered_access_control},
-                "source": """{
-                    "bool": {
-                        "should": [
-                            {
-                                "bool": {
-                                    "must_not": {
-                                        "exists": {
-                                            "field": "_allow_access_control"
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "terms": {
-                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
-                                }
-                            }
-                        ]
-                    }
-                }""",
+                "source": DLS_QUERY,
             }
         }
     }

--- a/connectors/access_control.py
+++ b/connectors/access_control.py
@@ -46,7 +46,7 @@ def es_access_control_query(access_control):
                             },
                         ]
                     }
-                }"""
+                }""",
             }
         }
     }

--- a/connectors/access_control.py
+++ b/connectors/access_control.py
@@ -25,21 +25,28 @@ def es_access_control_query(access_control):
 
     return {
         "query": {
-            "template": {"params": {"access_control": filtered_access_control}},
-            "source": {
-                "bool": {
-                    "filter": {
-                        "bool": {
-                            "should": [
-                                {
-                                    "terms": {
-                                        f"{ACCESS_CONTROL}.enum": filtered_access_control
+            "template": {
+                "params": {"access_control": filtered_access_control},
+                "source": """{
+                    "bool": {
+                        "should": [
+                            {
+                                "bool": {
+                                    "must_not": {
+                                        "exists": {
+                                            "field": "_allow_access_control"
+                                        }
                                     }
-                                },
-                            ]
-                        }
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                }
+                            },
+                        ]
                     }
-                }
-            },
+                }"""
+            }
         }
     }

--- a/connectors/access_control.py
+++ b/connectors/access_control.py
@@ -43,7 +43,7 @@ def es_access_control_query(access_control):
                                 "terms": {
                                     "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
                                 }
-                            },
+                            }
                         ]
                     }
                 }""",

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -14,6 +14,7 @@ import pytest
 from aiohttp import StreamReader
 from freezegun import freeze_time
 
+from connectors.access_control import DLS_QUERY
 from connectors.protocol import Filter
 from connectors.source import ConfigurableFieldValueError
 from connectors.sources.confluence import (
@@ -982,26 +983,8 @@ async def test_get_access_control_dls_enabled():
                         "group_id:607194d6bc3c3f006f4c35d8",
                         "role_key:607194d6bc3c3f006f4c35d9",
                     ]
-                }
-            },
-            "source": {
-                "bool": {
-                    "filter": {
-                        "bool": {
-                            "should": [
-                                {
-                                    "terms": {
-                                        "_allow_access_control.enum": [
-                                            "account_id:607194d6bc3c3f006f4c35d6",
-                                            "group_id:607194d6bc3c3f006f4c35d8",
-                                            "role_key:607194d6bc3c3f006f4c35d9",
-                                        ]
-                                    }
-                                },
-                            ]
-                        }
-                    }
-                }
+                },
+                "source": DLS_QUERY,
             },
         },
     }

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -11,6 +11,7 @@ import aiohttp
 import pytest
 from aiohttp.client_exceptions import ClientResponseError
 
+from connectors.access_control import DLS_QUERY
 from connectors.filtering.validation import SyncRuleValidationResult
 from connectors.protocol import Filter
 from connectors.source import ConfigurableFieldValueError
@@ -446,27 +447,9 @@ EXPECTED_ACCESS_CONTROL = [
                         "username:demo-user",
                         "email:demo@example.com",
                     ]
-                }
-            },
-            "source": {
-                "bool": {
-                    "filter": {
-                        "bool": {
-                            "should": [
-                                {
-                                    "terms": {
-                                        "_allow_access_control.enum": [
-                                            "user_id:#123",
-                                            "username:demo-user",
-                                            "email:demo@example.com",
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                }
-            },
+                },
+                "source": DLS_QUERY,
+            }
         },
     }
 ]

--- a/tests/sources/test_google_drive.py
+++ b/tests/sources/test_google_drive.py
@@ -1456,22 +1456,7 @@ async def test_prepare_access_control_doc(user, groups, access_control_doc):
         ):
             with mock.patch.object(ServiceAccountManager, "refresh"):
                 result = await source.prepare_single_access_control_document(user=user)
-
-                # mustache templates are hard to verify, so let's strip the mustache
-                filtered_input_source = " ".join(
-                    access_control_doc["query"]["template"]["source"]
-                    .replace("{{toJson}}access_control{{/toJson}}", "[]")
-                    .split()
-                )
-                filtered_output_source = " ".join(
-                    result["query"]["template"]["source"]
-                    .replace("{{toJson}}access_control{{/toJson}}", "[]")
-                    .split()
-                )
-
-                assert access_control_doc["_id"] == result["_id"]
-                assert access_control_doc["identity"] == result["identity"]
-                assert filtered_input_source == filtered_output_source
+                assert access_control_doc == result
 
 
 @pytest.mark.parametrize(
@@ -1540,22 +1525,7 @@ async def test_prepare_access_control_documents(
                 result = await anext(
                     source.prepare_access_control_documents(users_page=users_page)
                 )
-
-                # mustache templates are hard to verify, so let's strip the mustache
-                filtered_input_source = " ".join(
-                    access_control_docs[0]["query"]["template"]["source"]
-                    .replace("{{toJson}}access_control{{/toJson}}", "[]")
-                    .split()
-                )
-                filtered_output_source = " ".join(
-                    result["query"]["template"]["source"]
-                    .replace("{{toJson}}access_control{{/toJson}}", "[]")
-                    .split()
-                )
-
-                assert access_control_docs[0]["_id"] == result["_id"]
-                assert access_control_docs[0]["identity"] == result["identity"]
-                assert filtered_input_source == filtered_output_source
+                assert access_control_docs[0] == result
 
 
 @pytest.mark.asyncio

--- a/tests/sources/test_google_drive.py
+++ b/tests/sources/test_google_drive.py
@@ -16,6 +16,7 @@ from aiogoogle import Aiogoogle, HTTPError
 from aiogoogle.auth.managers import ServiceAccountManager
 from aiogoogle.models import Request, Response
 
+from connectors.access_control import DLS_QUERY
 from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.google_drive import RETRIES, GoogleDriveDataSource
 from tests.commons import AsyncIterator
@@ -1426,29 +1427,9 @@ async def test_prepare_file_on_my_drive_with_dls_enabled(file, expected_file):
                                 "group:group-2@test.com",
                                 "group:group-3@test.com",
                             ]
-                        }
-                    },
-                    "source": {
-                        "bool": {
-                            "filter": {
-                                "bool": {
-                                    "should": [
-                                        {
-                                            "terms": {
-                                                "_allow_access_control.enum": [
-                                                    "user:user1@test.com",
-                                                    "domain:test.com",
-                                                    "group:group-1@test.com",
-                                                    "group:group-2@test.com",
-                                                    "group:group-3@test.com",
-                                                ]
-                                            }
-                                        },
-                                    ]
-                                }
-                            }
-                        }
-                    },
+                        },
+                        "source": DLS_QUERY,
+                    }
                 },
             },
         ),
@@ -1474,10 +1455,23 @@ async def test_prepare_access_control_doc(user, groups, access_control_doc):
             Aiogoogle, "as_service_account", return_value=expected_response_object
         ):
             with mock.patch.object(ServiceAccountManager, "refresh"):
-                assert (
-                    access_control_doc
-                    == await source.prepare_single_access_control_document(user=user)
+                result = await source.prepare_single_access_control_document(user=user)
+
+                # mustache templates are hard to verify, so let's strip the mustache
+                filtered_input_source = " ".join(
+                    access_control_doc["query"]["template"]["source"]
+                    .replace("{{toJson}}access_control{{/toJson}}", "[]")
+                    .split()
                 )
+                filtered_output_source = " ".join(
+                    result["query"]["template"]["source"]
+                    .replace("{{toJson}}access_control{{/toJson}}", "[]")
+                    .split()
+                )
+
+                assert access_control_doc["_id"] == result["_id"]
+                assert access_control_doc["identity"] == result["identity"]
+                assert filtered_input_source == filtered_output_source
 
 
 @pytest.mark.parametrize(
@@ -1512,29 +1506,9 @@ async def test_prepare_access_control_doc(user, groups, access_control_doc):
                                     "group:group-2@test.com",
                                     "group:group-3@test.com",
                                 ]
-                            }
-                        },
-                        "source": {
-                            "bool": {
-                                "filter": {
-                                    "bool": {
-                                        "should": [
-                                            {
-                                                "terms": {
-                                                    "_allow_access_control.enum": [
-                                                        "user:user1@test.com",
-                                                        "domain:test.com",
-                                                        "group:group-1@test.com",
-                                                        "group:group-2@test.com",
-                                                        "group:group-3@test.com",
-                                                    ]
-                                                }
-                                            },
-                                        ]
-                                    }
-                                }
-                            }
-                        },
+                            },
+                            "source": DLS_QUERY,
+                        }
                     },
                 },
             ],
@@ -1563,9 +1537,25 @@ async def test_prepare_access_control_documents(
             Aiogoogle, "as_service_account", return_value=expected_response_object
         ):
             with mock.patch.object(ServiceAccountManager, "refresh"):
-                assert access_control_docs[0] == await anext(
+                result = await anext(
                     source.prepare_access_control_documents(users_page=users_page)
                 )
+
+                # mustache templates are hard to verify, so let's strip the mustache
+                filtered_input_source = " ".join(
+                    access_control_docs[0]["query"]["template"]["source"]
+                    .replace("{{toJson}}access_control{{/toJson}}", "[]")
+                    .split()
+                )
+                filtered_output_source = " ".join(
+                    result["query"]["template"]["source"]
+                    .replace("{{toJson}}access_control{{/toJson}}", "[]")
+                    .split()
+                )
+
+                assert access_control_docs[0]["_id"] == result["_id"]
+                assert access_control_docs[0]["identity"] == result["identity"]
+                assert filtered_input_source == filtered_output_source
 
 
 @pytest.mark.asyncio

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -16,6 +16,7 @@ from aiohttp import StreamReader
 from aiohttp.client_exceptions import ClientResponseError
 from freezegun import freeze_time
 
+from connectors.access_control import DLS_QUERY
 from connectors.protocol import Filter
 from connectors.source import ConfigurableFieldValueError
 from connectors.sources.jira import (
@@ -1031,26 +1032,8 @@ async def test_get_access_control_dls_enabled():
                         "group_id:607194d6bc3c3f006f4c35d8",
                         "role_key:607194d6bc3c3f006f4c35d9",
                     ]
-                }
-            },
-            "source": {
-                "bool": {
-                    "filter": {
-                        "bool": {
-                            "should": [
-                                {
-                                    "terms": {
-                                        "_allow_access_control.enum": [
-                                            "account_id:607194d6bc3c3f006f4c35d6",
-                                            "group_id:607194d6bc3c3f006f4c35d8",
-                                            "role_key:607194d6bc3c3f006f4c35d9",
-                                        ]
-                                    }
-                                },
-                            ]
-                        }
-                    }
-                }
+                },
+                "source": DLS_QUERY,
             },
         },
     }

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aioresponses import CallbackResult
 
+from connectors.access_control import DLS_QUERY
 from connectors.protocol import Filter
 from connectors.source import ConfigurableFieldValueError, DataSourceConfiguration
 from connectors.sources.salesforce import (
@@ -2033,26 +2034,9 @@ async def test_get_access_control_dls_enabled(mock_responses):
         "_timestamp": "2023-12-25T01:01:01Z",
         "query": {
             "template": {
-                "params": {"access_control": ["user:Dummy User", "user_id:user_id"]}
-            },
-            "source": {
-                "bool": {
-                    "filter": {
-                        "bool": {
-                            "should": [
-                                {
-                                    "terms": {
-                                        "_allow_access_control.enum": [
-                                            "user:Dummy User",
-                                            "user_id:user_id",
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                }
-            },
+                "params": {"access_control": ["user:Dummy User", "user_id:user_id"]},
+                "source": DLS_QUERY,
+            }
         },
     }
 

--- a/tests/sources/test_servicenow.py
+++ b/tests/sources/test_servicenow.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 import pytest
 from aiohttp.client_exceptions import ServerDisconnectedError
 
+from connectors.access_control import DLS_QUERY
 from connectors.filtering.validation import SyncRuleValidationResult
 from connectors.protocol import Filter
 from connectors.source import ConfigurableFieldValueError
@@ -817,27 +818,9 @@ async def test_get_access_control():
                         "username:demo.user",
                         "email:admin@email.com",
                     ]
-                }
-            },
-            "source": {
-                "bool": {
-                    "filter": {
-                        "bool": {
-                            "should": [
-                                {
-                                    "terms": {
-                                        "_allow_access_control.enum": [
-                                            "user_id:id_1",
-                                            "username:demo.user",
-                                            "email:admin@email.com",
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                }
-            },
+                },
+                "source": DLS_QUERY,
+            }
         },
     }
     async with create_service_now_source() as source:

--- a/tests/test_access_control.py
+++ b/tests/test_access_control.py
@@ -7,7 +7,6 @@
 import pytest
 
 from connectors.access_control import (
-    ACCESS_CONTROL,
     es_access_control_query,
     prefix_identity,
 )
@@ -20,18 +19,29 @@ async def test_access_control_query():
 
     assert access_control_query == {
         "query": {
-            "template": {"params": {"access_control": access_control}},
-            "source": {
-                "bool": {
-                    "filter": {
-                        "bool": {
-                            "should": [
-                                {"terms": {f"{ACCESS_CONTROL}.enum": access_control}},
-                            ]
-                        }
+            "template": {
+                "params": {"access_control": access_control},
+                "source": """{
+                    "bool": {
+                        "should": [
+                            {
+                                "bool": {
+                                    "must_not": {
+                                        "exists": {
+                                            "field": "_allow_access_control"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "terms": {
+                                    "_allow_access_control.enum": {{#toJson}}access_control{{/toJson}}
+                                }
+                            }
+                        ]
                     }
-                }
-            },
+                }""",
+            }
         }
     }
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1696


In a review of the [DLS + Internal Knowledge Search blog](https://www.elastic.co/search-labs/blog/articles/dls-internal-knowledge-search), @xeraa [had commented](https://github.com/elastic/search-labs-elastic-co/pull/292#discussion_r1467288194) that our DLS query looked overly complex. This sent me down a rabbit hole, first figuring out that our example DLS app _was_ using an overly-complex query, then wondering why we were having to create an explicit query at all, then finally realizing I'd had these thoughts before and filed https://github.com/elastic/connectors/issues/1696 to eventually address the issue.

The time has come. 

This PR removes the outer `bool: { filter: {` clause that's no longer necessary (since Workplace Search) as we do not have a `_deny_access_control` pattern for any of our connectors (yet). 

It also fixes the syntax of the output document so that the template contents can be directly taken and shoved into a role descriptor.

## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes

#### Changes Requiring Extra Attention

- [x] Security-related changes

## Related Pull Requests

* related update to the example app: https://github.com/elastic/elasticsearch-labs/pull/18 (we could replace most of the role descriptor once this PR is merged)


## Release Note

Changes the output structure of the documents created by ACL Syncs. Now these docs are appropriately structured to create Role Descriptors. The structure to access the identity and its permissions have not changed. This structure can take up to half as much space to store as the previous structure.
