### PR TITLE
[Sink] Improve wording

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -494,7 +494,7 @@ class Extractor:
         return existing_ids
 
     async def get_docs_incrementally(self, generator):
-        """Iterate on a generator of documents to fill a queue of bulk operations for the `Sink` to consume.
+        """Iterate on a generator of documents to fill a queue with bulk operations for the `Sink` to consume.
 
         A document might be discarded if its timestamp has not changed.
         Extraction happens in a separate task, when a document contains files.


### PR DESCRIPTION
It should be "fill a queue with" and not "fill a queue of"