### PR TITLE
[8.12] Make MemQueue used in sync configurable via config options (#2079)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -102,6 +102,17 @@
 #elasticsearch.bulk.queue_max_mem_size: 25
 #
 #
+##  Minimal interval of time between MemQueue checks for being full
+#elasticsearch.bulk.queue_refresh_interval: 1
+#
+#
+##  Maximal interval of time during which MemQueue does not dequeue a single document
+##  For example, if no documents were sent to Elasticsearch within 60 seconds because of
+##  Elasticsearch being overloaded, then an error will be raised.
+##  This mechanism exists to be a circuit-breaker for stuck jobs and stuck Elasticsearch.
+#elasticsearch.bulk.queue_refresh_timeout: 60
+#
+#
 ##  The max size in MB of a bulk request.
 ##    When the next request being prepared reaches that size, the query is
 ##    emitted even if `chunk_size` is not yet reached.
@@ -118,6 +129,14 @@
 #
 ##  Maximum number of concurrent downloads in the backend.
 #elasticsearch.bulk.concurrent_downloads: 10
+#
+#
+##  Maximum number of times failed bulk requests are retried
+#elasticsearch.bulk.max_retries: 5
+#
+#
+##  Retry interval between failed bulk attempts
+#elasticsearch.bulk.retry_interval: 10
 #
 #
 ## ------------------------------- Service ----------------------------------

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -9,6 +9,9 @@ from envyaml import EnvYAML
 
 from connectors.logger import logger
 
+DEFAULT_ELASTICSEARCH_MAX_RETRIES = 5
+DEFAULT_ELASTICSEARCH_RETRY_INTERVAL = 10
+
 
 def load_config(config_file):
     logger.info(f"Loading config from {config_file}")

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -1,4 +1,3 @@
-#
 # Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
@@ -54,6 +53,8 @@ def _default_config():
             "bulk": {
                 "queue_max_size": 1024,
                 "queue_max_mem_size": 25,
+                "queue_refresh_interval": 1,
+                "queue_refresh_timeout": 600,
                 "display_every": 100,
                 "chunk_size": 1000,
                 "max_concurrency": 5,

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -29,13 +29,15 @@ from elasticsearch import (
 )
 from elasticsearch.helpers import async_scan
 
+from connectors.config import (
+    DEFAULT_ELASTICSEARCH_MAX_RETRIES,
+)
 from connectors.es import ESClient, Mappings
 from connectors.es.settings import Settings
 from connectors.filtering.basic_rule import BasicRuleEngine, parse
 from connectors.logger import logger, tracer
 from connectors.protocol import Filter, JobType
 from connectors.utils import (
-    DEFAULT_BULK_MAX_RETRIES,
     DEFAULT_CHUNK_MEM_SIZE,
     DEFAULT_CHUNK_SIZE,
     DEFAULT_CONCURRENT_DOWNLOADS,
@@ -792,9 +794,6 @@ class SyncOrchestrator(ESClient):
             "concurrent_downloads", DEFAULT_CONCURRENT_DOWNLOADS
         )
         max_bulk_retries = options.get("max_retries", DEFAULT_ELASTICSEARCH_MAX_RETRIES)
-        retry_interval = options.get(
-            "retry_interval", DEFAULT_ELASTICSEARCH_RETRY_INTERVAL
-        )
         mem_queue_refresh_timeout = options.get("queue_refresh_timeout", 60)
         mem_queue_refresh_interval = options.get("queue_refresh_interval", 1)
 

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -791,9 +791,19 @@ class SyncOrchestrator(ESClient):
         concurrent_downloads = options.get(
             "concurrent_downloads", DEFAULT_CONCURRENT_DOWNLOADS
         )
-        max_bulk_retries = options.get("max_retries", DEFAULT_BULK_MAX_RETRIES)
+        max_bulk_retries = options.get("max_retries", DEFAULT_ELASTICSEARCH_MAX_RETRIES)
+        retry_interval = options.get(
+            "retry_interval", DEFAULT_ELASTICSEARCH_RETRY_INTERVAL
+        )
+        mem_queue_refresh_timeout = options.get("queue_refresh_timeout", 60)
+        mem_queue_refresh_interval = options.get("queue_refresh_interval", 1)
 
-        stream = MemQueue(maxsize=queue_size, maxmemsize=queue_mem_size * 1024 * 1024)
+        stream = MemQueue(
+            maxsize=queue_size,
+            maxmemsize=queue_mem_size * 1024 * 1024,
+            refresh_timeout=mem_queue_refresh_timeout,
+            refresh_interval=mem_queue_refresh_interval,
+        )
 
         # start the fetcher
         self._extractor = Extractor(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [Make MemQueue used in sync configurable via config options (#2079)](https://github.com/elastic/connectors/pull/2079)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)