### PR TITLE
Add problem URL to error message

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -1021,7 +1021,7 @@ class SharepointOnlineClient:
         actual_tenant_name = self._tenant_name_pattern.findall(url)[0]
 
         if self._tenant_name != actual_tenant_name:
-            msg = f"Unable to call Sharepoint REST API - tenant name is invalid. Authenticated for tenant name: {self._tenant_name}, actual tenant name for the service: {actual_tenant_name}."
+            msg = f"Unable to call Sharepoint REST API - tenant name is invalid. Authenticated for tenant name: {self._tenant_name}, actual tenant name for the service: {actual_tenant_name}. For url: {url}"
             raise InvalidSharepointTenant(msg)
 
     async def close(self):


### PR DESCRIPTION

See https://elastic.slack.com/archives/C7LLL50CA/p1706800182262059?thread_ts=1705426484.605769&cid=C7LLL50CA

Users can get an error that tells them that the tenant name is wrong, but it's difficult to track down _what_ is causing this issue. Adding the URL will let us go track down which item is associated with a different tennant. 

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
