### PR TITLE
Revert "Add logic to send a ping to connector's backend every loop (#2105)"

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -91,13 +91,10 @@ class JobSchedulingService(BaseService):
         data_source = source_klass(connector.configuration)
         data_source.set_logger(connector.logger)
 
+        connector.log_debug("Validating configuration")
         try:
-            connector.log_debug("Validating configuration")
             data_source.validate_config_fields()
             await data_source.validate_config()
-
-            connector.log_debug("Pinging the backend")
-            await data_source.ping()
         except Exception as e:
             connector.log_error(e, exc_info=True)
             await connector.error(e)

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -362,7 +362,6 @@ async def test_run_when_connector_fields_are_invalid(
 
     data_source_mock.validate_config_fields = Mock()
     data_source_mock.validate_config = AsyncMock(side_effect=[actual_error])
-    data_source_mock.ping = AsyncMock()
     data_source_mock.close = AsyncMock()
 
     connector = mock_connector(next_sync=datetime.utcnow())
@@ -371,37 +370,5 @@ async def test_run_when_connector_fields_are_invalid(
 
     data_source_mock.validate_config_fields.assert_called()
     data_source_mock.validate_config.assert_awaited_once()
-    data_source_mock.ping.assert_not_awaited()
-
-    connector.error.assert_awaited_with(actual_error)
-
-
-@pytest.mark.asyncio
-@patch("connectors.services.job_scheduling.get_source_klass")
-async def test_run_when_connector_ping_fails(
-    get_source_klass_mock, connector_index_mock, set_env
-):
-    error_message = "Something went wrong when trying to ping the data source!"
-    actual_error = Exception(error_message)
-
-    data_source_mock = Mock()
-
-    def _source_klass(config):
-        return data_source_mock
-
-    get_source_klass_mock.return_value = _source_klass
-
-    data_source_mock.validate_config_fields = Mock()
-    data_source_mock.validate_config = AsyncMock()
-    data_source_mock.ping = AsyncMock(side_effect=[actual_error])
-    data_source_mock.close = AsyncMock()
-
-    connector = mock_connector(next_sync=datetime.utcnow())
-    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    await create_and_run_service(JobSchedulingService, stop_after=0.15)
-
-    data_source_mock.validate_config_fields.assert_called()
-    data_source_mock.validate_config.assert_awaited_once()
-    data_source_mock.ping.assert_awaited_once()
 
     connector.error.assert_awaited_with(actual_error)


### PR DESCRIPTION

This reverts commit 038e4724d9c1471c8df893a4f595c0da6e07fc4c.

This change is a valuable one, but seems to have broken our nightly CI. We can re-introduce it in a follow-up, along with targeted fixes to the Box and Network Drive ftests that were failing. In the mean time, this will unblock some other work.



## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

- unblocks https://github.com/elastic/connectors/pull/2146


