### PR TITLE
[Notion] Implement an ability to retry for failed paginated api call

### DIFF
--- a/connectors/sources/notion.py
+++ b/connectors/sources/notion.py
@@ -8,13 +8,13 @@ import asyncio
 import os
 from copy import copy
 from functools import cached_property, partial
+from typing import Any, Awaitable, Callable
 from urllib.parse import unquote
 
 import aiohttp
 import fastjsonschema
 from aiohttp.client_exceptions import ClientResponseError
 from notion_client import APIResponseError, AsyncClient
-from notion_client.helpers import async_iterate_paginated_api
 
 from connectors.filtering.validation import (
     AdvancedRulesValidator,
@@ -28,7 +28,7 @@ RETRIES = 3
 RETRY_INTERVAL = 2
 DEFAULT_RETRY_SECONDS = 30
 BASE_URL = "https://api.notion.com"
-MAX_CONCURRENT_CLIENT_SUPPORT = 3
+MAX_CONCURRENT_CLIENT_SUPPORT = 30
 
 
 if "OVERRIDE_URL" in os.environ:
@@ -96,6 +96,48 @@ class NotionClient:
             else:
                 raise
 
+    @retryable(
+        retries=RETRIES,
+        interval=RETRY_INTERVAL,
+        strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
+        skipped_exceptions=NotFound,
+    )
+    async def fetch_results(
+        self, function: Callable[..., Awaitable[Any]], next_cursor=None, **kwargs: Any
+    ):
+        try:
+            return await function(start_cursor=next_cursor, **kwargs)
+        except Exception as exception:
+            if exception.code == "rate_limited" and exception.status == 429:
+                retry_after = (
+                    exception.headers.get("retry-after") or DEFAULT_RETRY_SECONDS
+                )
+                self._logger.info(
+                    f"Connector will attempt to retry after {int(retry_after)} seconds."
+                )
+                await self._sleeps.sleep(int(retry_after))
+                msg = "Rate limit exceeded."
+                raise Exception(msg) from exception
+            else:
+                raise
+
+    async def async_iterate_paginated_api(
+        self, function: Callable[..., Awaitable[Any]], **kwargs: Any
+    ):
+        """Return an async iterator over the results of any paginated Notion API."""
+        next_cursor = kwargs.pop("start_cursor", None)
+        while True:
+            try:
+                response = await self.fetch_results(function, next_cursor, **kwargs)
+                if response:
+                    for result in response.get("results"):
+                        yield result
+                    next_cursor = response.get("next_cursor")
+                    if not response["has_more"] or next_cursor is None:
+                        return
+            except Exception as error:
+                raise error
+
     async def fetch_owner(self):
         """Fetch integration authorized owner"""
         await self._get_client.users.me()
@@ -111,7 +153,7 @@ class NotionClient:
         """Iterate over user information retrieved from the API.
         Yields:
         dict: User document information excluding bots."""
-        async for user_document in async_iterate_paginated_api(
+        async for user_document in self.async_iterate_paginated_api(
             self._get_client.users.list
         ):
             if user_document.get("type") != "bot":
@@ -126,7 +168,7 @@ class NotionClient:
 
         async def fetch_children_recursively(block):
             if block.get("has_children") is True:
-                async for child_block in async_iterate_paginated_api(
+                async for child_block in self.async_iterate_paginated_api(
                     self._get_client.blocks.children.list, block_id=block.get("id")
                 ):
                     yield child_block
@@ -136,7 +178,7 @@ class NotionClient:
                     ):  # pyright: ignore
                         yield grandchild
 
-        async for block in async_iterate_paginated_api(
+        async for block in self.async_iterate_paginated_api(
             self._get_client.blocks.children.list, block_id=block_id
         ):
             if block.get("type") not in ["child_database", "child_page", "unsupported"]:
@@ -149,7 +191,7 @@ class NotionClient:
                     yield record
 
     async def fetch_by_query(self, query):
-        async for document in async_iterate_paginated_api(
+        async for document in self.async_iterate_paginated_api(
             self._get_client.search, **query
         ):
             yield document
@@ -158,7 +200,7 @@ class NotionClient:
                     yield database
 
     async def fetch_comments(self, block_id):
-        async for block_comment in async_iterate_paginated_api(
+        async for block_comment in self.async_iterate_paginated_api(
             self._get_client.comments.list, block_id=block_id
         ):
             yield block_comment
@@ -166,7 +208,7 @@ class NotionClient:
     async def query_database(self, database_id, body=None):
         if body is None:
             body = {}
-        async for result in async_iterate_paginated_api(
+        async for result in self.async_iterate_paginated_api(
             self._get_client.databases.query, database_id=database_id, **body
         ):
             yield result
@@ -248,7 +290,7 @@ class NotionAdvancedRulesValidator(AdvancedRulesValidator):
         page_title = []
         database_title = []
         query = {"filter": {"property": "object", "value": "database"}}
-        async for document in async_iterate_paginated_api(
+        async for document in self.source.notion_client.async_iterate_paginated_api(
             self.source.notion_client._get_client.search, **query
         ):
             databases.append(document.get("id").replace("-", ""))
@@ -287,7 +329,7 @@ class NotionAdvancedRulesValidator(AdvancedRulesValidator):
                         is_valid=False,
                         validation_message=str(error),
                     )
-            self._logger.info("Remote validation successful")
+        self._logger.info("Remote validation successful")
         return SyncRuleValidationResult.valid_result(
             SyncRuleValidationResult.ADVANCED_RULES
         )
@@ -423,7 +465,7 @@ class NotionDataSource(BaseDataSource):
                 "value": False,
             },
             "concurrent_downloads": {
-                "default_value": 20,
+                "default_value": 30,
                 "display": "numeric",
                 "label": "Maximum concurrent downloads",
                 "order": 5,

--- a/connectors/sources/notion.py
+++ b/connectors/sources/notion.py
@@ -107,7 +107,7 @@ class NotionClient:
     ):
         try:
             return await function(start_cursor=next_cursor, **kwargs)
-        except Exception as exception:
+        except APIResponseError as exception:
             if exception.code == "rate_limited" and exception.status == 429:
                 retry_after = (
                     exception.headers.get("retry-after") or DEFAULT_RETRY_SECONDS

--- a/tests/sources/test_notion.py
+++ b/tests/sources/test_notion.py
@@ -793,3 +793,51 @@ async def test_async_iterate_paginated_api():
             ):
                 assert "name" in result
             mock_client_instance.some_function.assert_called_once()
+
+
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+@pytest.mark.asyncio
+async def test_fetch_results_rate_limit_exceeded():
+    async def mock_function_with_429(**kwargs):
+        raise APIResponseError(
+            code="rate_limited",
+            message="Rate limit exceeded.",
+            response=Response(status_code=429, text="Rate limit exceeded."),
+        )
+
+    async with create_source(
+        NotionDataSource, notion_secret_key="secert_key"
+    ) as source:
+        with patch("connectors.sources.notion.DEFAULT_RETRY_SECONDS", 0.3):
+            with pytest.raises(Exception) as exc_info:
+                await source.notion_client.fetch_results(mock_function_with_429)
+
+            assert "Rate limit exceeded." in str(exc_info.value)
+
+
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+@pytest.mark.asyncio
+async def test_fetch_results_other_errors_not_retried():
+    async def mock_function_with_other_error(**kwargs):
+        raise APIResponseError(
+            code="object_not_found",
+            message="Object Not Found",
+            response=Response(status_code=404, text="Object Not Found"),
+        )
+
+    async with create_source(
+        NotionDataSource, notion_secret_key="secert_key"
+    ) as source:
+        with pytest.raises(APIResponseError) as exc_info:
+            await source.notion_client.fetch_results(mock_function_with_other_error)
+
+        assert exc_info.value.code == "object_not_found"
+        assert exc_info.value.status == 404
+
+
+@pytest.mark.asyncio
+async def test_original_async_iterate_paginated_api_not_called():
+    with patch(
+        "notion_client.helpers.async_iterate_paginated_api"
+    ) as mock_async_iterate_paginated_api:
+        assert not mock_async_iterate_paginated_api.called


### PR DESCRIPTION
## Part of #1958 

During performance testing, it was reported that the [notion sdk module](https://github.com/ramnes/notion-sdk-py/blob/d5e5f5c98ae5578ce4b0130b65ad6e8f9e92e02b/notion_client/helpers.py#L58) does not provision any retry mechanism for a paginated api call made via `async_iterate_paginated_api`. 

This PR attempts to implement `async_iterate_paginated_api` with an ability to retry a failed page. 

Simply decorating the module's helper method [async_iterate_paginated_api](https://github.com/ramnes/notion-sdk-py/blob/d5e5f5c98ae5578ce4b0130b65ad6e8f9e92e02b/notion_client/helpers.py#L58) with retryable decorator won't work as that would mean any error thrown by page k (k >1) would result in retrying from page 1 instead of retry on page k.

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
