### PR TITLE
Add connector name param to automated test runner

### DIFF
--- a/scripts/testing/README.md
+++ b/scripts/testing/README.md
@@ -60,9 +60,10 @@ A test case should be present as a YAML file.
 ---
 scenarios:
   - index_name: search-demo-index-001
+    connector_name: spo
     service_type: sharepoint_online
     index_language: en
-    connector_configuration: scenarios/clients/spo_sean_site.json
+    connector_configuration: scenarios/clients/spo_automated_testing_site.json
     native: false
     tests:
       - name: Full sync job is performed without errors

--- a/scripts/testing/cli.py
+++ b/scripts/testing/cli.py
@@ -482,6 +482,8 @@ def run_scenarios(name, es_host, es_username, es_password, vm_zone, test_case):
         connector_command = [
             "connector",
             "create",
+            "--name",
+            scenario["connector_name"],
             "--index-name",
             scenario["index_name"],
             "--service-type",

--- a/scripts/testing/scenarios/clients/spo_full_and_incremental_syncs.yml
+++ b/scripts/testing/scenarios/clients/spo_full_and_incremental_syncs.yml
@@ -1,6 +1,7 @@
 ---
 scenarios:
   - index_name: search-demo-index-001
+    connector_name: spo
     service_type: sharepoint_online
     index_language: en
     connector_configuration: scenarios/clients/spo_automated_testing_site.json


### PR DESCRIPTION
We need to supply `--name` when generating the connector cli's `connector create` command in the automated test runner.