### PR TITLE
[Network Drive] Change traversal strategy to ingest as you go instead of pre-fetching the whole tree

### DIFF
--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -174,7 +174,7 @@ async def test_create_connection_with_invalid_credentials(session_mock):
 
 @mock.patch("smbclient.scandir")
 @pytest.mark.asyncio
-async def test_get_files_with_invalid_path(dir_mock):
+async def test_traverse_diretory_with_invalid_path(dir_mock):
     """Tests the scandir method of smbclient throws error on invalid path
 
     Args:
@@ -186,14 +186,14 @@ async def test_get_files_with_invalid_path(dir_mock):
         dir_mock.side_effect = SMBOSError(ntstatus=3221225487, filename="unknown_path")
 
         # Execute
-        async for file in source.get_files(path=path):
+        async for file in source.traverse_diretory(path=path):
             assert file == []
 
 
 @mock.patch("smbclient.scandir")
 @mock.patch("connectors.utils.time_to_sleep_between_retries", mock.Mock(return_value=0))
 @pytest.mark.asyncio
-async def test_get_files_retried_on_smb_timeout(dir_mock):
+async def test_traverse_diretory_retried_on_smb_timeout(dir_mock):
     """Tests the scandir method of smbclient is retried on SMBConnectionClosed error
 
     Args:
@@ -217,54 +217,13 @@ async def test_get_files_retried_on_smb_timeout(dir_mock):
                 "size": "30",
                 "type": "file",
             }
-            async for file in source.get_files(path=path):
+            async for file in source.traverse_diretory(path=path):
                 assert file == expected_output
 
 
 @pytest.mark.asyncio
-@mock.patch("smbclient.scandir")
-async def test_get_files(dir_mock):
-    """Tests the get_files method for network drive
-
-    Args:
-        dir_mock (patch): The patch of scandir method
-    """
-    # Setup
-    async with create_source(NASDataSource) as source:
-        path = "\\1.2.3.4/dummy_path"
-        dir_mock.return_value = [mock_file(name="a1.md"), mock_folder(name="A")]
-        expected_output = [
-            {
-                "_id": "1",
-                "_timestamp": "2022-04-21T12:12:30",
-                "path": "\\1.2.3.4/dummy_path/a1.md",
-                "title": "a1.md",
-                "created_at": "2022-01-11T12:12:30",
-                "size": "30",
-                "type": "file",
-            },
-            {
-                "_id": "122",
-                "_timestamp": "2022-05-21T12:12:30",
-                "path": "\\1.2.3.4/dummy_path/A",
-                "title": "A",
-                "created_at": "2022-02-11T12:12:30",
-                "size": "200",
-                "type": "folder",
-            },
-        ]
-
-        # Execute
-        response = []
-        async for file in source.get_files(path=path):
-            response.append(file)
-
-        # Assert
-        assert response == expected_output
-
-
-@pytest.mark.asyncio
 @mock.patch("smbclient.open_file")
+@mock.patch.object(smbclient, "register_session")
 async def test_fetch_file_when_file_is_inaccessible(file_mock, caplog):
     """Tests the open_file method of smbclient throws error when file cannot be accessed
 
@@ -406,23 +365,16 @@ async def test_get_content_when_file_type_not_supported():
 
 
 @pytest.mark.asyncio
-@mock.patch.object(NASDataSource, "get_files", return_value=mock.MagicMock())
+@mock.patch.object(NASDataSource, "traverse_diretory", return_value=mock.MagicMock())
 @mock.patch.object(NASDataSource, "fetch_groups_info", return_value=mock.AsyncMock())
-@mock.patch("smbclient.walk")
 @mock.patch("smbclient.register_session")
-async def test_get_doc(mock_get_files, mock_fetch_groups, mock_walk, session):
-    """Test get_doc method of NASDataSource Class
-
-    Args:
-        mock_get_files (coroutine): The patch of get_files coroutine
-        mock_walk (patch): The patch of walk method of smbclient
-    """
+async def test_get_doc(mock_traverse_diretory, mock_fetch_groups, session):
     # Setup
     async with create_source(NASDataSource) as source:
         # Execute
         async for _, _ in source.get_docs():
             # Assert
-            mock_get_files.assert_awaited()
+            mock_traverse_diretory.assert_awaited()
 
 
 @pytest.mark.asyncio
@@ -456,7 +408,7 @@ async def test_close_without_session():
 
 
 @pytest.mark.parametrize(
-    "advanced_rules, expected_validation_result",
+    "advanced_rules, expected_validation_result, mocked_document",
     [
         (
             # valid: empty array should be valid
@@ -464,6 +416,7 @@ async def test_close_without_session():
             SyncRuleValidationResult.valid_result(
                 SyncRuleValidationResult.ADVANCED_RULES
             ),
+            [],
         ),
         (
             # valid: empty object should also be valid -> default value in Kibana
@@ -471,6 +424,7 @@ async def test_close_without_session():
             SyncRuleValidationResult.valid_result(
                 SyncRuleValidationResult.ADVANCED_RULES
             ),
+            [],
         ),
         (
             # valid: one custom pattern
@@ -478,13 +432,56 @@ async def test_close_without_session():
             SyncRuleValidationResult.valid_result(
                 SyncRuleValidationResult.ADVANCED_RULES
             ),
+            [
+                AsyncIterator(
+                    [
+                        {
+                            "path": "\\\1.2.3.4/a/b",
+                            "size": "0",
+                            "_id": "0",
+                            "created_at": "1111-11-11T11:11:11",
+                            "type": "folder",
+                            "title": "b",
+                            "_timestamp": "1212-12-12T12:12:12",
+                        },
+                    ]
+                )
+            ],
         ),
         (
             # valid: two custom patterns
-            [{"pattern": "a/b/*"}, {"pattern": "a/*"}],
+            [{"pattern": "a/b/*"}, {"pattern": "a/**"}],
             SyncRuleValidationResult.valid_result(
                 SyncRuleValidationResult.ADVANCED_RULES
             ),
+            [
+                AsyncIterator(
+                    [
+                        {
+                            "path": "\\1.2.3.4/a/b/c",
+                            "size": "0",
+                            "_id": "1",
+                            "created_at": "1111-11-11T11:11:11",
+                            "type": "folder",
+                            "title": "c",
+                            "_timestamp": "1212-12-12T12:12:12",
+                        },
+                    ]
+                ),
+                AsyncIterator(
+                    [
+                        {
+                            "path": "\\1.2.3.4/a/b/e",
+                            "size": "0",
+                            "_id": "3",
+                            "created_at": "1111-11-11T11:11:11",
+                            "type": "folder",
+                            "title": "e",
+                            "_timestamp": "1212-12-12T12:12:12",
+                        },
+                    ]
+                ),
+            ],
         ),
         (
             # invalid: pattern empty
@@ -494,6 +491,7 @@ async def test_close_without_session():
                 is_valid=False,
                 validation_message=ANY,
             ),
+            [],
         ),
         (
             # invalid: unallowed key
@@ -503,6 +501,7 @@ async def test_close_without_session():
                 is_valid=False,
                 validation_message=ANY,
             ),
+            [],
         ),
         (
             # invalid: list of strings -> wrong type
@@ -512,6 +511,7 @@ async def test_close_without_session():
                 is_valid=False,
                 validation_message=ANY,
             ),
+            [],
         ),
         (
             # invalid: array of arrays -> wrong type
@@ -521,41 +521,38 @@ async def test_close_without_session():
                 is_valid=False,
                 validation_message=ANY,
             ),
+            [],
         ),
     ],
 )
 @pytest.mark.asyncio
-async def test_advanced_rules_validation(advanced_rules, expected_validation_result):
-    mock_data = [
-        ("\\1.2.3.4/a", ["d.txt"], ["b"]),
-        ("\\1.2.3.4/a/b", ["c.txt"], ["e"]),
-        ("\\1.2.3.4/a/b/e", [], []),
-    ]
+async def test_advanced_rules_validation(
+    advanced_rules, expected_validation_result, mocked_document
+):
     async with create_source(NASDataSource) as source:
         with mock.patch.object(smbclient, "register_session"):
+            mock_data = [
+                ("\\1.2.3.4/a", ["d.txt"], ["b"]),
+                ("\\1.2.3.4/a/b", ["c.txt"], ["e"]),
+                ("\\1.2.3.4/a/b/e", [], []),
+            ]
             with mock.patch.object(
                 smbclient, "walk", side_effect=[iter(mock_data), iter(mock_data)]
             ):
-                validation_result = await NetworkDriveAdvancedRulesValidator(
-                    source
-                ).validate(advanced_rules)
+                with mock.patch.object(
+                    NASDataSource, "traverse_diretory", side_effect=mocked_document
+                ):
+                    validation_result = await NetworkDriveAdvancedRulesValidator(
+                        source
+                    ).validate(advanced_rules)
 
-                assert validation_result == expected_validation_result
+                    assert validation_result == expected_validation_result
 
 
 @pytest.mark.parametrize(
     "filtering",
     [
-        Filter(
-            {
-                ADVANCED_SNIPPET: {
-                    "value": [
-                        {"pattern": "training/python/async"},
-                        {"pattern": "training/**/examples"},
-                    ]
-                }
-            }
-        ),
+        Filter({ADVANCED_SNIPPET: {"value": [{"pattern": "training/python/async*"}]}}),
     ],
 )
 @pytest.mark.asyncio
@@ -564,28 +561,29 @@ async def test_get_docs_with_advanced_rules(session, filtering):
     async with create_source(NASDataSource) as source:
         response_list = []
         mock_data = [
-            ("\\1.2.3.4/training", ["d.txt", "a.txt"], ["java", "python"]),
             ("\\1.2.3.4/training/python", ["c.txt"], ["basics", "async"]),
-            ("\\1.2.3.4/training/python/async", ["coroutines.py"], []),
-            ("\\1.2.3.4/training/python/basics", [], ["examples"]),
-            ("\\1.2.3.4/training/python/basics/examples", ["lecture.py"], []),
-            (
-                "\\1.2.3.4/training/java",
-                ["hello.java", "inheritance.java", "collections.java"],
-                [],
-            ),
+            ("\\1.2.3.4/training/python/async", ["lecture.py"], []),
         ]
         with mock.patch.object(
             smbclient, "walk", side_effect=[iter(mock_data), iter(mock_data)]
         ):
             with mock.patch.object(
                 NASDataSource,
-                "get_files",
+                "traverse_diretory",
                 side_effect=[
                     AsyncIterator(
                         [
                             {
-                                "path": "\\1.2.3.4/training/python/basics/examples/lecture.py",
+                                "path": "\\1.2.3.4/training/python/async",
+                                "size": "0",
+                                "_id": "987",
+                                "created_at": "1111-11-11T11:11:11",
+                                "type": "folder",
+                                "title": "async",
+                                "_timestamp": "1212-12-12T12:12:12",
+                            },
+                            {
+                                "path": "\\1.2.3.4/training/python/async/lecture.py",
                                 "size": "2700",
                                 "_id": "1233",
                                 "created_at": "1111-11-11T11:11:11",
@@ -595,43 +593,30 @@ async def test_get_docs_with_advanced_rules(session, filtering):
                             },
                         ]
                     ),
-                    AsyncIterator(
-                        [
-                            {
-                                "path": "\\1.2.3.4/training/python/async/coroutines.py",
-                                "size": "30000",
-                                "_id": "987",
-                                "created_at": "1111-11-11T11:11:11",
-                                "type": "file",
-                                "title": "coroutines.py",
-                                "_timestamp": "1212-12-12T12:12:12",
-                            },
-                        ]
-                    ),
                 ],
             ):
                 async for response in source.get_docs(filtering):
                     response_list.append(response[0])
-        assert [
-            {
-                "path": "\\1.2.3.4/training/python/basics/examples/lecture.py",
-                "size": "2700",
-                "_id": "1233",
-                "created_at": "1111-11-11T11:11:11",
-                "type": "file",
-                "title": "lecture.py",
-                "_timestamp": "1212-12-12T12:12:12",
-            },
-            {
-                "path": "\\1.2.3.4/training/python/async/coroutines.py",
-                "size": "30000",
-                "_id": "987",
-                "created_at": "1111-11-11T11:11:11",
-                "type": "file",
-                "title": "coroutines.py",
-                "_timestamp": "1212-12-12T12:12:12",
-            },
-        ] == response_list
+            assert [
+                {
+                    "path": "\\1.2.3.4/training/python/async",
+                    "size": "0",
+                    "_id": "987",
+                    "created_at": "1111-11-11T11:11:11",
+                    "type": "folder",
+                    "title": "async",
+                    "_timestamp": "1212-12-12T12:12:12",
+                },
+                {
+                    "path": "\\1.2.3.4/training/python/async/lecture.py",
+                    "size": "2700",
+                    "_id": "1233",
+                    "created_at": "1111-11-11T11:11:11",
+                    "type": "file",
+                    "title": "lecture.py",
+                    "_timestamp": "1212-12-12T12:12:12",
+                },
+            ] == response_list
 
 
 def test_parse_output():
@@ -746,6 +731,22 @@ async def test_get_access_control_linux_empty_csv_file_path():
 
 
 @pytest.mark.asyncio
+async def test_get_access_control_linux():
+    async with create_source(NASDataSource) as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        source.drive_type = LINUX
+        source.identity_mappings = "/a/b"
+        with mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data="user1;S-1;S-11,S-22\nuser2;S-2;S-22"),
+        ):
+            acl = []
+            async for access_control in source.get_access_control():
+                acl.append(access_control)
+            assert len(acl) == 2
+
+
+@pytest.mark.asyncio
 async def test_fetch_groups_info():
     mock_groups = {"Admins": "S-1-5-32-546"}
     mock_group_members = {
@@ -796,17 +797,9 @@ async def test_get_access_control_dls_enabled():
         assert expected_user_access_control == user_access_control
 
 
-@mock.patch(
-    "smbclient.walk",
-    return_value=iter(
-        [
-            ("\\1.2.3.4/a", ["a1.txt"], ["A"]),
-        ]
-    ),
-)
 @mock.patch.object(
     NASDataSource,
-    "get_files",
+    "traverse_diretory",
     side_effect=[
         AsyncIterator(
             [
@@ -835,9 +828,7 @@ async def test_get_access_control_dls_enabled():
 @mock.patch.object(NASDataSource, "fetch_groups_info", return_value=mock.AsyncMock())
 @mock.patch("smbclient.register_session")
 @pytest.mark.asyncio
-async def test_get_docs_without_dls_enabled(
-    mock_get_files, mock_walk, mock_fetch_groups, session
-):
+async def test_get_docs_without_dls_enabled(mock_get_files, mock_fetch_groups, session):
     async with create_source(NASDataSource) as source:
         source._dls_enabled = MagicMock(return_value=False)
 
@@ -858,7 +849,7 @@ async def test_get_docs_without_dls_enabled(
 @mock.patch("smbclient.register_session")
 @mock.patch.object(
     NASDataSource,
-    "get_files",
+    "traverse_diretory",
     side_effect=[
         AsyncIterator(
             [
@@ -883,14 +874,6 @@ async def test_get_docs_without_dls_enabled(
             ]
         ),
     ],
-)
-@mock.patch(
-    "smbclient.walk",
-    return_value=iter(
-        [
-            ("\\1.2.3.4/a", ["a1.txt"], ["A"]),
-        ]
-    ),
 )
 @mock.patch.object(
     NASDataSource,
@@ -921,8 +904,7 @@ async def test_get_docs_without_dls_enabled(
 )
 async def test_get_docs_with_dls_enabled(
     session,
-    mock_get_files,
-    mock_walk,
+    mock_traverse_diretory,
     mock_permissions,
     mock_groups,
     mock_members,


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2265###
This PR contains the traversal of directories/subdirectory changes, now we are using scandir method to fetch data from network drive, which start ingestion data in seconds after connector starts syncing.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
