### PR TITLE
Fix logs for incorrect configuration values in Redis

### DIFF
--- a/connectors/sources/redis.py
+++ b/connectors/sources/redis.py
@@ -347,6 +347,11 @@ class RedisDataSource(BaseDataSource):
         invalid_db = []
         msg = ""
         if self.client.database != ["*"]:
+            try:
+                await self.client.ping()
+            except Exception:
+                self._logger.exception("Error while connecting to Redis.")
+                raise
             for db in self.client.database:
                 if not db.isdigit() or int(db) < 0:
                     invalid_type.append(db)

--- a/tests/sources/test_redis.py
+++ b/tests/sources/test_redis.py
@@ -123,6 +123,18 @@ async def test_validate_config_when_database_is_not_integer():
 
 
 @pytest.mark.asyncio
+async def test_validate_config_with_wrong_configuration():
+    async with create_redis_source() as source:
+        mocked_client = AsyncMock()
+        with mock.patch("redis.asyncio.from_url", return_value=mocked_client):
+            mocked_client.ping = AsyncMock(
+                side_effect=redis.exceptions.AuthenticationError
+            )
+            with pytest.raises(Exception):
+                await source.validate_config()
+
+
+@pytest.mark.asyncio
 async def test_validate_config_when_database_is_invalid():
     async with create_redis_source() as source:
         source.client.database = ["123"]


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2258###
This PR includes fix for:
1. Raising correct error incase of incorrect configuration values and correct database name

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
