### PR TITLE
[Sink] Use constant for END_DOCS and FETCH_ERROR

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -50,6 +50,8 @@ from connectors.utils import (
 )
 
 __all__ = ["SyncOrchestrator"]
+FETCH_ERROR = "FETCH_ERROR"
+END_DOCS = "END_DOCS"
 
 OP_INDEX = "index"
 OP_UPSERT = "update"
@@ -229,7 +231,7 @@ class Sink:
 
         while True:
             doc_size, doc = await self.fetch_doc()
-            if doc in ("END_DOCS", "FETCH_ERROR"):
+            if doc in (END_DOCS, FETCH_ERROR):
                 break
             operation = doc["_op_type"]
             doc_id = doc["_id"]
@@ -371,7 +373,7 @@ class Extractor:
             # We clear the queue as we could not actually ingest anything.
             # After that we indicate that we've encountered an error
             self.queue.clear()
-            await self.put_doc("FETCH_ERROR")
+            await self.put_doc(FETCH_ERROR)
             self.fetch_error = ElasticsearchOverloadedError(e)
         except Exception as e:
             if isinstance(e, ForceCanceledError) or self._canceled:
@@ -381,7 +383,7 @@ class Extractor:
                 return
 
             self._logger.critical("Document extractor failed", exc_info=True)
-            await self.put_doc("FETCH_ERROR")
+            await self.put_doc(FETCH_ERROR)
             self.fetch_error = e
 
     @tracer.start_as_current_span("get_doc call", slow_log=1.0)
@@ -468,7 +470,7 @@ class Extractor:
             await lazy_downloads.join()
 
         await self.enqueue_docs_to_delete(existing_ids)
-        await self.put_doc("END_DOCS")
+        await self.put_doc(END_DOCS)
 
     async def _load_existing_docs(self):
         start = time.time()
@@ -554,7 +556,7 @@ class Extractor:
             # wait for all downloads to be finished
             await lazy_downloads.join()
 
-        await self.put_doc("END_DOCS")
+        await self.put_doc(END_DOCS)
 
     async def get_access_control_docs(self, generator):
         """Iterate on a generator of access control documents to fill a queue with bulk operations for the `Sink` to consume.
@@ -619,7 +621,7 @@ class Extractor:
             await asyncio.sleep(0)
 
         await self.enqueue_docs_to_delete(existing_ids)
-        await self.put_doc("END_DOCS")
+        await self.put_doc(END_DOCS)
 
     async def enqueue_docs_to_delete(self, existing_ids):
         self._logger.debug(f"Delete {len(existing_ids)} docs from index '{self.index}'")


### PR DESCRIPTION
Small PR to improve consistency. We use constants for operations we're using at multiple places, so we should also use constants for `FETCH_ERROR` and `END_DOCS` IMO.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
~- [ ] this PR links to all relevant github issues that it fixes or partially addresses~
~- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue~
(didn't create an issue for a 20 seconds refactoring)
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)