### PR TITLE
Make Gmail connector's 'subject' field label match docs

### DIFF
--- a/connectors/sources/gmail.py
+++ b/connectors/sources/gmail.py
@@ -32,7 +32,7 @@ from connectors.utils import (
 
 CUSTOMER_ID_LABEL = "Google customer id"
 
-SUBJECT_LABEL = "Subject"
+SUBJECT_LABEL = "Google Workspace admin email"
 
 SERVICE_ACCOUNT_CREDENTIALS_LABEL = "GMail service account JSON"
 
@@ -180,7 +180,7 @@ class GMailDataSource(BaseDataSource):
         subject = self.configuration["subject"]
 
         if not validate_email_address(subject):
-            msg = f"Subject field value needs to be a valid email address. '{subject}' is invalid."
+            msg = f"{SUBJECT_LABEL} field value needs to be a valid email address. '{subject}' is invalid."
             raise ConfigurableFieldValueError(msg)
 
         await self._validate_google_directory_auth()


### PR DESCRIPTION
In the Gmail connector's config, the 'Subject' config field's label didn't match how that field is referred to in the [docs](https://www.elastic.co/guide/en/enterprise-search/8.12/connectors-gmail.html). It should be labeled 'Google Workspace admin email' instead.
