### PR TITLE
introduce limited syncs

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -409,7 +409,7 @@ class Extractor:
         lazy_downloads = ConcurrentTasks(self.concurrent_downloads)
         try:
             async for count, doc in aenumerate(generator):
-                if limit and count >= limit:
+                if limit is not None and count >= limit:
                     break
 
                 doc, lazy_download, operation = doc

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -283,6 +283,10 @@ class SyncJob(ESDocument):
     def job_type(self):
         return JobType(self.get("job_type"))
 
+    @property
+    def params(self):
+        return self.get("parameters", default=None)
+
     def is_content_sync(self):
         return self.job_type in (JobType.FULL, JobType.INCREMENTAL)
 

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -268,6 +268,7 @@ class SyncJobRunner:
             skip_unchanged_documents=self._skip_unchanged_documents_enabled(
                 job_type, self.data_provider
             ),
+            custom_params=self.sync_job.params,
         )
 
     async def _sync_done(self, sync_status, sync_error=None):
@@ -327,12 +328,14 @@ class SyncJobRunner:
 
     @with_concurrency_control()
     async def sync_starts(self):
+        logger.debug("Made it to sync_starts")
         if not await self.reload_connector():
             msg = f"Couldn't reload connector {self.connector.id}"
             raise SyncJobStartError(msg)
 
         job_type = self.sync_job.job_type
 
+        logger.debug(f"Job type is {job_type}")
         if job_type in [JobType.FULL, JobType.INCREMENTAL]:
             if self.connector.last_sync_status == JobStatus.IN_PROGRESS:
                 logger.debug(

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -328,14 +328,12 @@ class SyncJobRunner:
 
     @with_concurrency_control()
     async def sync_starts(self):
-        logger.debug("Made it to sync_starts")
         if not await self.reload_connector():
             msg = f"Couldn't reload connector {self.connector.id}"
             raise SyncJobStartError(msg)
 
         job_type = self.sync_job.job_type
 
-        logger.debug(f"Job type is {job_type}")
         if job_type in [JobType.FULL, JobType.INCREMENTAL]:
             if self.connector.last_sync_status == JobStatus.IN_PROGRESS:
                 logger.debug(


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2129

This PR introduces an optional `parameters` object to the connector sync job record. This will allow us to trigger sync jobs based on the same connector configuration but with different runtime parameters. 

The first such parameter (also introduced here) is `limit`, which will function much like a SQL "limit clause" to constrain how many documents are sent to Elasticsearch.

This does not necessarily influence how many documents are fetched from the 3rd-party - it just prematurely terminates the sync job once the limited number of documents have been pulled from the generator.

On its own, this change is not usable. Neither Kibana, the connectors API, nor the CLI leverage the `parameters` object yet. Those will be addressed in separate PRs.

To test, you can follow a process like:
1. create a connector
2. configure your config.yml with the connector ID
3. start the connectors process
4. configure your connector
5. stop the connectors process
6. start a full sync through Kibana (no connector process is available to pick up this job yet)
7. look up the job record in `.elastic-connectors-sync-jobs` and modify it to have `"parameters": {"limit": 1}`
8. re-start the connectors process
9. the job should index just one document and "complete" successfully

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
  - will follow up once these parameters are actually exposed
