### PR TITLE
Don't fail the sync if there are failed operations in the bulk api request

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -198,7 +198,6 @@ class Sink:
                 for op, data in item.items():
                     if "error" in data:
                         self._logger.error(f"operation {op} failed, {data['error']}")
-                        raise Exception(data["error"]["reason"])
 
         self._populate_stats(stats, res)
 
@@ -360,6 +359,9 @@ class Sink:
                     break
                 operation = doc["_op_type"]
                 doc_id = doc["_id"]
+                if not doc_id:
+                    self._logger.warning(f"Skip document {doc} as '_id' is missing.")
+                    continue
                 if operation == OP_DELETE:
                     stats[operation][doc_id] = 0
                 else:

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -1208,7 +1208,7 @@ async def test_batch_bulk_with_errors(patch_logger):
             "items": [{"index": {"_id": "1", "error": error}}],
         }
         client.client.bulk = AsyncMock(return_value=mock_result)
-        await sink._batch_bulk([], {OP_INDEX: {"1": 20}, OP_UPSERT: {}, OP_DELETE: {}})
+        await sink._batch_bulk([], {OP_INDEX: {"1": 20}, OP_UPDATE: {}, OP_DELETE: {}})
         patch_logger.assert_present(f"operation index failed, {error}")
 
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -1178,6 +1178,40 @@ async def test_batch_bulk_with_retry():
         assert client.client.bulk.await_count == 2
 
 
+@pytest.mark.asyncio
+async def test_batch_bulk_with_errors(patch_logger):
+    config = {
+        "username": "elastic",
+        "password": "changeme",
+        "host": "http://nowhere.com:9200",
+    }
+    client = ESManagementClient(config)
+    client.client = AsyncMock()
+    sink = Sink(
+        client=client,
+        queue=None,
+        chunk_size=0,
+        pipeline={"name": "pipeline"},
+        chunk_mem_size=0,
+        max_concurrency=0,
+        max_retries=3,
+        retry_interval=10,
+    )
+
+    with mock.patch.object(asyncio, "sleep"):
+        error = {
+            "type": "illegal_argument_exception",
+            "reason": "if _id is specified it must not be empty",
+        }
+        mock_result = {
+            "errors": True,
+            "items": [{"index": {"_id": "1", "error": error}}],
+        }
+        client.client.bulk = AsyncMock(return_value=mock_result)
+        await sink._batch_bulk([], {OP_INDEX: {"1": 20}, OP_UPSERT: {}, OP_DELETE: {}})
+        patch_logger.assert_present(f"operation index failed, {error}")
+
+
 @pytest.mark.parametrize(
     "extractor_task, extractor_task_done, sink_task, sink_task_done, expected_result",
     [


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/5808

This PR makes 2 changes:
1. When there's field `_id` missing in a document, skip the document and log an error message
2. When one or more operations fail in a bulk request, don't fail the whole sync job, log the error message instead.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
