### PR TITLE
Remove unsafe dict call from ServiceNow

### DIFF
--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -324,9 +324,21 @@ class ServiceNowClient:
                 ]
                 async for table_data in self.get_data(batched_apis=batched_apis):
                     for mapping in table_data:  # pyright: ignore
-                        if mapping["label"] in invalid_services:
-                            servicenow_mapping[mapping["label"]] = mapping["name"]
-                            invalid_services.remove(mapping["label"])
+                        name = mapping.get("name")
+                        if not name:
+                            msg = f"Entry in sys_db_object without sysparm_field 'name' was found. This is a non-issue if no invalid services are flagged."
+                            self._logger.debug(msg)
+                            continue
+
+                        label = mapping.get("label")
+                        if not label:
+                            msg = f"Entry in sys_db_object without sysparm_field 'label' was found. This is a non-issue if no invalid services are flagged."
+                            self._logger.debug(msg)
+                            continue
+
+                        if label in invalid_services:
+                            servicenow_mapping[label] = name
+                            invalid_services.remove(label)
 
             return servicenow_mapping, invalid_services
 

--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -326,13 +326,13 @@ class ServiceNowClient:
                     for mapping in table_data:  # pyright: ignore
                         name = mapping.get("name")
                         if not name:
-                            msg = f"Entry in sys_db_object without sysparm_field 'name' was found. This is a non-issue if no invalid services are flagged."
+                            msg = "Entry in sys_db_object without sysparm_field 'name' was found. This is a non-issue if no invalid services are flagged."
                             self._logger.debug(msg)
                             continue
 
                         label = mapping.get("label")
                         if not label:
-                            msg = f"Entry in sys_db_object without sysparm_field 'label' was found. This is a non-issue if no invalid services are flagged."
+                            msg = "Entry in sys_db_object without sysparm_field 'label' was found. This is a non-issue if no invalid services are flagged."
                             self._logger.debug(msg)
                             continue
 

--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -348,7 +348,7 @@ class ServiceNowClient:
             raise
 
     def _log_missing_sysparm_field(self, sys_id, field):
-        msg = f"Entry in sys_db_object with id '{sys_id}' is missing sysparm_field '{field}'. This is a non-issue if no invalid services are flagged."
+        msg = f"Entry in sys_db_object with sys_id '{sys_id}' is missing sysparm_field '{field}'. This is a non-issue if no invalid services are flagged."
         self._logger.debug(msg)
 
     async def ping(self):

--- a/connectors/sources/servicenow.py
+++ b/connectors/sources/servicenow.py
@@ -324,15 +324,15 @@ class ServiceNowClient:
                 ]
                 async for table_data in self.get_data(batched_apis=batched_apis):
                     for mapping in table_data:  # pyright: ignore
-                        id = mapping.get("sys_id")
+                        sys_id = mapping.get("sys_id")
                         name = mapping.get("name")
                         if not name:
-                            self._log_missing_sysparm_field(id, "name")
+                            self._log_missing_sysparm_field(sys_id, "name")
                             continue
 
                         label = mapping.get("label")
                         if not label:
-                            self._log_missing_sysparm_field(id, "label")
+                            self._log_missing_sysparm_field(sys_id, "label")
                             continue
 
                         if label in invalid_services:
@@ -347,8 +347,8 @@ class ServiceNowClient:
             )
             raise
 
-    def _log_missing_sysparm_field(self, id, field):
-        msg = f"Entry in sys_db_object with id '{id}' is missing sysparm_field '{field}'. This is a non-issue if no invalid services are flagged."
+    def _log_missing_sysparm_field(self, sys_id, field):
+        msg = f"Entry in sys_db_object with id '{sys_id}' is missing sysparm_field '{field}'. This is a non-issue if no invalid services are flagged."
         self._logger.debug(msg)
 
     async def ping(self):

--- a/tests/sources/test_servicenow.py
+++ b/tests/sources/test_servicenow.py
@@ -266,8 +266,10 @@ async def test_filter_services_when_sysparm_fields_missing():
                 ]
             ),
         ):
-            result = await source.servicenow_client.filter_services(source.servicenow_client.services)
-            assert result[0] == {"Incident": 'incident'}
+            result = await source.servicenow_client.filter_services(
+                source.servicenow_client.services
+            )
+            assert result[0] == {"Incident": "incident"}
             assert sorted(result[1]) == sorted(["Feature", "User"])
 
 
@@ -291,8 +293,10 @@ async def test_filter_services_when_sysparm_fields_missing_for_unrelated_table()
                 ]
             ),
         ):
-            result = await source.servicenow_client.filter_services(source.servicenow_client.services)
-            assert result[0] == {"Incident": 'incident', "Feature": "feature"}
+            result = await source.servicenow_client.filter_services(
+                source.servicenow_client.services
+            )
+            assert result[0] == {"Incident": "incident", "Feature": "feature"}
             # unrelated tables are ignored and don't cause errors
             assert result[1] == []
 

--- a/tests/sources/test_servicenow.py
+++ b/tests/sources/test_servicenow.py
@@ -103,8 +103,8 @@ async def test_validate_configuration_with_invalid_service_then_raise():
                 return_value=AsyncIterator(
                     [
                         [
-                            {"name": "name_1", "label": "label_1"},
-                            {"name": "name_2", "label": "label_2"},
+                            {"sys_id": "id_1", "name": "name_1", "label": "label_1"},
+                            {"sys_id": "id_2", "name": "name_2", "label": "label_2"},
                         ]
                     ]
                 ),
@@ -259,9 +259,9 @@ async def test_filter_services_when_sysparm_fields_missing():
             return_value=AsyncIterator(
                 [
                     [
-                        {"name": "user"},
-                        {"label": "Feature"},
-                        {"name": "incident", "label": "Incident"},
+                        {"sys_id": "id_1", "name": "user"},
+                        {"sys_id": "id_2", "label": "Feature"},
+                        {"sys_id": "id_3", "name": "incident", "label": "Incident"},
                     ]
                 ]
             ),
@@ -285,10 +285,10 @@ async def test_filter_services_when_sysparm_fields_missing_for_unrelated_table()
             return_value=AsyncIterator(
                 [
                     [
-                        {"name": "feature", "label": "Feature"},
-                        {"name": "incident", "label": "Incident"},
-                        {"name": "Label-less Foo"},
-                        {"label": "nameless_bar"},
+                        {"sys_id": "id_1", "name": "feature", "label": "Feature"},
+                        {"sys_id": "id_2", "name": "incident", "label": "Incident"},
+                        {"sys_id": "id_3", "name": "Label-less Foo"},
+                        {"sys_id": "id_4", "label": "nameless_bar"},
                     ]
                 ]
             ),

--- a/tests/sources/test_servicenow.py
+++ b/tests/sources/test_servicenow.py
@@ -278,7 +278,7 @@ async def test_filter_services_when_sysparm_fields_missing_for_unrelated_table()
     async with create_service_now_source() as source:
         source.servicenow_client.services = ["Incident", "Feature"]
 
-        source.servicenow_client.get_table_length = mock.AsyncMock(return_value=3)
+        source.servicenow_client.get_table_length = mock.AsyncMock(return_value=4)
         with mock.patch.object(
             ServiceNowClient,
             "get_data",


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2164

Remove the unsafe dict call from ServiceNow.
There are circumstances where tables fetched from `sys_db_object` may be missing `name` or `label` fields. Even if the user is not trying to query those tables, they are checked during the filtering operation. If `name` or `label` is missing, the connector shouldn't crash with the unsafe dict call. It should log the issue as debug and continue syncing.
