### PR TITLE
Enabled incremental syncs for more connectors

### DIFF
--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -27,6 +27,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
 
     name = "Azure Blob Storage"
     service_type = "azure_blob_storage"
+    incremental_sync_enabled = True
 
     def __init__(self, configuration):
         """Set up the connection to the azure base client

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -982,6 +982,7 @@ class GitHubDataSource(BaseDataSource):
     service_type = "github"
     advanced_rules_enabled = True
     dls_enabled = True
+    incremental_sync_enabled = True
 
     def __init__(self, configuration):
         """Setup the connection to the GitHub instance.

--- a/connectors/sources/gmail.py
+++ b/connectors/sources/gmail.py
@@ -109,6 +109,7 @@ class GMailDataSource(BaseDataSource):
     service_type = "gmail"
     advanced_rules_enabled = True
     dls_enabled = True
+    incremental_sync_enabled = True
 
     def __init__(self, configuration):
         super().__init__(configuration=configuration)

--- a/connectors/sources/microsoft_teams.py
+++ b/connectors/sources/microsoft_teams.py
@@ -839,6 +839,7 @@ class MicrosoftTeamsDataSource(BaseDataSource):
 
     name = "Microsoft Teams"
     service_type = "microsoft_teams"
+    incremental_sync_enabled = True
 
     def __init__(self, configuration):
         """Set up the connection to the Microsoft Teams.

--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -645,6 +645,7 @@ class OutlookDataSource(BaseDataSource):
 
     name = "Outlook"
     service_type = "outlook"
+    incremental_sync_enabled = True
 
     def __init__(self, configuration):
         """Setup the connection to the Outlook

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -1286,6 +1286,7 @@ class SalesforceDataSource(BaseDataSource):
     service_type = "salesforce"
     advanced_rules_enabled = True
     dls_enabled = True
+    incremental_sync_enabled = True
 
     def __init__(self, configuration):
         super().__init__(configuration=configuration)


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6468

This enables incremental syncs for the connectors which can present `_timestamp` field. Therefore, they can use the optimization introduced in this [PR](https://github.com/elastic/connectors/pull/2057).

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

* https://github.com/elastic/connectors/pull/2057

## Release Note
Enable incremental sync jobs for Github, Outlook, Gmail, Azure blog storage, and Microsoft Teams connectors.
