### PR TITLE
Add more debug logging in job execution

### DIFF
--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -59,6 +59,10 @@ class JobExecutionService(BaseService):
         source_klass = get_source_klass(self.source_list[sync_job.service_type])
         connector_id = sync_job.connector_id
 
+        sync_job.log_debug(
+            f"Detected PENDING '{sync_job.job_type}' sync for '{sync_job.service_type}' connector with id '{connector_id}'."
+        )
+
         try:
             connector = await self.connector_index.fetch_by_id(connector_id)
         except DocumentNotFoundError:
@@ -87,6 +91,11 @@ class JobExecutionService(BaseService):
             es_config=self._override_es_config(connector),
             service_config=self.service_config,
         )
+
+        sync_job.log_debug(
+            f"Attempting to start '{sync_job.job_type}' sync for '{sync_job.service_type}' connector with id '{connector_id}'."
+        )
+
         if not self.sync_job_pool.try_put(sync_job_runner.execute):
             sync_job.log_debug(
                 f"{self.display_name.capitalize()} service is already running {self.max_concurrency} sync jobs and can't run more at this poinit. Increase '{self.max_concurrency_config}' in config if you want the service to run more sync jobs."  # pyright: ignore

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -59,7 +59,7 @@ class JobExecutionService(BaseService):
         source_klass = get_source_klass(self.source_list[sync_job.service_type])
         connector_id = sync_job.connector_id
 
-        sync_job.log_debug(f"Detected pending {sync_job.job_type.value} sync.")
+        sync_job.log_debug(f"Detected pending {sync_job.job_type} sync.")
 
         try:
             connector = await self.connector_index.fetch_by_id(connector_id)
@@ -90,7 +90,7 @@ class JobExecutionService(BaseService):
             service_config=self.service_config,
         )
 
-        sync_job.log_debug(f"Attempting to start {sync_job.job_type.value} sync.")
+        sync_job.log_debug(f"Attempting to start {sync_job.job_type} sync.")
 
         if not self.sync_job_pool.try_put(sync_job_runner.execute):
             sync_job.log_debug(

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -60,7 +60,7 @@ class JobExecutionService(BaseService):
         connector_id = sync_job.connector_id
 
         sync_job.log_debug(
-            f"Detected PENDING '{sync_job.job_type}' sync with id '{sync_job.id}'."
+            f"Detected PENDING '{sync_job.job_type}' sync job with id '{sync_job.id}'."
         )
 
         try:

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -59,9 +59,7 @@ class JobExecutionService(BaseService):
         source_klass = get_source_klass(self.source_list[sync_job.service_type])
         connector_id = sync_job.connector_id
 
-        sync_job.log_debug(
-            f"Detected PENDING '{sync_job.job_type}' sync job with id '{sync_job.id}'."
-        )
+        sync_job.log_debug(f"Detected pending {sync_job.job_type.value} sync.")
 
         try:
             connector = await self.connector_index.fetch_by_id(connector_id)
@@ -92,9 +90,7 @@ class JobExecutionService(BaseService):
             service_config=self.service_config,
         )
 
-        sync_job.log_debug(
-            f"Attempting to start '{sync_job.job_type}' sync job with id '{sync_job.id}'."
-        )
+        sync_job.log_debug(f"Attempting to start {sync_job.job_type.value} sync.")
 
         if not self.sync_job_pool.try_put(sync_job_runner.execute):
             sync_job.log_debug(

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -60,7 +60,7 @@ class JobExecutionService(BaseService):
         connector_id = sync_job.connector_id
 
         sync_job.log_debug(
-            f"Detected PENDING '{sync_job.job_type}' sync for '{sync_job.service_type}' connector with id '{connector_id}'."
+            f"Detected PENDING '{sync_job.job_type}' sync with id '{sync_job.id}'."
         )
 
         try:
@@ -93,7 +93,7 @@ class JobExecutionService(BaseService):
         )
 
         sync_job.log_debug(
-            f"Attempting to start '{sync_job.job_type}' sync for '{sync_job.service_type}' connector with id '{connector_id}'."
+            f"Attempting to start '{sync_job.job_type}' sync job with id '{sync_job.id}'."
         )
 
         if not self.sync_job_pool.try_put(sync_job_runner.execute):

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -110,7 +110,9 @@ class SyncJobRunner:
 
         self.running = True
 
-        self.sync_job.log_debug(f"Starting sync job '{self.sync_job.id}'.")
+        job_type = self.sync_job.job_type.value
+
+        self.sync_job.log_debug(f"Starting execution of {job_type} sync job.")
 
         await self.sync_starts()
         sync_cursor = (
@@ -121,7 +123,7 @@ class SyncJobRunner:
         await self.sync_job.claim(sync_cursor=sync_cursor)
         self._start_time = time.time()
 
-        self.sync_job.log_debug(f"Successfully claimed sync job '{self.sync_job.id}'.")
+        self.sync_job.log_debug("Successfully claimed the sync job.")
 
         try:
             self.data_provider = self.source_klass(
@@ -132,9 +134,7 @@ class SyncJobRunner:
                 self._data_source_framework_config()
             )
 
-            self.sync_job.log_debug(
-                f"Instantiated data provider for sync job '{self.sync_job.id}'."
-            )
+            self.sync_job.log_debug("Instantiated data provider for the sync job.")
 
             if not await self.data_provider.changed():
                 self.sync_job.log_info("No change in remote source, skipping sync")
@@ -336,9 +336,9 @@ class SyncJobRunner:
 
         if await self.reload_sync_job():
             if await self.reload_connector():
-                ingestion_stats["total_document_count"] = (
-                    await self.connector.document_count()
-                )
+                ingestion_stats[
+                    "total_document_count"
+                ] = await self.connector.document_count()
 
             if sync_status == JobStatus.ERROR:
                 await self.sync_job.fail(sync_error, ingestion_stats=ingestion_stats)

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -133,7 +133,7 @@ class SyncJobRunner:
             )
 
             self.sync_job.log_debug(
-                f"Instantiated data provided for sync job '{self.sync_job.id}'."
+                f"Instantiated data provider for sync job '{self.sync_job.id}'."
             )
 
             if not await self.data_provider.changed():

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -110,7 +110,7 @@ class SyncJobRunner:
 
         self.running = True
 
-        job_type = self.sync_job.job_type.value
+        job_type = self.sync_job.job_type
 
         self.sync_job.log_debug(f"Starting execution of {job_type} sync job.")
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2194

Add more debug-level logging when executing sync jobs. 

Example output from job execution service and the sync job runner:

```
[FMWK][12:17:01][DEBUG] Polling every 30 seconds for access control sync job execution
[FMWK][12:17:01][DEBUG] Polling every 30 seconds for content sync job execution
[FMWK][12:17:02][DEBUG] Polling every 30 seconds for Job Scheduling
[FMWK][12:17:02][DEBUG] [Connector id: 97VO0I0Bam-j8dNh-4C4, index name: search-g, Sync job id: BrWI0I0Bam-j8dNhIIGV] Detected pending JobType.FULL sync.
[FMWK][12:17:02][DEBUG] [Connector id: 97VO0I0Bam-j8dNh-4C4, index name: search-g, Sync job id: BrWI0I0Bam-j8dNhIIGV] Attempting to start JobType.FULL sync.
[FMWK][12:17:02][DEBUG] [Connector id: 97VO0I0Bam-j8dNh-4C4, index name: search-g, Sync job id: BrWI0I0Bam-j8dNhIIGV] Starting execution of JobType.FULL sync job.
[FMWK][12:17:03][DEBUG] [Connector id: 97VO0I0Bam-j8dNh-4C4, index name: search-g, Sync job id: BrWI0I0Bam-j8dNhIIGV] Successfully claimed the sync job.
[FMWK][12:17:03][DEBUG] [Connector id: 97VO0I0Bam-j8dNh-4C4, index name: search-g, Sync job id: BrWI0I0Bam-j8dNhIIGV] Instantiated data provider for the sync job.
[FMWK][12:17:03][DEBUG] [Connector id: 97VO0I0Bam-j8dNh-4C4, index name: search-g, Sync job id: BrWI0I0Bam-j8dNhIIGV] Setting '_features' for Google Drive
[FMWK][12:17:03][DEBUG] [Connector id: 97VO0I0Bam-j8dNh-4C4, index name: search-g, Sync job id: BrWI0I0Bam-j8dNhIIGV] Validating configuration

```

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

