### PR TITLE
Check both repo_type and use_document_level_security for dls_enabled

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -1115,7 +1115,10 @@ class GitHubDataSource(BaseDataSource):
         ):
             return False
 
-        return self.configuration["use_document_level_security"]
+        return (
+            self.configuration["repo_type"] == "organization"
+            and self.configuration["use_document_level_security"]
+        )
 
     async def get_invalid_repos(self):
         try:


### PR DESCRIPTION
The configuration `use_document_level_security` of GitHub connector depends on field `repo_type = organization`, but function `_dls_enabled` doesn't check `repo_type`.

## Checklists

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)