### PR TITLE
Avoid ftest perf8 race condition

### DIFF
--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -98,6 +98,7 @@ if [[ $PERF8 == "yes" ]]; then
     set +e
     PERF8_PID=`ps aux | grep bin/perf8 | grep -v grep | awk '{print $2}'`
     if [ ! -z "$PERF8_PID" ] # if the process is already gone, move on
+    then
       echo 'Waiting for PERF8 to finish the report'
       while kill -0 "$PERF8_PID"; do
           sleep 0.5

--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -96,11 +96,13 @@ $PYTHON fixture.py --name $NAME --action stop_stack
 # So we wait in the end of the script to not block second sync from happening while we also compile the report
 if [[ $PERF8 == "yes" ]]; then
     set +e
-    echo 'Waiting for PERF8 to finish the report'
     PERF8_PID=`ps aux | grep bin/perf8 | grep -v grep | awk '{print $2}'`
-    while kill -0 "$PERF8_PID"; do
-        sleep 0.5
-    done
+    if [ ! -z "$PERF8_PID" ] # if the process is already gone, move on
+      echo 'Waiting for PERF8 to finish the report'
+      while kill -0 "$PERF8_PID"; do
+          sleep 0.5
+      done
+    fi
     set -e
 
     rm -f description.txt


### PR DESCRIPTION
nightly CI was failing and the final logs were:

```

+ set +e
--
  | + echo 'Waiting for PERF8 to finish the report'
  | Waiting for PERF8 to finish the report
  | ++ ps aux
  | ++ grep bin/perf8
  | ++ grep -v grep
  | ++ awk '{print $2}'
  | + PERF8_PID=
  | + kill -0 ''
  | tests/ftest.sh: line 101: kill: `': not a pid or valid job spec
  | + set -e
  | + rm -f description.txt
  | + STATUS=1
  | + exit 1
  | make: *** [Makefile:62: ftest] Error 1
  | 🚨 Error: The command exited with status 2


```

So this attempts to just move on if we have an empty value for `PERF8_PID`