### PR TITLE
Fix problem with cancel jobs action using closed client

### DIFF
--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -652,7 +652,8 @@ def test_job_cancel():
     job = SyncJobObject(job_index, doc)
 
     with patch(
-        "connectors.cli.job.Job._Job__async_list_jobs", AsyncMock(return_value=[job])
+        "connectors.protocol.SyncJobIndex.get_all_docs",
+        AsyncIterator([job])
     ):
         with patch.object(job, "_terminate") as mocked_method:
             result = runner.invoke(cli, ["job", "cancel", job_id])
@@ -667,7 +668,7 @@ def test_job_cancel_error():
     runner = CliRunner()
     job_id = "test_job_id"
     with patch(
-        "connectors.cli.job.Job._Job__async_list_jobs",
+        "connectors.protocol.SyncJobIndex.get_all_docs",
         side_effect=ApiError(500, meta="meta", body="error"),
     ):
         result = runner.invoke(cli, ["job", "cancel", job_id])

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -651,10 +651,7 @@ def test_job_cancel():
 
     job = SyncJobObject(job_index, doc)
 
-    with patch(
-        "connectors.protocol.SyncJobIndex.get_all_docs",
-        AsyncIterator([job])
-    ):
+    with patch("connectors.protocol.SyncJobIndex.get_all_docs", AsyncIterator([job])):
         with patch.object(job, "_terminate") as mocked_method:
             result = runner.invoke(cli, ["job", "cancel", job_id])
 


### PR DESCRIPTION
## Problem found during https://github.com/elastic/enterprise-search-team/issues/7054

This PR fixes a problem that CLI uses already closed client during "cancel job" action.

This problem started happening because new transient retrier relies on proper usage of `close` method and stops executing actions if it's closed. Other clients do not (yet) follow this pattern, so the problem did not manifest itself before.

## Checklists
#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
