### PR TITLE
Clarify Elasticsearch Client Log Message While Waiting for Connection

### DIFF
--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -159,7 +159,9 @@ class ESClient:
             logger.info(
                 f"Waiting for Elasticsearch at {self.configured_host} (so far: {int(time.time() - start)} secs)"
             )
-            logger.debug(f"Seed node configuration: {self.client.transport.node_pool._seed_nodes}")
+            logger.debug(
+                f"Seed node configuration: {self.client.transport.node_pool._seed_nodes}"
+            )
             if await self.ping():
                 return True
             await self._sleeps.sleep(backoff)

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -156,8 +156,9 @@ class ESClient:
                 return False
 
             logger.info(
-                f"Waiting for {self.host} (so far: {int(time.time() - start)} secs)"
+                f"Waiting for {self.host.url} (so far: {int(time.time() - start)} secs)"
             )
+            logger.debug(f"Seed node configuration: {self.client.transport.node_pool._seed_nodes}")
             if await self.ping():
                 return True
             await self._sleeps.sleep(backoff)

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -46,8 +46,9 @@ class ESClient:
         # for now we just use an env flag
         self.serverless = "SERVERLESS" in os.environ
         self.config = config
+        self.configured_host = config.get("host", "http://localhost:9200")
         self.host = url_to_node_config(
-            config.get("host", "http://localhost:9200"),
+            self.configured_host,
             use_default_ports_for_scheme=True,
         )
         self._sleeps = CancellableSleeps()
@@ -62,7 +63,7 @@ class ESClient:
             "request_timeout": config.get("request_timeout", 120),
             "retry_on_timeout": config.get("retry_on_timeout", True),
         }
-        logger.debug(f"Host is {self.host}")
+        logger.debug(f"Initial Elasticsearch node configuration is {self.host}")
 
         if "api_key" in config:
             logger.debug(f"Connecting with an API Key ({config['api_key'][:5]}...)")
@@ -156,7 +157,7 @@ class ESClient:
                 return False
 
             logger.info(
-                f"Waiting for {self.host.url} (so far: {int(time.time() - start)} secs)"
+                f"Waiting for Elasticsearch at {self.configured_host} (so far: {int(time.time() - start)} secs)"
             )
             logger.debug(f"Seed node configuration: {self.client.transport.node_pool._seed_nodes}")
             if await self.ping():


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/843
## Helps with https://github.com/elastic/connectors/issues/1826

The `self.host` variable for the Elasticsearch client is set up before the AsyncElasticsearch client is created, and thus does not have various options set (such as `ca_certs` in this case) - or, better stated, the defaults for the NodeConfig are used. Once the AsyncElasticsearch client is created, a copy of the `self.host` NodeConfig is created and the additional options are merged.

This PR logs only the URL from the `self.host` at the INFO level. If DEBUG logging is turned on, an additional log line with the seed node configuration (`self.client.transport.node_pool._seed_nodes`) will be logged that has additional information including the `ca_certs` populated amongst others.

As an example, with `service.log_level: DEBUG`, the following is emitted: 
```
[FMWK][06:30:41][INFO] Waiting for Elasticsearch at https://localhost:9200 (so far: 3 secs)
[FMWK][06:30:41][DEBUG] Seed node configuration: (NodeConfig(scheme='https', host='localhost', port=9200, path_prefix='', headers={'user-agent': 'elasticsearch-py/8.12.0 (Python/3.11.6; elastic-transport/8.12.0)'}, connections_per_node=10, request_timeout=10.0, http_compress=False, verify_certs=True, ca_certs='/Users/mhoy/Development/connectors/certificate.pem', client_cert=None, client_key=None, ssl_assert_hostname=None, ssl_assert_fingerprint=None, ssl_version=None, ssl_context=None, ssl_show_warn=True, _extras={}),)
```

## Checklists
#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
