### PR TITLE
limited syncs in cli

### DIFF
--- a/connectors/cli/job.py
+++ b/connectors/cli/job.py
@@ -28,8 +28,8 @@ class Job:
     def cancel(self, connector_id=None, index_name=None, job_id=None):
         return asyncio.run(self.__async_cancel_jobs(connector_id, index_name, job_id))
 
-    def start(self, connector_id, job_type):
-        return asyncio.run(self.__async_start(connector_id, job_type))
+    def start(self, connector_id, job_type, parameters):
+        return asyncio.run(self.__async_start(connector_id, job_type, parameters))
 
     def job(self, job_id):
         return asyncio.run(self.__async_job(job_id))
@@ -45,13 +45,14 @@ class Job:
             await self.sync_job_index.close()
             await self.es_management_client.close()
 
-    async def __async_start(self, connector_id, job_type):
+    async def __async_start(self, connector_id, job_type, parameters):
         try:
             connector = await self.connector_index.fetch_by_id(connector_id)
             job_id = await self.sync_job_index.create(
                 connector=connector,
                 trigger_method=JobTriggerMethod.ON_DEMAND,
                 job_type=JobType(job_type),
+                parameters=parameters,
             )
 
             return job_id

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -1003,7 +1003,7 @@ class SyncJobIndex(ESIndex):
             doc_source=doc_source,
         )
 
-    async def create(self, connector, trigger_method, job_type):
+    async def create(self, connector, trigger_method, job_type, parameters=None):
         filtering = connector.filtering.get_active_filter().transform_filtering()
         index_name = connector.index_name
 
@@ -1029,6 +1029,8 @@ class SyncJobIndex(ESIndex):
             "created_at": iso_utc(),
             "last_seen": iso_utc(),
         }
+        if parameters:
+            job_def["parameters"] = parameters
         api_response = await self.index(job_def)
 
         return api_response["_id"]


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2130


This adds the capability for us to trigger sync jobs with specific runtime params, by specifying a `-p` option to `bin/connectors job start` that takes a JSON string describing such params.

Example usage:
```
bin/connectors job start -i T-pJYY0Bk83P4QElXhsn -t full -p '{"limit": 1}'
```

updated help text:
```
$ bin/connectors job start --help
Usage: connectors job start [OPTIONS]

  Start a sync job.

Options:
  -i TEXT                         Connector ID  [required]
  -t [full|incremental|access_control]
                                  Job type  [required]
  -p TEXT                         JSON representation of job parameters
  -o, --format [json|text]        Output format
  --help                          Show this message and exit.

```

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
  - will document separately

## Related Pull Requests

* builds off of https://github.com/elastic/connectors/pull/2137

