### PR TITLE
[8.13] [Redis] Log correct message when cannot connect to Redis  (#2259)

### DIFF
--- a/connectors/sources/redis.py
+++ b/connectors/sources/redis.py
@@ -347,6 +347,11 @@ class RedisDataSource(BaseDataSource):
         invalid_db = []
         msg = ""
         if self.client.database != ["*"]:
+            try:
+                await self.client.ping()
+            except Exception:
+                self._logger.exception("Error while connecting to Redis.")
+                raise
             for db in self.client.database:
                 if not db.isdigit() or int(db) < 0:
                     invalid_type.append(db)

--- a/tests/sources/test_redis.py
+++ b/tests/sources/test_redis.py
@@ -123,6 +123,18 @@ async def test_validate_config_when_database_is_not_integer():
 
 
 @pytest.mark.asyncio
+async def test_validate_config_with_wrong_configuration():
+    async with create_redis_source() as source:
+        mocked_client = AsyncMock()
+        with mock.patch("redis.asyncio.from_url", return_value=mocked_client):
+            mocked_client.ping = AsyncMock(
+                side_effect=redis.exceptions.AuthenticationError
+            )
+            with pytest.raises(Exception):
+                await source.validate_config()
+
+
+@pytest.mark.asyncio
 async def test_validate_config_when_database_is_invalid():
     async with create_redis_source() as source:
         source.client.database = ["123"]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Redis] Log correct message when cannot connect to Redis  (#2259)](https://github.com/elastic/connectors/pull/2259)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)