### PR TITLE
[CI] Update nightly CI pipelines to use the right branches

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,12 +22,9 @@ spec:
   lifecycle: "production"
   owner: "group:ingestion-team"
 
-###############################################################################
-############################# buildkite pipelines #############################
-# Declare our Buildkite pipelines
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+# ------------------------------------------------------------------------------
+# this is the main pipeline, triggered via pull requests and merges
 
-# Declare the main pipeline that's used for PRs and commits
 ---
 apiVersion: "backstage.io/v1alpha1"
 kind: "Resource"
@@ -57,8 +54,9 @@ spec:
         ingestion-team: {}
         search-productivity-team: {}
 
-############################# Nightly Test Suites #############################
-# Declare daily/nightly tests pipeline
+# ------------------------------------------------------------------------------
+# nightly pipelines
+
 ---
 apiVersion: "backstage.io/v1alpha1"
 kind: "Resource"
@@ -87,18 +85,6 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
-        Daily 8_9:
-          branch: '8.9'
-          cronline: '@daily'
-          message: "Runs daily `8.9` e2e test"
-        Daily 8_10:
-          branch: '8.10'
-          cronline: '@daily'
-          message: "Runs daily `8.10` e2e test"
-        Daily 8_11:
-          branch: '8.11'
-          cronline: '@daily'
-          message: "Runs daily `8.11` e2e test"   
         Daily 8_12:
           branch: '8.12'
           cronline: '@daily'
@@ -113,15 +99,12 @@ spec:
         ingestion-team: {}
         search-productivity-team: {}
 
-
-############################# Nightly Test Suites #############################
-# Declare daily/nightly aarch64 tests pipeline
 ---
 apiVersion: "backstage.io/v1alpha1"
 kind: "Resource"
 metadata:
   name: "connectors-nightly-aarch64"
-  description: "Nightly Connector Service Tests"
+  description: "Nightly Connector Service Tests on aarch64"
   links:
     - title: "connectors Nightly Buildkite Jobs"
       url: "https://buildkite.com/elastic/connectors"
@@ -134,7 +117,7 @@ spec:
     kind: "Pipeline"
     metadata:
       name: "connectors-nightly-aarch64"
-      description: "Connectors Service Nightly Tests"
+      description: "Connectors Service Nightly Tests on aarch64"
       links:
         - title: "Connector Service Nightly Pipeline"
           url: "https://buildkite.com/elastic/connectors-nightly-aarch64"
@@ -144,6 +127,10 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
+        Daily 8_12:
+          branch: '8.12'
+          cronline: '@daily'
+          message: "Runs daily `8.12` e2e aarch64 test"
         Daily main:
           branch: main
           cronline: '@daily'
@@ -154,7 +141,6 @@ spec:
         ingestion-team: {}
         search-productivity-team: {}
 
-############################# Nightly Test Suites #############################
 ---
 apiVersion: "backstage.io/v1alpha1"
 kind: "Resource"
@@ -183,26 +169,14 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
-        Daily 8_9:
-          branch: '8.9'
-          cronline: '@daily'
-          message: "Runs daily `8.9` e2e aarch64 test"
-        Daily 8_10:
-          branch: '8.10'
-          cronline: '@daily'
-          message: "Runs daily `8.10` e2e aarch64 test"
-        Daily 8_11:
-          branch: '8.11'
-          cronline: '@daily'
-          message: "Runs daily `8.11` e2e aarch64 test"
         Daily 8_12:
           branch: '8.12'
           cronline: '@daily'
-          message: "Runs daily `8.12` e2e aarch64 test"
+          message: "Builds and pushes daily `8.12` docker images"
         Daily main:
           branch: main
           cronline: '@daily'
-          message: "Runs daily `main` docker"
+          message: "Builds and pushes daily `main` docker images"
       teams:
         everyone:
           access_level: "READ_ONLY"


### PR DESCRIPTION
* we no longer need to build pre-`8.12`
* we should be building the same branches across all nightly pipelines
