### PR TITLE
Improve debug log for next sync message

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -210,7 +210,7 @@ class JobSchedulingService(BaseService):
 
             try:
                 next_sync = connector.next_sync(job_type, last_wake_up_time)
-                connector.log_debug(f"Next sync is at {next_sync}")
+                connector.log_debug(f"Next '{job_type_value}' sync is at {next_sync}")
             except Exception as e:
                 connector.log_critical(e, exc_info=True)
                 await connector.error(str(e))


### PR DESCRIPTION
Minor improvement: 

Log message that says when next sync happens was missing the sync type.

Before:

```
[FMWK][17:03:59][DEBUG] [Connector id: network_drive, index name: search-network_drive] Next sync is at 2024-02-02 16:04:01.648207
```

After:

```
[FMWK][17:03:59][DEBUG] [Connector id: network_drive, index name: search-network_drive] Next 'full' sync is at 2024-02-02 16:04:01.648207
```