### PR TITLE
Add logic to send a ping to connector's backend every loop

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -91,10 +91,13 @@ class JobSchedulingService(BaseService):
         data_source = source_klass(connector.configuration)
         data_source.set_logger(connector.logger)
 
-        connector.log_debug("Validating configuration")
         try:
+            connector.log_debug("Validating configuration")
             data_source.validate_config_fields()
             await data_source.validate_config()
+
+            connector.log_debug("Pinging the backend")
+            await data_source.ping()
         except Exception as e:
             connector.log_error(e, exc_info=True)
             await connector.error(e)

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -362,6 +362,7 @@ async def test_run_when_connector_fields_are_invalid(
 
     data_source_mock.validate_config_fields = Mock()
     data_source_mock.validate_config = AsyncMock(side_effect=[actual_error])
+    data_source_mock.ping = AsyncMock()
     data_source_mock.close = AsyncMock()
 
     connector = mock_connector(next_sync=datetime.utcnow())
@@ -370,5 +371,36 @@ async def test_run_when_connector_fields_are_invalid(
 
     data_source_mock.validate_config_fields.assert_called()
     data_source_mock.validate_config.assert_awaited_once()
+    data_source_mock.ping.assert_not_awaited()
+
+    connector.error.assert_awaited_with(actual_error)
+
+@pytest.mark.asyncio
+@patch("connectors.services.job_scheduling.get_source_klass")
+async def test_run_when_connector_ping_fails(
+    get_source_klass_mock, connector_index_mock, set_env
+):
+    error_message = "Something invalid is in config!"
+    actual_error = Exception(error_message)
+
+    data_source_mock = Mock()
+
+    def _source_klass(config):
+        return data_source_mock
+
+    get_source_klass_mock.return_value = _source_klass
+
+    data_source_mock.validate_config_fields = Mock()
+    data_source_mock.validate_config = AsyncMock()
+    data_source_mock.ping = AsyncMock(side_effect=[actual_error])
+    data_source_mock.close = AsyncMock()
+
+    connector = mock_connector(next_sync=datetime.utcnow())
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    await create_and_run_service(JobSchedulingService, stop_after=0.15)
+
+    data_source_mock.validate_config_fields.assert_called()
+    data_source_mock.validate_config.assert_awaited_once()
+    data_source_mock.ping.assert_awaited_once()
 
     connector.error.assert_awaited_with(actual_error)

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -381,7 +381,7 @@ async def test_run_when_connector_fields_are_invalid(
 async def test_run_when_connector_ping_fails(
     get_source_klass_mock, connector_index_mock, set_env
 ):
-    error_message = "Something invalid is in config!"
+    error_message = "Something went wrong when trying to ping the data source!"
     actual_error = Exception(error_message)
 
     data_source_mock = Mock()

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -375,6 +375,7 @@ async def test_run_when_connector_fields_are_invalid(
 
     connector.error.assert_awaited_with(actual_error)
 
+
 @pytest.mark.asyncio
 @patch("connectors.services.job_scheduling.get_source_klass")
 async def test_run_when_connector_ping_fails(


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/5678

Additionally to running RCF validation (see https://github.com/elastic/connectors/pull/2093) every time we check connector for whether the job should be scheduled, now we send a ping to the backend of this connector as well to verify, that it's available.

Before this logic would happen only before sync, which is too late.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

- https://github.com/elastic/connectors/pull/2093

## Release Note

Now configurations checks health of 3rd-party system periodically and reports errors to Kibana. Previously it was only done before the sync is started.