### PR TITLE
Log all counters

### DIFF
--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -342,7 +342,9 @@ class SyncJobRunner:
         )
         persisted_stats = {
             "indexed_document_count": ingestion_stats.get("indexed_document_count", 0),
-            "indexed_document_volume": ingestion_stats.get("indexed_document_volume", 0),
+            "indexed_document_volume": ingestion_stats.get(
+                "indexed_document_volume", 0
+            ),
             "deleted_document_count": ingestion_stats.get("deleted_document_count", 0),
         }
 

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -381,9 +381,24 @@ class SyncJobRunner:
             f"deleted: {ingestion_stats.get('doc_deleted', 0)} "
             f"(took {int(time.time() - self._start_time)} seconds)"  # pyright: ignore
         )
+        self.log_counters(ingestion_stats)
+
+    def log_counters(self, counters):
+        """
+        Logs out a dump of everything in "counters"
+
+        This serves a dual-purpose:
+        1. Providing human-readable counts on separate lines, which can be helpful for
+            visualizing how a counter changes over multiple runs (like in Discover)
+        2. Providing a machine-readable hash of all counters, that can be easily copy-pasted
+           into a REPL or script for analysis.
+        See more of the discussion: https://github.com/elastic/connectors/pull/2323
+        :param counters: a dictionary of counter_name -> counter_value like: {"added": 2, "deleted": 1}
+        """
         self.sync_job.log_info("--- Counters ---")
-        for k, v in sorted(ingestion_stats.items()):
+        for k, v in sorted(counters.items()):
             self.sync_job.log_info(f"'{k}' : {v}")
+        self.sync_job.log_info(f"full counters dictionary: {counters}")
         self.sync_job.log_info("----------------")
 
     @with_concurrency_control()

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -134,7 +134,7 @@ def sync_orchestrator_mock():
         sync_orchestrator_mock.done = Mock(return_value=True)
         sync_orchestrator_mock.fetch_error = Mock(return_value=None)
         sync_orchestrator_mock.cancel = AsyncMock()
-        sync_orchestrator_mock.ingestion_stats = Mock()
+        sync_orchestrator_mock.ingestion_stats = Mock(return_value={})
         sync_orchestrator_mock.close = AsyncMock()
         sync_orchestrator_mock.has_active_license_enabled = AsyncMock(
             return_value=(True, License.PLATINUM)


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2314

Adds some logging on sync completion that prints out every metric that we have in the orchestrator's `ingestion_stats` dict. This means that going forward, all we have to do is add something to `ingestion_stats` in order to expose it from the logs.

The new output looks like:
```
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] --- Counters ---
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] 'attachment_extracted' : 0
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] 'bulk_operations' : {'index': 21}
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] 'deleted_document_count' : 0
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] 'doc_created' : 21
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] 'doc_deleted' : 0
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] 'doc_updated' : 0
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] 'indexed_document_count' : 21
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] 'indexed_document_volume' : 0
[FMWK][10:30:03][INFO] [Connector id: eV5Fmo4BAQ4Y7gVESEBV, index name: slack, Sync job id: fF5Hmo4BAQ4Y7gVES0Dr] ----------------
```

## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)


## Release Note

Connector sync jobs now log more counters at their conclusion.
