### PR TITLE
[CLI] Create and store API keys for native connectors in CLI

### DIFF
--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -320,19 +320,12 @@ def create(
     )
 
     if result["api_key_skipped"]:
-        if is_native:
-            click.echo(
-                click.style(
-                    "API keys for native connectors are internally managed. An API key will be automatically generated for this connector during its first sync.",
-                )
+        click.echo(
+            click.style(
+                "Cannot create a connector-specific API key when authenticating to Elasticsearch with an API key. Consider using username/password to authenticate, or create a connector-specific API key through Kibana.",
+                fg="yellow",
             )
-        else:
-            click.echo(
-                click.style(
-                    "Cannot create a connector-specific API key when authenticating to Elasticsearch with an API key. Consider using username/password to authenticate, or create a connector-specific API key through Kibana.",
-                    fg="yellow",
-                )
-            )
+        )
 
     if result["api_key_error"]:
         click.echo(click.style(result["api_key_error"], fg="yellow"))

--- a/connectors/es/management_client.py
+++ b/connectors/es/management_client.py
@@ -193,3 +193,18 @@ class ESManagementClient(ESClient):
             )
         )
         return secret.get("value")
+
+    async def create_connector_secret(self, secret_value):
+        secret = await self._retrier.execute_with_retry(
+            partial(
+                self.client.perform_request,
+                "POST",
+                "/_connector/_secret",
+                headers={
+                    "accept": "application/json",
+                    "content-type": "application/json",
+                },
+                body={"value": secret_value},
+            )
+        )
+        return secret.get("id")

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -304,4 +304,3 @@ class TestESManagementClient:
             body={"value": secret_value},
             headers={"accept": "application/json", "content-type": "application/json"},
         )
-

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -286,3 +286,22 @@ class TestESManagementClient:
         with pytest.raises(ElasticNotFoundError):
             secret = await es_management_client.get_connector_secret(secret_id)
             assert secret is None
+
+    @pytest.mark.asyncio
+    async def test_create_connector_secret(self, es_management_client, mock_responses):
+        secret_id = "secret-id"
+        secret_value = "my-secret"
+
+        es_management_client.client.perform_request = AsyncMock(
+            return_value={"id": secret_id}
+        )
+
+        returned_id = await es_management_client.create_connector_secret(secret_value)
+        assert returned_id == secret_id
+        es_management_client.client.perform_request.assert_awaited_with(
+            "POST",
+            "/_connector/_secret",
+            body={"value": secret_value},
+            headers={"accept": "application/json", "content-type": "application/json"},
+        )
+

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -491,35 +491,42 @@ def test_connector_create_native_connector(patched_confirm):
     )
 
     with patch(
-        "connectors.cli.connector.Connector._Connector__create_api_key", AsyncMock()
+        "connectors.cli.connector.Connector._Connector__create_api_key",
+        AsyncMock(return_value={"id": "api-key-123", "encoded": "foo"}),
     ) as patched_create_api_key:
         with patch(
-            "connectors.protocol.connectors.ConnectorIndex.index",
-            AsyncMock(return_value={"_id": "new_connector_id"}),
-        ) as patched_create:
-            result = runner.invoke(
-                cli,
-                [
-                    "connector",
-                    "create",
-                    "--service-type",
-                    "mongodb",
-                    "--from-index",
-                    "--native",
-                ],
-                input=input_params,
-            )
+            "connectors.cli.connector.Connector._Connector__store_api_key",
+            AsyncMock(return_value="secret-123"),
+        ) as patched_store_api_key:
+            with patch(
+                "connectors.protocol.connectors.ConnectorIndex.index",
+                AsyncMock(return_value={"_id": "new_connector_id"}),
+            ) as patched_create:
+                result = runner.invoke(
+                    cli,
+                    [
+                        "connector",
+                        "create",
+                        "--service-type",
+                        "mongodb",
+                        "--from-index",
+                        "--native",
+                    ],
+                    input=input_params,
+                )
 
-            patched_create.assert_called_once()
+                patched_create.assert_called_once()
 
-            call_args = patched_create.call_args[0][0]
-            assert call_args["is_native"] is True
-            assert call_args["api_key_id"] is None
+                call_args = patched_create.call_args[0][0]
+                assert call_args["is_native"] is True
+                assert call_args["api_key_id"] == "api-key-123"
+                assert call_args["api_key_secret_id"] == "secret-123"
 
-            patched_create_api_key.assert_not_called()
-            assert result.exit_code == 0
+                patched_create_api_key.assert_called_once()
+                patched_store_api_key.assert_called_once()
+                assert result.exit_code == 0
 
-            assert "has been created" in result.output
+                assert "has been created" in result.output
 
 
 def test_index_help_page():


### PR DESCRIPTION
### Summary
We had to revert automated API key generation [here](https://github.com/elastic/connectors/pull/2233) because it didn't work in Cloud as we expected.
Previously, we would just allow native connectors to be created in CLI without an API key, and rely on it being generated before a sync. Now that we know this isn't possible, we need to explicitly generate and store API keys for native connectors when they are created in CLI.

### Changes

- Allow API keys to be created for native connectors
- Store native connector API keys to secrets
- Update `api_key_secret_id` field on connector doc with secret id
