### PR TITLE
Fix table/db names not being escaped for MySQL connector

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -51,7 +51,7 @@ class MySQLQueries(Queries):
         return f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{self.database}' AND TABLE_NAME = '{table}' AND COLUMN_KEY = 'PRI'"
 
     def table_data(self, table):
-        return f"SELECT * FROM {self.database}.{table}"
+        return f"SELECT * FROM `{self.database}`.`{table}`"
 
     def table_last_update_time(self, table):
         return f"SELECT UPDATE_TIME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '{self.database}' AND TABLE_NAME = '{table}'"
@@ -450,7 +450,7 @@ class MySqlDataSource(BaseDataSource):
 
     async def _validate_database_accessible(self, cursor):
         try:
-            await cursor.execute(f"USE {self.database};")
+            await cursor.execute(f"USE `{self.database}`;")
         except aiomysql.Error as e:
             msg = f"The database '{self.database}' is either not present or not accessible for the user '{self.configuration['user']}'."
             raise ConfigurableFieldValueError(msg) from e
@@ -461,7 +461,7 @@ class MySqlDataSource(BaseDataSource):
 
         for table in tables_to_validate:
             try:
-                await cursor.execute(f"SELECT 1 FROM {table} LIMIT 1;")
+                await cursor.execute(f"SELECT 1 FROM `{table}` LIMIT 1;")
             except aiomysql.Error:
                 non_accessible_tables.append(table)
 

--- a/tests/sources/test_mysql.py
+++ b/tests/sources/test_mysql.py
@@ -827,7 +827,7 @@ async def test_validate_database_accessible_when_accessible_then_no_error_raised
         cursor.execute.return_value = None
 
         await source._validate_database_accessible(cursor)
-        cursor.execute.assert_called_with(f"USE {source.database};")
+        cursor.execute.assert_called_with(f"USE `{source.database}`;")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/6495

It's possible to create DB and TABLE names in MySQL that will break current connector, for example:

```
mysql> create database `really@strange*database$name`;
mysql> use `really@strange*database$name`;
mysql> create table `really@strange*table$name` (id MEDIUMINT NOT NULL AUTO_INCREMENT, name CHAR(30) NOT NULL, PRIMARY KEY (id) );
mysql> INSERT INTO `really@strange*table$name`(name)  VALUES('dog');
```
If you try to select without escaping the table name, it will not work, the table name has to be escaped (see PR changes). This PR makes sure that all places that need to have table names escaped properly do so.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

MySQL Connector: Fix an issue when special characters in database/table names make it impossible to sync data.
