### PR TITLE
Fix native API key authentication

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -24,10 +24,6 @@ import logging
 import time
 from collections import defaultdict
 
-from elasticsearch import (
-    NotFoundError as ElasticNotFoundError,
-)
-
 from connectors.config import (
     DEFAULT_ELASTICSEARCH_MAX_RETRIES,
     DEFAULT_ELASTICSEARCH_RETRY_INTERVAL,
@@ -83,10 +79,6 @@ class ElasticsearchOverloadedError(Exception):
         msg = "Connector was unable to ingest data into overloaded Elasticsearch. Make sure Elasticsearch instance is healthy, has enough resources and content index is healthy."
         super().__init__(msg)
         self.__cause__ = cause
-
-
-class ApiKeyNotFoundError(Exception):
-    pass
 
 
 class Sink:
@@ -681,18 +673,6 @@ class SyncOrchestrator:
 
     async def close(self):
         await self.es_management_client.close()
-
-    async def update_authorization(self, index_name, secret_id):
-        # Updates the ESManagementClient auth options for native connectors after fetching API key
-        try:
-            api_key = await self.es_management_client.get_connector_secret(secret_id)
-            self._logger.debug(
-                f"Using API key found in secrets storage for authorization for index [{index_name}]."
-            )
-            self.es_management_client.client.options(api_key=api_key)
-        except ElasticNotFoundError as e:
-            msg = f"API key not found in secrets storage for index [{index_name}]."
-            raise ApiKeyNotFoundError(msg) from e
 
     async def has_active_license_enabled(self, license_):
         # TODO: think how to make it not a proxy method to the client

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -12,9 +12,6 @@ from unittest.mock import ANY, AsyncMock, Mock, call
 
 import pytest
 from elasticsearch import ApiError, BadRequestError
-from elasticsearch import (
-    NotFoundError as ElasticNotFoundError,
-)
 
 from connectors.es import Mappings
 from connectors.es.management_client import ESManagementClient
@@ -22,7 +19,6 @@ from connectors.es.sink import (
     OP_DELETE,
     OP_INDEX,
     OP_UPSERT,
-    ApiKeyNotFoundError,
     AsyncBulkRunningError,
     ElasticsearchOverloadedError,
     Extractor,
@@ -1303,53 +1299,6 @@ async def test_cancel_sync(extractor_task_done, sink_task_done, force_cancel):
         else:
             es._extractor.force_cancel.assert_not_called()
             es._sink.force_cancel.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_update_authorization():
-    config = {
-        "host": "http://nowhere.com:9200",
-        "user": "someone",
-        "password": "something",
-    }
-    sync_orchestrator = SyncOrchestrator(config)
-
-    sync_orchestrator.es_management_client.get_connector_secret = AsyncMock(
-        return_value="secret-value"
-    )
-    sync_orchestrator.es_management_client.client.options = AsyncMock()
-
-    await sync_orchestrator.update_authorization("my-index", "my-secret-id")
-
-    sync_orchestrator.es_management_client.get_connector_secret.assert_called_with(
-        "my-secret-id"
-    )
-    sync_orchestrator.es_management_client.client.options.assert_called_with(
-        api_key="secret-value"
-    )
-
-
-@pytest.mark.asyncio
-async def test_update_authorization_when_api_key_not_found():
-    config = {
-        "host": "http://nowhere.com:9200",
-        "user": "someone",
-        "password": "something",
-    }
-    sync_orchestrator = SyncOrchestrator(config)
-
-    error_meta = Mock()
-    error_meta.status = 404
-    sync_orchestrator.es_management_client.get_connector_secret = AsyncMock(
-        side_effect=ElasticNotFoundError(
-            "resource_not_found_exception",
-            error_meta,
-            "No secret with id [my-secret-id]",
-        )
-    )
-
-    with pytest.raises(ApiKeyNotFoundError):
-        await sync_orchestrator.update_authorization("my-index", "my-secret-id")
 
 
 async def test_extractor_run_when_mem_full_is_raised():

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -7,15 +7,20 @@ import asyncio
 from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
-from elasticsearch import ConflictError
+from elasticsearch import (
+    ConflictError,
+)
+from elasticsearch import (
+    NotFoundError as ElasticNotFoundError,
+)
 
 from connectors.es.client import License
 from connectors.es.index import DocumentNotFoundError
-from connectors.es.sink import ApiKeyNotFoundError
 from connectors.filtering.validation import InvalidFilteringError
 from connectors.protocol import Filter, JobStatus, JobType, Pipeline
 from connectors.source import BaseDataSource
 from connectors.sync_job_runner import (
+    ApiKeyNotFoundError,
     SyncJobRunner,
     SyncJobStartError,
 )
@@ -129,10 +134,24 @@ def sync_orchestrator_mock():
         sync_orchestrator_mock.has_active_license_enabled = AsyncMock(
             return_value=(True, License.PLATINUM)
         )
-        sync_orchestrator_mock.update_authorization = AsyncMock()
         sync_orchestrator_klass_mock.return_value = sync_orchestrator_mock
 
         yield sync_orchestrator_mock
+
+
+@pytest.fixture(autouse=True)
+def es_management_client_mock():
+    with patch(
+        "connectors.sync_job_runner.ESManagementClient"
+    ) as es_management_client_klass_mock:
+        es_management_client_mock = Mock()
+        es_management_client_mock.get_connector_secret = AsyncMock(
+            return_value="my-secret"
+        )
+        es_management_client_mock.close = AsyncMock()
+        es_management_client_klass_mock.return_value = es_management_client_mock
+
+        yield es_management_client_mock
 
 
 def create_runner_yielding_docs(docs=None):
@@ -907,7 +926,7 @@ async def test_unsupported_job_type():
 )
 @pytest.mark.asyncio
 async def test_native_connector_sync_fails_when_api_key_secret_missing(
-    job_type, sync_cursor, sync_orchestrator_mock
+    job_type, sync_cursor, sync_orchestrator_mock, es_management_client_mock
 ):
     ingestion_stats = {
         "indexed_document_count": 0,
@@ -916,8 +935,8 @@ async def test_native_connector_sync_fails_when_api_key_secret_missing(
         "total_document_count": TOTAL_DOCUMENT_COUNT,
     }
     sync_orchestrator_mock.ingestion_stats.return_value = ingestion_stats
-    sync_orchestrator_mock.update_authorization = AsyncMock(
-        side_effect=ApiKeyNotFoundError()
+    es_management_client_mock.get_connector_secret.side_effect = ElasticNotFoundError(
+        message="not found", meta=None, body={}
     )
 
     sync_job_runner = create_runner(job_type=job_type, sync_cursor=sync_cursor)
@@ -932,7 +951,7 @@ async def test_native_connector_sync_fails_when_api_key_secret_missing(
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
 
-    sync_job_runner.sync_orchestrator.async_bulk.assert_not_awaited()
+    sync_job_runner.sync_orchestrator is None
 
     sync_job_runner.connector.sync_starts.assert_awaited_with(job_type)
     sync_job_runner.connector.sync_done.assert_awaited_with(

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -951,7 +951,7 @@ async def test_native_connector_sync_fails_when_api_key_secret_missing(
     sync_job_runner.sync_job.cancel.assert_not_awaited()
     sync_job_runner.sync_job.suspend.assert_not_awaited()
 
-    sync_job_runner.sync_orchestrator is None
+    assert sync_job_runner.sync_orchestrator is None
 
     sync_job_runner.connector.sync_starts.assert_awaited_with(job_type)
     sync_job_runner.connector.sync_done.assert_awaited_with(


### PR DESCRIPTION
API key authentication for native connectors is currently broken, because the `ESManagementClient.client.options` update func doesn't change requests to use API key authentication.
This PR changes how the `ESManagementClient` is initialised:

1. Fetch API key from connector secrets
2. Attach API key to es_config
3. Initialise ESManagementClient (using API key from the start)

To do this, it's necessary to create a second ESManagementClient that authenticates with username and password. This is because the connector secrets API is only accessible by the Enterprise Search system role.
