### PR TITLE
Wait for sync jobs to finish before closing clients

### DIFF
--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -148,6 +148,7 @@ class JobExecutionService(BaseService):
                     break
                 await self._sleeps.sleep(self.idling)
         finally:
+            await self.sync_job_pool.join()
             if self.connector_index is not None:
                 self.connector_index.stop_waiting()
                 await self.connector_index.close()

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -410,7 +410,11 @@ class ConcurrentTasks:
     def _callback(self, task, result_callback=None):
         self.tasks.remove(task)
         self._sem.release()
-        if task.exception():
+        if task.cancelled():
+            logger.error(
+                f"Task {task.get_name()} was cancelled",
+            )
+        elif task.exception():
             logger.error(
                 f"Exception found for task {task.get_name()}: {task.exception()}",
                 exc_info=True,


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2167

The problem started happening due to recent fix to actually close ESClient instances properly.

The problem in short happened because the instances of ESClient were closed while SyncJobRunner was attempting to suspend the sync - to suspend the sync it needed to load the job record from ES, then update it, then do some more small calls to Elasticsearch. It failed because the client was already closed by the time these calls were made.

The change now ensures, that all tasks in ConcurrentTasks finish before actually closing ESClients.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Fixed connectors not properly suspending jobs on host being forcefully stopped.