### PR TITLE
[Sink] rename get_mb_size to get_mib_size

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -59,7 +59,7 @@ OP_DELETE = "delete"
 CANCELATION_TIMEOUT = 5
 
 
-def get_mb_size(ob):
+def get_mib_size(ob):
     """Returns the size of ob in MiB"""
     return round(get_size(ob) / (1024 * 1024), 2)
 
@@ -156,7 +156,7 @@ class Sink:
 
         if self._logger.isEnabledFor(logging.DEBUG):
             self._logger.debug(
-                f"Task {task_num} - Sending a batch of {len(operations)} ops -- {get_mb_size(operations)}MiB"
+                f"Task {task_num} - Sending a batch of {len(operations)} ops -- {get_mib_size(operations)}MiB"
             )
 
         # TODO: retry 429s for individual items here
@@ -490,7 +490,7 @@ class Extractor:
 
         if self._logger.isEnabledFor(logging.DEBUG):
             self._logger.debug(
-                f"Size of ids in memory is {get_mb_size(existing_ids)}MiB"
+                f"Size of ids in memory is {get_mib_size(existing_ids)}MiB"
             )
 
         return existing_ids
@@ -576,7 +576,7 @@ class Extractor:
 
         if self._logger.isEnabledFor(logging.DEBUG):
             self._logger.debug(
-                f"Size of {len(existing_ids)} access control document ids  in memory is {get_mb_size(existing_ids)}MiB"
+                f"Size of {len(existing_ids)} access control document ids  in memory is {get_mib_size(existing_ids)}MiB"
             )
 
         count = 0

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -59,9 +59,9 @@ OP_DELETE = "delete"
 CANCELATION_TIMEOUT = 5
 
 
-def get_mib_size(ob):
+def get_mib_size(obj):
     """Returns the size of ob in MiB"""
-    return round(get_size(ob) / (1024 * 1024), 2)
+    return round(get_size(obj) / (1024 * 1024), 2)
 
 
 class UnsupportedJobType(Exception):


### PR DESCRIPTION
The method called `get_mb_size` states that it returns `MiB` (Mebibyte) so the name should also reflect it IMO instead of using `mb` (Megabyte).