### PR TITLE
log filtering validation result at info

### DIFF
--- a/connectors/filtering/validation.py
+++ b/connectors/filtering/validation.py
@@ -198,7 +198,7 @@ class FilteringValidator:
             for validator in advanced_rules_validators:
                 filtering_validation_result += await validator.validate(advanced_rules)
 
-        self._logger.debug(
+        self._logger.info(
             f"Filtering validation result: {filtering_validation_result.state}"
         )
 


### PR DESCRIPTION
We log the start of validation at INFO, but with this at DEBUG, it's unclear to the customer (by default) if validation succeeds or not.