### PR TITLE
Revert "Generate API keys when running native connector syncs  #2188"

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -487,7 +487,7 @@ class Features:
 
     def native_connector_api_keys_enabled(self):
         return self._nested_feature_enabled(
-            ["native_connector_api_keys", "enabled"], default=False
+            ["native_connector_api_keys", "enabled"], default=True
         )
 
     def sync_rules_enabled(self):

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -8,7 +8,6 @@ from functools import cached_property
 from connectors.es.client import License
 from connectors.es.index import DocumentNotFoundError
 from connectors.es.license import requires_platinum_license
-from connectors.es.management_client import ESManagementClient
 from connectors.logger import logger
 from connectors.protocol import (
     ConnectorIndex,
@@ -82,34 +81,6 @@ class JobExecutionService(BaseService):
 
         if not self.should_execute(connector, sync_job):
             return
-
-        if (
-            connector.native
-            and connector.features.native_connector_api_keys_enabled()
-            and not connector.api_key_secret_id
-        ):
-            sync_job.log_debug(
-                f"No secret found for [{connector_id}], generating and storing API key..."
-            )
-            es_management_client = ESManagementClient(
-                self._override_es_config(connector)
-            )
-            try:
-                storage_result = await es_management_client.generate_and_store_api_key(
-                    connector.index_name
-                )
-                sync_job.log_debug(
-                    f"API key stored as secret: {storage_result}, updating connector doc..."
-                )
-                await self.connector_index.update(connector_id, storage_result)
-                await connector.reload()
-            except Exception as e:
-                sync_job.log_error(
-                    f"Couldn't generate and store an API key for native connector {connector_id}. Error: {e}."
-                )
-                return
-            finally:
-                await es_management_client.close()
 
         sync_job_runner = SyncJobRunner(
             source_klass=source_klass,

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -385,7 +385,7 @@ class BaseDataSource:
     advanced_rules_enabled = False
     dls_enabled = False
     incremental_sync_enabled = False
-    native_connector_api_keys_enabled = True
+    native_connector_api_keys_enabled = False
 
     def __init__(self, configuration):
         # Initialize to the global logger

--- a/connectors/source.py
+++ b/connectors/source.py
@@ -385,7 +385,7 @@ class BaseDataSource:
     advanced_rules_enabled = False
     dls_enabled = False
     incremental_sync_enabled = False
-    native_connector_api_keys_enabled = False
+    native_connector_api_keys_enabled = True
 
     def __init__(self, configuration):
         # Initialize to the global logger

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -908,7 +908,3 @@ def func_human_readable_name(func):
         return func.__name__
     except AttributeError:
         return str(func)
-
-
-def alphanumericize_string(value):
-    return "".join(char for char in value if char.isalnum())

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -14,10 +14,6 @@ from elasticsearch import (
 )
 
 from connectors.es.management_client import ESManagementClient
-from connectors.protocol import (
-    CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX,
-    CONNECTORS_INDEX,
-)
 from tests.commons import AsyncIterator
 
 
@@ -290,64 +286,3 @@ class TestESManagementClient:
         with pytest.raises(ElasticNotFoundError):
             secret = await es_management_client.get_connector_secret(secret_id)
             assert secret is None
-
-    @pytest.mark.asyncio
-    async def test_create_connector_secret(self, es_management_client, mock_responses):
-        secret_id = "secret-id"
-        secret_value = "my-secret"
-
-        es_management_client.client.perform_request = AsyncMock(
-            return_value={"id": secret_id}
-        )
-
-        returned_id = await es_management_client.create_connector_secret(secret_value)
-        assert returned_id == secret_id
-        es_management_client.client.perform_request.assert_awaited_with(
-            "POST",
-            "/_connector/_secret",
-            body={"value": secret_value},
-            headers={"accept": "application/json", "content-type": "application/json"},
-        )
-
-    @pytest.mark.asyncio
-    async def test_generate_and_store_api_key(
-        self, es_management_client, mock_responses
-    ):
-        index_name = "index-1"
-        expected_role_descriptors = {
-            "index1-connector-role": {
-                "cluster": ["monitor"],
-                "index": [
-                    {
-                        "names": [
-                            index_name,
-                            f"{CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}{index_name}",
-                            f"{CONNECTORS_INDEX}*",
-                        ],
-                        "privileges": ["all"],
-                    }
-                ],
-            }
-        }
-        expected_response = {
-            "api_key_id": "api-key-id",
-            "api_key_secret_id": "secret-id",
-        }
-
-        es_management_client.client.security.create_api_key = AsyncMock(
-            return_value={"id": "api-key-id", "encoded": "encoded-api-key-value"}
-        )
-        es_management_client.create_connector_secret = AsyncMock(
-            return_value="secret-id"
-        )
-
-        response = await es_management_client.generate_and_store_api_key(index_name)
-        assert response == expected_response
-
-        es_management_client.client.security.create_api_key.assert_awaited_with(
-            name=f"{index_name}-connector",
-            role_descriptors=expected_role_descriptors,
-        )
-        es_management_client.create_connector_secret.assert_awaited_with(
-            "encoded-api-key-value"
-        )

--- a/tests/services/test_job_execution.py
+++ b/tests/services/test_job_execution.py
@@ -86,25 +86,15 @@ def mock_connector(
     last_sync_status=JobStatus.COMPLETED,
     last_access_control_sync_status=JobStatus.COMPLETED,
     document_level_security_enabled=True,
-    is_native=False,
-    api_key_secret_id=None,
-    native_connector_api_keys_enabled=True,
 ):
     connector = Mock()
     connector.id = "1"
-    connector.index_name = "my-index"
     connector.last_sync_status = last_sync_status
     connector.last_access_control_sync_status = last_access_control_sync_status
-    connector.native = is_native
-    connector.api_key_secret_id = api_key_secret_id
     connector.features = Mock()
     connector.features.document_level_security_enabled = Mock(
         return_value=document_level_security_enabled
     )
-    connector.features.native_connector_api_keys_enabled = Mock(
-        return_value=native_connector_api_keys_enabled
-    )
-    connector.reload = AsyncMock()
 
     return connector
 
@@ -375,105 +365,3 @@ async def test_job_execution_new_sync_job_not_blocked(
 
     sync_job_pool_mock.try_put.assert_called_with(sync_job_runner_mock.execute)
     assert sync_job_pool_mock.try_put.call_count == 2
-
-
-@pytest.mark.parametrize(
-    "service_klass, job_type",
-    [
-        (ContentSyncJobExecutionService, JobType.FULL),
-        (AccessControlSyncJobExecutionService, JobType.ACCESS_CONTROL),
-    ],
-)
-async def test_job_execution_native_connector_with_api_key_secret(
-    connector_index_mock,
-    sync_job_index_mock,
-    concurrent_tasks_mocks,
-    sync_job_runner_mock,
-    service_klass,
-    job_type,
-    set_env,
-):
-    sync_job_pool_mock = concurrent_tasks_mocks
-
-    connector = mock_connector(is_native=True, api_key_secret_id="secret-id")
-
-    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
-
-    sync_job = mock_sync_job(job_type=job_type)
-    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
-
-    await create_and_run_service(service_klass)
-
-    sync_job_pool_mock.try_put.assert_called_once_with(sync_job_runner_mock.execute)
-
-
-@pytest.mark.parametrize(
-    "service_klass, job_type",
-    [
-        (ContentSyncJobExecutionService, JobType.FULL),
-        (AccessControlSyncJobExecutionService, JobType.ACCESS_CONTROL),
-    ],
-)
-async def test_job_execution_native_connector_when_api_key_secret_empty(
-    connector_index_mock,
-    sync_job_index_mock,
-    concurrent_tasks_mocks,
-    sync_job_runner_mock,
-    service_klass,
-    job_type,
-    set_env,
-):
-    expected_doc_update = {"api_key_id": "api-key-id", "api_key_secret_id": "secret-id"}
-
-    sync_job_pool_mock = concurrent_tasks_mocks
-
-    connector = mock_connector(is_native=True)
-    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
-    connector_index_mock.update = AsyncMock(return_value={"result": "updated"})
-
-    sync_job = mock_sync_job(job_type=job_type)
-    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
-
-    with patch(
-        "connectors.es.management_client.ESManagementClient.generate_and_store_api_key",
-        AsyncMock(return_value=expected_doc_update),
-    ) as api_key_generation_mock:
-        await create_and_run_service(service_klass)
-
-        sync_job_pool_mock.try_put.assert_called_once_with(sync_job_runner_mock.execute)
-        api_key_generation_mock.assert_called_once_with(connector.index_name)
-        connector_index_mock.update.assert_called_once_with(
-            connector.id, expected_doc_update
-        )
-
-
-@pytest.mark.parametrize(
-    "service_klass, job_type",
-    [
-        (ContentSyncJobExecutionService, JobType.FULL),
-        (AccessControlSyncJobExecutionService, JobType.ACCESS_CONTROL),
-    ],
-)
-async def test_job_execution_native_connector_when_feature_disabled(
-    connector_index_mock,
-    sync_job_index_mock,
-    concurrent_tasks_mocks,
-    sync_job_runner_mock,
-    service_klass,
-    job_type,
-    set_env,
-):
-    sync_job_pool_mock = concurrent_tasks_mocks
-
-    connector = mock_connector(is_native=True, native_connector_api_keys_enabled=False)
-    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
-    connector_index_mock.fetch_by_id = AsyncMock(return_value=connector)
-
-    sync_job = mock_sync_job(job_type=job_type)
-    sync_job_index_mock.pending_jobs.return_value = AsyncIterator([sync_job])
-
-    await create_and_run_service(service_klass)
-
-    sync_job_pool_mock.try_put.assert_called_once_with(sync_job_runner_mock.execute)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -30,7 +30,6 @@ from connectors.utils import (
     NonBlockingBoundedSemaphore,
     RetryStrategy,
     UnknownRetryStrategyError,
-    alphanumericize_string,
     base64url_to_base64,
     convert_to_b64,
     decode_base64_value,
@@ -1056,7 +1055,3 @@ async def test_time_to_sleep_between_retries_invalid_strategy():
         time_to_sleep_between_retries("lalala", 1, 1)
 
     assert e is not None
-
-
-def test_alphanumericize_string():
-    assert alphanumericize_string("ABC/def!123#_-'$%^&") == "ABCdef123"


### PR DESCRIPTION
Revert #2188

It was discovered through QA that API keys generated by Enterprise Search on cloud cannot provide access to indices created by the user in Kibana, so this feature doesn't work.
Instead, I will make follow-up PRs providing verbose errors + instructions on how to fix native connectors that fail API key auth.