### PR TITLE
Use API keys for native connector syncs

### DIFF
--- a/connectors/es/management_client.py
+++ b/connectors/es/management_client.py
@@ -183,3 +183,13 @@ class ESManagementClient(ESClient):
             timestamp = source.get(TIMESTAMP_FIELD)
 
             yield doc_id, timestamp
+
+    async def get_connector_secret(self, connector_secret_id):
+        secret = await self._retrier.execute_with_retry(
+            partial(
+                self.client.perform_request,
+                "GET",
+                f"/_connector/_secret/{connector_secret_id}",
+            )
+        )
+        return secret.get("value")

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -24,6 +24,10 @@ import logging
 import time
 from collections import defaultdict
 
+from elasticsearch import (
+    NotFoundError as ElasticNotFoundError,
+)
+
 from connectors.config import (
     DEFAULT_ELASTICSEARCH_MAX_RETRIES,
     DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,
@@ -47,9 +51,6 @@ from connectors.utils import (
     get_size,
     iso_utc,
     retryable,
-)
-from elasticsearch import (
-    NotFoundError as ElasticNotFoundError,
 )
 
 __all__ = ["SyncOrchestrator"]
@@ -673,9 +674,9 @@ class SyncOrchestrator:
                 f"Using API key found in secrets storage for authorization for index [{index_name}]."
             )
             self.es_management_client.client.options(api_key=api_key)
-        except ElasticNotFoundError:
+        except ElasticNotFoundError as e:
             msg = f"API key not found in secrets storage for index [{index_name}]."
-            raise ApiKeyNotFoundError(msg)
+            raise ApiKeyNotFoundError(msg) from e
 
     async def has_active_license_enabled(self, license_):
         # TODO: think how to make it not a proxy method to the client

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -467,6 +467,8 @@ class Features:
     BASIC_RULES_OLD = "basic_rules_old"
     ADVANCED_RULES_OLD = "advanced_rules_old"
 
+    NATIVE_CONNECTOR_API_KEYS = "native_connector_api_keys"
+
     def __init__(self, features=None):
         if features is None:
             features = {}
@@ -481,6 +483,11 @@ class Features:
     def document_level_security_enabled(self):
         return self._nested_feature_enabled(
             ["document_level_security", "enabled"], default=False
+        )
+
+    def native_connector_api_keys_enabled(self):
+        return self._nested_feature_enabled(
+            ["native_connector_api_keys", "enabled"], default=False
         )
 
     def sync_rules_enabled(self):
@@ -623,6 +630,10 @@ class Connector(ESDocument):
     @property
     def sync_cursor(self):
         return self.get("sync_cursor")
+
+    @property
+    def api_key_secret_id(self):
+        return self.get("api_key_secret_id")
 
     async def heartbeat(self, interval):
         if (

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -385,6 +385,7 @@ class BaseDataSource:
     advanced_rules_enabled = False
     dls_enabled = False
     incremental_sync_enabled = False
+    native_connector_api_keys_enabled = False
 
     def __init__(self, configuration):
         # Initialize to the global logger
@@ -489,6 +490,9 @@ class BaseDataSource:
             },
             "incremental_sync": {
                 "enabled": cls.incremental_sync_enabled,
+            },
+            "native_connector_api_keys": {
+                "enabled": cls.native_connector_api_keys_enabled,
             },
         }
 

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -144,7 +144,10 @@ class SyncJobRunner:
                 self.es_config, self.sync_job.logger
             )
 
-            if self.connector.native and self.connector.features.native_connector_api_keys_enabled():
+            if (
+                self.connector.native
+                and self.connector.features.native_connector_api_keys_enabled()
+            ):
                 await self.sync_orchestrator.update_authorization(
                     self.connector.index_name, self.connector.api_key_secret_id
                 )
@@ -231,7 +234,7 @@ class SyncJobRunner:
             is BaseDataSource.get_docs_incrementally
         )
 
-    async def  _execute_content_sync_job(self, job_type, bulk_options):
+    async def _execute_content_sync_job(self, job_type, bulk_options):
         if (
             self.sync_job.job_type == JobType.INCREMENTAL
             and not self.connector.features.incremental_sync_enabled()

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -124,7 +124,6 @@ class SyncJobRunner:
                 await self._sync_done(sync_status=JobStatus.COMPLETED)
                 return
 
-            self.sync_job.log_debug(f"Features: {self.connector.features}")
             self.data_provider.set_features(self.connector.features)
 
             self.sync_job.log_debug("Validating configuration")

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -52,7 +52,8 @@ All communication will need to go through Elasticsearch. We've created a connect
 This is our main communication index, used to communicate the connector's configuration, status and other related data. All dates in UTC.
 ```
 {
-  api_key_id: string;   -> ID of the current API key in use
+  api_key_id: string;           -> ID of the current API key in use
+  api_key_secret_id: string;    -> ID of Connector Secret doc that stores the API key
   configuration: {
     [key]: {
       default_value: any;   -> The value used if `value` is empty (only for non-required fields)
@@ -188,6 +189,7 @@ This is our main communication index, used to communicate the connector's config
   "dynamic": false,
   "properties" : {
     "api_key_id" : { "type" : "keyword" },
+    "api_key_secret_id" : { "type" : "keyword" },
     "configuration" : { "type" : "object" },
     "custom_scheduling" : { "type" : "object" },
     "description" : { "type" : "text" },

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -255,22 +255,34 @@ class TestESManagementClient:
 
     @pytest.mark.asyncio
     async def test_get_connector_secret(self, es_management_client, mock_responses):
-        secret_id = 'secret-id'
+        secret_id = "secret-id"
 
-        es_management_client.client.perform_request = AsyncMock(return_value={'id': secret_id, 'value': 'secret-value'})
+        es_management_client.client.perform_request = AsyncMock(
+            return_value={"id": secret_id, "value": "secret-value"}
+        )
 
         secret = await es_management_client.get_connector_secret(secret_id)
-        assert secret == 'secret-value'
-        es_management_client.client.perform_request.assert_awaited_with('GET', f"/_connector/_secret/{secret_id}")
+        assert secret == "secret-value"
+        es_management_client.client.perform_request.assert_awaited_with(
+            "GET", f"/_connector/_secret/{secret_id}"
+        )
 
     @pytest.mark.asyncio
-    async def test_get_connector_secret_when_secret_does_not_exist(self, es_management_client, mock_responses):
-        secret_id = 'secret-id'
+    async def test_get_connector_secret_when_secret_does_not_exist(
+        self, es_management_client, mock_responses
+    ):
+        secret_id = "secret-id"
 
         error_meta = Mock()
         error_meta.status = 404
-        es_management_client.client.perform_request = AsyncMock(side_effect=ElasticNotFoundError('resource_not_found_exception', error_meta, f"No secret with id [{secret_id}]"))
+        es_management_client.client.perform_request = AsyncMock(
+            side_effect=ElasticNotFoundError(
+                "resource_not_found_exception",
+                error_meta,
+                f"No secret with id [{secret_id}]",
+            )
+        )
 
         with pytest.raises(ElasticNotFoundError):
             secret = await es_management_client.get_connector_secret(secret_id)
-            assert secret == None
+            assert secret is None

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -201,6 +201,7 @@ def test_utc():
 
 mongo = {
     "api_key_id": "",
+    "api_key_secret_id": "",
     "configuration": {
         "host": {"value": "mongodb://127.0.0.1:27021", "label": "MongoDB Host"},
         "database": {"value": "sample_airbnb", "label": "MongoDB Database"},
@@ -321,6 +322,7 @@ async def test_connector_properties():
     connector_src = {
         "_id": "test",
         "_source": {
+            "api_key_secret_id": "api-key-secret-id",
             "service_type": "test",
             "index_name": "search-some-index",
             "configuration": {},
@@ -360,6 +362,7 @@ async def test_connector_properties():
     assert connector.incremental_sync_scheduling["enabled"]
     assert connector.incremental_sync_scheduling["interval"] == "* * * * *"
     assert connector.sync_cursor == SYNC_CURSOR
+    assert connector.api_key_secret_id == "api-key-secret-id"
     assert isinstance(connector.last_seen, datetime)
     assert isinstance(connector.filtering, Filtering)
     assert isinstance(connector.pipeline, Pipeline)

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -1303,27 +1303,49 @@ async def test_cancel_sync(extractor_task_done, sink_task_done, force_cancel):
             es._extractor.force_cancel.assert_not_called()
             es._sink.force_cancel.assert_not_called()
 
+
 @pytest.mark.asyncio
 async def test_update_authorization():
-    config = {"host": "http://nowhere.com:9200", "user": "someone", "password": "something"}
+    config = {
+        "host": "http://nowhere.com:9200",
+        "user": "someone",
+        "password": "something",
+    }
     sync_orchestrator = SyncOrchestrator(config)
 
-    sync_orchestrator.es_management_client.get_connector_secret = AsyncMock(return_value='secret-value')
+    sync_orchestrator.es_management_client.get_connector_secret = AsyncMock(
+        return_value="secret-value"
+    )
     sync_orchestrator.es_management_client.client.options = AsyncMock()
 
-    await sync_orchestrator.update_authorization('my-index', 'my-secret-id')
+    await sync_orchestrator.update_authorization("my-index", "my-secret-id")
 
-    sync_orchestrator.es_management_client.get_connector_secret.assert_called_with('my-secret-id')
-    sync_orchestrator.es_management_client.client.options.assert_called_with(api_key='secret-value')
+    sync_orchestrator.es_management_client.get_connector_secret.assert_called_with(
+        "my-secret-id"
+    )
+    sync_orchestrator.es_management_client.client.options.assert_called_with(
+        api_key="secret-value"
+    )
+
 
 @pytest.mark.asyncio
 async def test_update_authorization_when_api_key_not_found():
-    config = {"host": "http://nowhere.com:9200", "user": "someone", "password": "something"}
+    config = {
+        "host": "http://nowhere.com:9200",
+        "user": "someone",
+        "password": "something",
+    }
     sync_orchestrator = SyncOrchestrator(config)
 
     error_meta = Mock()
     error_meta.status = 404
-    sync_orchestrator.es_management_client.get_connector_secret = AsyncMock(side_effect=ElasticNotFoundError('resource_not_found_exception', error_meta, f"No secret with id [my-secret-id]"))
+    sync_orchestrator.es_management_client.get_connector_secret = AsyncMock(
+        side_effect=ElasticNotFoundError(
+            "resource_not_found_exception",
+            error_meta,
+            "No secret with id [my-secret-id]",
+        )
+    )
 
     with pytest.raises(ApiKeyNotFoundError):
-        await sync_orchestrator.update_authorization('my-index', 'my-secret-id')
+        await sync_orchestrator.update_authorization("my-index", "my-secret-id")

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -896,6 +896,7 @@ async def test_unsupported_job_type():
     with pytest.raises(SyncJobStartError):
         await sync_job_runner.execute()
 
+
 @pytest.mark.parametrize(
     "job_type, sync_cursor",
     [
@@ -915,7 +916,9 @@ async def test_native_connector_sync_fails_when_api_key_secret_missing(
         "total_document_count": TOTAL_DOCUMENT_COUNT,
     }
     sync_orchestrator_mock.ingestion_stats.return_value = ingestion_stats
-    sync_orchestrator_mock.update_authorization = AsyncMock(side_effect=ApiKeyNotFoundError())
+    sync_orchestrator_mock.update_authorization = AsyncMock(
+        side_effect=ApiKeyNotFoundError()
+    )
 
     sync_job_runner = create_runner(job_type=job_type, sync_cursor=sync_cursor)
 
@@ -935,6 +938,7 @@ async def test_native_connector_sync_fails_when_api_key_secret_missing(
     sync_job_runner.connector.sync_done.assert_awaited_with(
         sync_job_runner.sync_job, cursor=sync_cursor
     )
+
 
 @pytest.mark.parametrize(
     "job_type, sync_cursor",
@@ -957,9 +961,13 @@ async def test_connector_client_sync_succeeds_when_api_key_secret_missing(
         "deleted_document_count": 20,
     }
     sync_orchestrator_mock.ingestion_stats.return_value = ingestion_stats
-    sync_orchestrator_mock.update_authorization = AsyncMock(side_effect=ApiKeyNotFoundError())
+    sync_orchestrator_mock.update_authorization = AsyncMock(
+        side_effect=ApiKeyNotFoundError()
+    )
 
-    sync_job_runner = create_runner(job_type=job_type, connector=connector, sync_cursor=sync_cursor)
+    sync_job_runner = create_runner(
+        job_type=job_type, connector=connector, sync_cursor=sync_cursor
+    )
     await sync_job_runner.execute()
 
     ingestion_stats["total_document_count"] = TOTAL_DOCUMENT_COUNT


### PR DESCRIPTION
## Summary

In 8.13 we will be using API keys for native connector content ingestion. This is applicable to both content and ACL syncs.
API keys are generated for native connectors upon creation ([Kibana changes here](https://github.com/elastic/kibana/pull/176046)). The API keys are stored in secrets storage, with a reference in the connector document under `api_key_secret_id`.

When performing a sync, a native connector will now fetch its API key from secrets storage and use that as the authorization header for requests. This is only for the duration of that sync. The connector will fetch the API key each time it syncs. This is so that if the user changes the API key, they don't need to restart everything to have it applied.

These changes do not impact connector clients, which will continue to use the authorization set in the `confg.yml` file.

Lastly, this is behind a feature flag called `native_connector_api_keys`. This is `False` by default for all connectors for now. I intend for this to be `True` when we release, but these changes will likely impact others' development (and also I still need to confirm they will work on cloud), so for now it is `False`.

### Changes

- Add method in `ESManagementClient` for fetching connector secrets
- Change authorization for native connector syncs to API key found in connector secrets doc
- Add feature flag `native_connector_api_keys` with default value `False`
- Add unit tests
