### PR TITLE
[Network Drive] Fix Download of documents in Windows and debug logs

### DIFF
--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -48,8 +48,8 @@ def mock_file(name):
     mock_stats = {}
     mock_stats["file_id"] = mock.Mock()
     mock_stats["file_id"].get_value.return_value = "1"
-    mock_stats["allocation_size"] = mock.Mock()
-    mock_stats["allocation_size"].get_value.return_value = "30"
+    mock_stats["end_of_file"] = mock.Mock()
+    mock_stats["end_of_file"].get_value.return_value = "30"
     mock_stats["creation_time"] = mock.Mock()
     mock_stats["creation_time"].get_value.return_value = datetime.datetime(
         2022, 1, 11, 12, 12, 30
@@ -78,8 +78,8 @@ def mock_folder(name):
     mock_stats = {}
     mock_stats["file_id"] = mock.Mock()
     mock_stats["file_id"].get_value.return_value = "122"
-    mock_stats["allocation_size"] = mock.Mock()
-    mock_stats["allocation_size"].get_value.return_value = "200"
+    mock_stats["end_of_file"] = mock.Mock()
+    mock_stats["end_of_file"].get_value.return_value = "200"
     mock_stats["creation_time"] = mock.Mock()
     mock_stats["creation_time"].get_value.return_value = datetime.datetime(
         2022, 2, 11, 12, 12, 30


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2122 ,https://github.com/elastic/connectors-py/issues/2120


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

This PR aims adds following changes to network drive connector
- Use of `end_of_file` for calculating file size
- Use of more Debug logs. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
