### PR TITLE
Eliminate Duplicate Buildkite Builds on Branches and PRs

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -8,7 +8,7 @@
       "allowed_list": ["praveen-elastic", "moxarth-elastic", "khusbu-crest", "akanshi-crest"],
       "set_commit_status": true,
       "commit_status_context": "buildkite/connectors",
-      "build_on_commit": true,
+      "build_on_commit": false,
       "build_on_comment": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
@@ -18,4 +18,3 @@
     }
   ]
 }
-

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -48,6 +48,8 @@ spec:
       branch_configuration: "main"
       pipeline_file: ".buildkite/pipeline.yml"
       repository: "elastic/connectors"
+      provider_settings:
+        skip_pull_request_builds_for_existing_commits: false
       teams:
         everyone:
           access_level: "READ_ONLY"


### PR DESCRIPTION
A small CI related change to reduce the number of duplicated Buildkite jobs. This:

1) sets `"build_on_commit": false` in the `pull-requests.json` to allow the webhook settings to determine when to build
2) sets `skip_pull_request_builds_for_existing_commits: false` in the `catalog-info.yaml` file to ensure new builds are created only when there's a new commit (you can still run the comment commands to rebuild that will flow through the other webhook)

## Checklists
#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
