### PR TITLE
Automatically update content index settings and mappings

### DIFF
--- a/connectors/es/management_client.py
+++ b/connectors/es/management_client.py
@@ -72,7 +72,7 @@ class ESManagementClient(ESClient):
         existing_mappings = response[index].get("mappings", {})
         if len(existing_mappings) == 0:
             if mappings:
-                logger.debug(
+                logger.info(
                     "Index %s has no mappings or it's empty. Adding mappings...", index
                 )
                 try:
@@ -85,13 +85,13 @@ class ESManagementClient(ESClient):
                             properties=mappings.get("properties", {}),
                         )
                     )
-                    logger.debug("Successfully added mappings for index %s", index)
+                    logger.info("Successfully added mappings for index %s", index)
                 except Exception as e:
                     logger.warning(
                         f"Could not create mappings for index {index}, encountered error {e}"
                     )
             else:
-                logger.debug(
+                logger.info(
                     "Index %s has no mappings but no mappings are provided, skipping mappings creation"
                 )
         else:
@@ -106,7 +106,7 @@ class ESManagementClient(ESClient):
         settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
 
         if "analysis" not in existing_settings.get("index", {}):
-            logger.debug(
+            logger.info(
                 f"Index {index_name} has no settings or it's empty. Adding settings..."
             )
 
@@ -141,12 +141,12 @@ class ESManagementClient(ESClient):
                     await self._retrier.execute_with_retry(
                         partial(self.client.indices.open, index=index_name)
                     )
+
+                    logger.info(f"Successfully added settings for index {index_name}")
             except Exception as e:
                 logger.warning(
                     f"Could not create settings for index {index_name}, encountered error {e}"
                 )
-
-            logger.debug(f"Successfully added settings for index {index_name}")
         else:
             logger.debug(
                 f"Index {index_name} already has settings, skipping settings creation"

--- a/connectors/es/management_client.py
+++ b/connectors/es/management_client.py
@@ -105,7 +105,7 @@ class ESManagementClient(ESClient):
         existing_settings = index.get("settings", {})
         settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
 
-        if "analysis" not in existing_settings.get('index', {}) and settings:
+        if "analysis" not in existing_settings.get("index", {}):
             logger.debug(
                 f"Index {index_name} has no settings or it's empty. Adding settings..."
             )
@@ -119,7 +119,10 @@ class ESManagementClient(ESClient):
                             "PUT",
                             f"/{index_name}/_settings?reopen=true",
                             body=settings,
-                            headers = {"accept": "application/json", "content-type": "application/json"}
+                            headers={
+                                "accept": "application/json",
+                                "content-type": "application/json",
+                            },
                         )
                     )
                 else:
@@ -194,7 +197,11 @@ class ESManagementClient(ESClient):
 
     async def get_index(self, index_name, ignore_unavailable=False):
         return await self._retrier.execute_with_retry(
-            partial(self.client.indices.get, index=index_name, ignore_unavailable=ignore_unavailable)
+            partial(
+                self.client.indices.get,
+                index=index_name,
+                ignore_unavailable=ignore_unavailable,
+            )
         )
 
     async def upsert(self, _id, index_name, doc):

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -682,7 +682,9 @@ class SyncOrchestrator:
         """Creates the index, given a mapping/settings if it does not exists."""
         self._logger.debug(f"Checking index {index_name}")
 
-        result = await self.es_management_client.get_index(index_name, ignore_unavailable=True)
+        result = await self.es_management_client.get_index(
+            index_name, ignore_unavailable=True
+        )
 
         index = result.get(index_name, None)
 
@@ -704,7 +706,9 @@ class SyncOrchestrator:
         else:
             # Create a new index
             self._logger.info(f"Creating content index: {index_name}")
-            await self.es_management_client.create_content_index(index_name, language_code)
+            await self.es_management_client.create_content_index(
+                index_name, language_code
+            )
             self._logger.info(f"Content index successfully created:  {index_name}")
 
     def done(self):

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -678,25 +678,34 @@ class SyncOrchestrator:
         # TODO: think how to make it not a proxy method to the client
         return await self.es_management_client.has_active_license_enabled(license_)
 
-    async def prepare_content_index(self, index, language_code=None):
-        """Creates the index, given a mapping if it does not exists."""
-        self._logger.debug(f"Checking index {index}")
+    async def prepare_content_index(self, index_name, language_code=None):
+        """Creates the index, given a mapping/settings if it does not exists."""
+        self._logger.debug(f"Checking index {index_name}")
 
-        exists = await self.es_management_client.index_exists(index)
+        result = await self.es_management_client.get_index(index_name, ignore_unavailable=True)
+
+        index = result.get(index_name, None)
 
         mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
 
-        if exists:
+        if index:
             # Update the index mappings if needed
-            self._logger.debug(f"{index} exists")
+            self._logger.debug(f"{index_name} exists")
+
+            # Settings contain analizers which are being used in the index mappings
+            # Therefore settings must be applied before mappings
+            await self.es_management_client.ensure_content_index_settings(
+                index_name=index_name, index=index, language_code=language_code
+            )
+
             await self.es_management_client.ensure_content_index_mappings(
-                index, mappings
+                index_name, mappings
             )
         else:
             # Create a new index
-            self._logger.info(f"Creating content index: {index}")
-            await self.es_management_client.create_content_index(index, language_code)
-            self._logger.info(f"Content index successfully created:  {index}")
+            self._logger.info(f"Creating content index: {index_name}")
+            await self.es_management_client.create_content_index(index_name, language_code)
+            self._logger.info(f"Content index successfully created:  {index_name}")
 
     def done(self):
         if self._extractor_task is not None and not self._extractor_task.done():

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -298,7 +298,7 @@ class SyncJobRunner:
         logger.debug("Preparing the content index")
 
         await self.sync_orchestrator.prepare_content_index(
-            index=self.sync_job.index_name, language_code=self.sync_job.language
+            index_name=self.sync_job.index_name, language_code=self.sync_job.language
         )
 
         content_extraction_enabled = (

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -14,6 +14,7 @@ from elasticsearch import (
 )
 
 from connectors.es.management_client import ESManagementClient
+from connectors.es.settings import Settings
 from tests.commons import AsyncIterator
 
 
@@ -110,6 +111,73 @@ class TestESManagementClient:
 
         await es_management_client.ensure_content_index_mappings(index_name, mappings)
         es_management_client.client.indices.put_mapping.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ensure_content_index_settings_when_settings_exist(
+        self, es_management_client
+    ):
+        index_name = "something"
+        index = {"settings": {"index": {"analysis": "something"}}}
+
+        await es_management_client.ensure_content_index_settings(index_name, index)
+        es_management_client.client.indices.close.assert_not_called()
+        es_management_client.client.indices.put_settings.assert_not_called()
+        es_management_client.client.indices.open.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ensure_content_index_settings_when_settings_do_not_exist(
+        self, es_management_client
+    ):
+        language_code = "en"
+        index_name = "something"
+        index = {}
+        settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
+
+        await es_management_client.ensure_content_index_settings(
+            index_name, index, language_code
+        )
+
+        es_management_client.client.indices.close.assert_called()
+        es_management_client.client.indices.put_settings.assert_awaited_with(
+            index=index_name, body=settings
+        )
+        es_management_client.client.indices.open.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_ensure_content_index_settings_when_settings_do_not_exist_for_serverless(
+        self, es_management_client
+    ):
+        es_management_client.serverless = True
+        language_code = "en"
+        index_name = "something"
+        index = {}
+        settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
+
+        await es_management_client.ensure_content_index_settings(
+            index_name, index, language_code
+        )
+
+        es_management_client.client.perform_request.assert_awaited_with(
+            "PUT",
+            f"/{index_name}/_settings?reopen=true",
+            headers={"accept": "application/json", "content-type": "application/json"},
+            body=settings,
+        )
+
+    @pytest.mark.asyncio
+    async def test_ensure_content_index_settings_when_settings_exist_for_serverless(
+        self, es_management_client
+    ):
+        es_management_client.serverless = True
+        language_code = "en"
+        index_name = "something"
+        index = {"settings": {"index": {"analysis": "something"}}}
+
+        await es_management_client.ensure_content_index_settings(
+            index_name, index, language_code
+        )
+
+        es_management_client.client.perform_request.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ensure_ingest_pipeline_exists_when_pipeline_do_not_exist(

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -6,6 +6,7 @@
 import asyncio
 import datetime
 import itertools
+import json
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import ANY, AsyncMock, Mock, call
@@ -14,8 +15,8 @@ import pytest
 from elasticsearch import ApiError, BadRequestError
 
 from connectors.es import Mappings
-from connectors.es.settings import Settings
 from connectors.es.management_client import ESManagementClient
+from connectors.es.settings import Settings
 from connectors.es.sink import (
     OP_DELETE,
     OP_INDEX,
@@ -29,7 +30,6 @@ from connectors.es.sink import (
 )
 from connectors.protocol import JobType, Pipeline
 from tests.commons import AsyncIterator
-import json
 
 INDEX = "some-index"
 TIMESTAMP = datetime.datetime(year=2023, month=1, day=1)
@@ -68,7 +68,7 @@ async def test_prepare_content_index_raise_error_when_index_creation_failed(
         f"http://nowhere.com:9200/{index_name}?ignore_unavailable=true",
         headers=headers,
         status=200,
-        body="{}"
+        body="{}",
     )
 
     mock_responses.put(
@@ -102,7 +102,7 @@ async def test_prepare_content_index_create_index(
         f"http://nowhere.com:9200/{index_name}?ignore_unavailable=true",
         headers=headers,
         status=200,
-        body='{}',
+        body="{}",
     )
 
     mock_responses.put(

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -14,6 +14,7 @@ import pytest
 from elasticsearch import ApiError, BadRequestError
 
 from connectors.es import Mappings
+from connectors.es.settings import Settings
 from connectors.es.management_client import ESManagementClient
 from connectors.es.sink import (
     OP_DELETE,
@@ -28,6 +29,7 @@ from connectors.es.sink import (
 )
 from connectors.protocol import JobType, Pipeline
 from tests.commons import AsyncIterator
+import json
 
 INDEX = "some-index"
 TIMESTAMP = datetime.datetime(year=2023, month=1, day=1)
@@ -60,11 +62,15 @@ async def test_prepare_content_index_raise_error_when_index_creation_failed(
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
     )
-    mock_responses.head(
-        f"http://nowhere.com:9200/{index_name}",
+
+    # not found
+    mock_responses.get(
+        f"http://nowhere.com:9200/{index_name}?ignore_unavailable=true",
         headers=headers,
-        status=404,
+        status=200,
+        body="{}"
     )
+
     mock_responses.put(
         f"http://nowhere.com:9200/{index_name}",
         payload={"_id": "1"},
@@ -90,13 +96,23 @@ async def test_prepare_content_index_create_index(
     mock_responses.post(
         "http://nowhere.com:9200/.elastic-connectors/_refresh", headers=headers
     )
-    mock_responses.head(
-        f"http://nowhere.com:9200/{index_name}",
+
+    # not found
+    mock_responses.get(
+        f"http://nowhere.com:9200/{index_name}?ignore_unavailable=true",
         headers=headers,
-        status=404,
+        status=200,
+        body='{}',
     )
+
     mock_responses.put(
         f"http://nowhere.com:9200/{index_name}",
+        payload={"_id": "1"},
+        headers=headers,
+    )
+
+    mock_responses.put(
+        f"http://nowhere.com:9200/{index_name}/_settings",
         payload={"_id": "1"},
         headers=headers,
     )
@@ -120,35 +136,48 @@ async def test_prepare_content_index_create_index(
 
 @pytest.mark.asyncio
 async def test_prepare_content_index(mock_responses):
+    language_code = "en"
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     headers = {"X-Elastic-Product": "Elasticsearch"}
+    settings = Settings(language_code=language_code, analysis_icu=False).to_hash()
     # prepare-index, with mappings
 
     mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
+    index_name = "search-new-index"
 
-    mock_responses.head(
-        "http://nowhere.com:9200/search-new-index",
-        headers=headers,
-    )
+    response = {
+        index_name: {
+            "mappings": {},
+            "settings": {},
+        }
+    }
     mock_responses.get(
-        "http://nowhere.com:9200/search-new-index/_mapping",
+        f"http://nowhere.com:9200/{index_name}?ignore_unavailable=true",
         headers=headers,
-        payload={"search-new-index": {"mappings": {}}},
+        status=200,
+        body=json.dumps(response),
     )
+
     mock_responses.put(
-        "http://nowhere.com:9200/search-new-index/_mapping",
+        f"http://nowhere.com:9200/{index_name}/_mapping",
         headers=headers,
         payload=mappings,
         body='{"acknowledged": True}',
     )
 
+    mock_responses.put(
+        f"http://nowhere.com:9200/{index_name}/_settings",
+        headers=headers,
+        payload=settings,
+        body='{"acknowledged": True}',
+    )
+
     es = SyncOrchestrator(config)
-    index_name = "search-new-index"
     with mock.patch.object(
         es.es_management_client,
         "ensure_content_index_mappings",
     ) as put_mapping_mock:
-        await es.prepare_content_index(index_name)
+        await es.prepare_content_index(index_name, language_code)
 
         await es.close()
 


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5765

This PR will improve the following scenarios:

### Connectors clients, programmatic access, ESS and ES3
1. A Customer creates a new connector and a new index using Elasticsearch API or Connectors API
2. The customer runs a full sync job
3. The connector service tries to apply mappings and fails with: 
```
[FMWK][16:54:58][WARNING] Client method 'put_mapping' retry 1: api error with status 400
[FMWK][16:54:58][WARNING] Could not create mappings for index test-mysql-custom-3, encountered error BadRequestError(400, 'mapper_parsing_exception', 'Failed to parse mapping: dynamic template [data] has invalid content [{"match_mapping_type":"string","mapping":{"analyzer":"iq_text_base","fields":{"prefix":{"search_analyzer":"q_prefix","analyzer":"i_prefix","type":"text","index_options":"docs"},"delimiter":{"analyzer":"iq_text_delimiter","type":"text","index_options":"freqs"},"joined":{"search_analyzer":"q_text_bigram","analyzer":"i_text_bigram","type":"text","index_options":"freqs"},"enum":{"ignore_above":2048,"type":"keyword"},"stem":{"analyzer":"iq_text_stem","type":"text"}},"index_options":"freqs","type":"text"}}], attempted to validate it with the following match_mapping_type: [string]')
```
The default content indices mapping uses analizers which should be defined in the index settings. Therefore, we should add settings first and only after that add mappings. 

**Note:**
We should use a different API endpoint to apply settings for a stateless Elasticsearch instance. 

Also, this PR will raise the log level for the messages that indicate the index settings and mapping changes. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note
The connector service tries to apply Settings and Mapping if the index is created programmatically (Connectors API or Elasticsearch API)
