### PR TITLE
Revert "Bump Dockerfile base image to python:3.11.6-slim (#1911)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM python:3.11.6-slim
+FROM python:3.10
 COPY . /app
 WORKDIR /app
-RUN apt update && \
-    apt upgrade -y && \
-    apt install -y make build-essential && \
-    rm -rf /var/lib/apt/lists/*
-RUN make clean install PYTHON=python3.11
+RUN make clean install

--- a/Dockerfile.ftest
+++ b/Dockerfile.ftest
@@ -1,9 +1,5 @@
-FROM python:3.11.6-slim
+FROM python:3.10
 COPY . /connectors
 WORKDIR /connectors
-RUN apt update && \
-    apt upgrade -y && \
-    apt install -y make build-essential && \
-    rm -rf /var/lib/apt/lists/*
-RUN make clean install PYTHON=python3.11
+RUN make clean install
 RUN bin/pip install -r requirements/ftest.txt


### PR DESCRIPTION
This reverts commit 7baa53991844f3cf43464e0e3f5908277a859b48.

Related to: https://github.com/elastic/connectors/issues/2144

Python 3.11 is incompatible with a MongoDB dependency Motor, so revert to 3.10 until that dependency issue can be resolved.