### PR TITLE
[8.12] [CI] Fix Issues in Docker Publishing Pipeline (#2180)

### DIFF
--- a/.buildkite/publish/build-docker.sh
+++ b/.buildkite/publish/build-docker.sh
@@ -20,7 +20,7 @@ source $CURDIR/publish-common.sh
 pushd $PROJECT_ROOT
 
 # set our complete tag name and build the image
-TAG_NAME="$BASE_TAG_NAME-${ARCHITECTURE}:${VERSION}"
+TAG_NAME="$BASE_TAG_NAME:${VERSION}-${ARCHITECTURE}"
 docker build -t $TAG_NAME .
 
 # save the image to an archive file

--- a/.buildkite/publish/build-multiarch-docker.sh
+++ b/.buildkite/publish/build-multiarch-docker.sh
@@ -13,8 +13,12 @@ source $CURDIR/publish-common.sh
 
 # Set our tag name as well as the tag names of the indiividual platform images
 TAG_NAME="${BASE_TAG_NAME}:${VERSION}"
-AMD64_TAG="${BASE_TAG_NAME}-amd64:${VERSION}"
-ARM64_TAG="${BASE_TAG_NAME}-arm64:${VERSION}"
+AMD64_TAG="${BASE_TAG_NAME}:${VERSION}-amd64"
+ARM64_TAG="${BASE_TAG_NAME}:${VERSION}-arm64"
+
+# Pull the images from the registry
+buildah pull $AMD64_TAG
+buildah pull $ARM64_TAG
 
 # ensure +x is set to avoid writing any sensitive information to the console
 set +x

--- a/.buildkite/publish/push-docker.sh
+++ b/.buildkite/publish/push-docker.sh
@@ -30,6 +30,6 @@ vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-con
   docker login -u $DOCKER_USER --password-stdin docker.elastic.co
 
 # Set our tag name and push the image
-TAG_NAME="$BASE_TAG_NAME-${ARCHITECTURE}:${VERSION}"
+TAG_NAME="$BASE_TAG_NAME:${VERSION}-${ARCHITECTURE}"
 echo "Pushing image to docker with tag: $TAG_NAME"
 docker push $TAG_NAME

--- a/.buildkite/publish/test-docker.sh
+++ b/.buildkite/publish/test-docker.sh
@@ -84,5 +84,5 @@ printf '%s\n' "$TEST_CONFIG_TEXT" > "$TEST_CONFIG_FILE"
 
 # Finally, run the tests
 echo "Running container-structure-test"
-TAG_NAME="$BASE_TAG_NAME-${ARCHITECTURE}:${VERSION}"
+TAG_NAME="$BASE_TAG_NAME:${VERSION}-${ARCHITECTURE}"
 "$TEST_EXEC" test --image "$TAG_NAME" --config "$TEST_CONFIG_FILE"

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -1,58 +1,74 @@
 ## 🏠/.buildkite/pipeline-release.yml
 # Manual triggered pipeline to build and publish Docker images
 
-agents:
-  provider: "gcp"
-  machineType: "n1-standard-8"
-  useVault: true
-
 steps:
   # ----
   # Docker builds for amd64
   # ----
   - group: ":package: amd64 Build and Test"
     key: "build_and_test_amd64"
-    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/)"
-    env:
-      - ARCHITECTURE="amd64"
-    agents:
-      provider: aws
-      instanceType: m6i.xlarge
-      imagePrefix: ci-amazonlinux-2
+    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
     steps:
       - label: "Building amd64 Docker image"
+        agents:
+          provider: aws
+          instanceType: m6i.xlarge
+          imagePrefix: ci-amazonlinux-2
+        env:
+          ARCHITECTURE: "amd64"
         command: ".buildkite/publish/build-docker.sh"
         key: "build_docker_image_amd64"
         artifact_paths: ".artifacts/elastic-connectors-docker-*.tar.gz"
       - label: "Testing amd64 Docker image"
+        agents:
+          provider: aws
+          instanceType: m6i.xlarge
+          imagePrefix: ci-amazonlinux-2
+        env:
+          ARCHITECTURE: "amd64"
         depends_on: "build_docker_image_amd64"
-        command: ".buildkite/publish/test-docker.sh"
+        commands:
+          - "mkdir -p .artifacts"
+          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_amd64
+          - ".buildkite/publish/test-docker.sh"
   # ----
   # Docker builds for arm64
   # ----
   - group: ":package: arm64 Build and Test"
     key: "build_and_test_arm64"
-    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/)"
-    env:
-      - ARCHITECTURE="arm64"
-    agents:
-      provider: aws
-      instanceType: m6g.xlarge
-      imagePrefix: ci-amazonlinux-2-aarch64
-      diskSizeGb: 40
-      diskName: '/dev/xvda'
+    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
     steps:
       - label: "Building arm64 Docker image"
+        agents:
+          provider: aws
+          instanceType: m6g.xlarge
+          imagePrefix: ci-amazonlinux-2-aarch64
+          diskSizeGb: 40
+          diskName: '/dev/xvda'
+        env:
+          ARCHITECTURE: "arm64"
         command: ".buildkite/publish/build-docker.sh"
         key: "build_docker_image_arm64"
         artifact_paths: ".artifacts/elastic-connectors-docker-*.tar.gz"
       - label: "Testing arm64 Docker image"
+        agents:
+          provider: aws
+          instanceType: m6g.xlarge
+          imagePrefix: ci-amazonlinux-2-aarch64
+          diskSizeGb: 40
+          diskName: '/dev/xvda'
+        env:
+          ARCHITECTURE: "arm64"
         depends_on: "build_docker_image_arm64"
-        command: ".buildkite/publish/test-docker.sh"
+        commands:
+          - "mkdir -p .artifacts"
+          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_arm64
+          - ".buildkite/publish/test-docker.sh"
   # ----
   # Multiarch Docker image build and push
   # ----
   - group: ":truck: Publish images"
+    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
     depends_on:
       - "build_and_test_amd64"
       - "build_and_test_arm64"
@@ -60,7 +76,7 @@ steps:
       - label: "Push amd64 Docker image"
         key: "push_amd64_docker_image"
         env:
-          - ARCHITECTURE="amd64"
+          ARCHITECTURE: "amd64"
         agents:
           provider: aws
           instanceType: m6i.xlarge
@@ -72,7 +88,7 @@ steps:
       - label: "Push arm64 Docker image"
         key: "push_arm64_docker_image"
         env:
-          - ARCHITECTURE="arm64"
+          ARCHITECTURE: "arm64"
         agents:
           provider: aws
           instanceType: m6g.xlarge
@@ -84,6 +100,10 @@ steps:
           - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_arm64
           - ".buildkite/publish/push-docker.sh"
       - label: "Build and push multiarch Docker image"
+        agents:
+          image: "docker.elastic.co/ci-agent-images/drivah:0.24.3"
+          ephemeralStorage: "20G"
+          memory: "4G"
         command: ".buildkite/publish/build-multiarch-docker.sh"
         depends_on:
           - "push_amd64_docker_image"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[CI] Fix Issues in Docker Publishing Pipeline (#2180)](https://github.com/elastic/connectors/pull/2180)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)