### PR TITLE
Switch to an official Oracle container image in functional tests

### DIFF
--- a/tests/sources/fixtures/oracle/connector.json
+++ b/tests/sources/fixtures/oracle/connector.json
@@ -27,13 +27,13 @@
                         "label": "Port",
                         "order": 2,
                         "type": "int",
-                        "value": 9090
+                        "value": 1521
                 },
                 "username": {
                         "label": "Username",
                         "order": 3,
                         "type": "str",
-                        "value": "admin"
+                        "value": "c##admin"
                 },
                 "password": {
                         "label": "Password",
@@ -46,7 +46,7 @@
                         "label": "Database",
                         "order": 5,
                         "type": "str",
-                        "value": "xe"
+                        "value": "FREE"
                 },
                 "tables": {
                         "display": "textarea",

--- a/tests/sources/fixtures/oracle/docker-compose.yml
+++ b/tests/sources/fixtures/oracle/docker-compose.yml
@@ -74,11 +74,11 @@ services:
       - esnet
 
   oracle:
-    image: gvenzl/oracle-xe:latest
+    image: container-registry.oracle.com/database/free:latest
     ports:
-      - 9090:1521
-    environment: 
-      - ORACLE_PASSWORD=Password_123
+      - 1521:1521
+    environment:
+      - ORACLE_PWD=Password_123
     restart: always
 
 networks:

--- a/tests/sources/fixtures/oracle/fixture.py
+++ b/tests/sources/fixtures/oracle/fixture.py
@@ -21,10 +21,10 @@ RETRY_INTERVAL = 4
 RETRIES = 1
 BATCH_SIZE = 100
 
-USER = "admin"
+USER = "c##admin"
 PASSWORD = "Password_123"
 ENCODING = "UTF-8"
-DSN = "(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=9090))(CONNECT_DATA=(SID=xe)))"
+DSN = "localhost:1521/FREE"
 
 DATA_SIZE = os.environ.get("DATA_SIZE", "medium").lower()
 
@@ -70,8 +70,8 @@ async def load():
         user="system", password=PASSWORD, dsn=DSN, encoding=ENCODING
     )
     cursor = connection.cursor()
-    cursor.execute("CREATE USER admin IDENTIFIED by Password_123")
-    cursor.execute("GRANT CONNECT, RESOURCE, DBA TO admin")
+    cursor.execute(f"CREATE USER {USER} IDENTIFIED by {PASSWORD} CONTAINER=ALL")
+    cursor.execute(f"GRANT CONNECT, RESOURCE, DBA TO {USER}")
     connection.commit()
 
     connection = oracledb.connect(


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1853

This updates the Oracle connector's functional tests to use an officlal container image from Oracle, instead of the community/third-party Oracle Express Edition image we have been using. According to [this post](https://medium.com/version-1/oracle-database-express-edition-now-database-free-ed5aa444152), Oracle Free appears to supersede Express Edition, so it probably makes sense to switch to testing against it.

Note however that with this change we are still can't enable the Oracle functional tests [on arm64](https://github.com/elastic/connectors/blob/main/.buildkite/nightly_steps.yml#L41), since getting an arm64 Oracle container image is [a bit more complicated](https://github.com/elastic/connectors/issues/1579#issuecomment-1924745013).