### PR TITLE
Create a nested_get_from_dict function in utils

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -35,6 +35,7 @@ from connectors.utils import (
     deep_merge_dicts,
     filter_nested_dict_by_keys,
     iso_utc,
+    nested_get_from_dict,
     next_run,
 )
 
@@ -476,18 +477,18 @@ class Features:
         self.features = features
 
     def incremental_sync_enabled(self):
-        return self._nested_feature_enabled(
-            ["incremental_sync", "enabled"], default=False
+        return nested_get_from_dict(
+            self.features, ["incremental_sync", "enabled"], default=False
         )
 
     def document_level_security_enabled(self):
-        return self._nested_feature_enabled(
-            ["document_level_security", "enabled"], default=False
+        return nested_get_from_dict(
+            self.features, ["document_level_security", "enabled"], default=False
         )
 
     def native_connector_api_keys_enabled(self):
-        return self._nested_feature_enabled(
-            ["native_connector_api_keys", "enabled"], default=True
+        return nested_get_from_dict(
+            self.features, ["native_connector_api_keys", "enabled"], default=True
         )
 
     def sync_rules_enabled(self):
@@ -503,12 +504,12 @@ class Features:
     def feature_enabled(self, feature):
         match feature:
             case Features.BASIC_RULES_NEW:
-                return self._nested_feature_enabled(
-                    ["sync_rules", "basic", "enabled"], default=False
+                return nested_get_from_dict(
+                    self.features, ["sync_rules", "basic", "enabled"], default=False
                 )
             case Features.ADVANCED_RULES_NEW:
-                return self._nested_feature_enabled(
-                    ["sync_rules", "advanced", "enabled"], default=False
+                return nested_get_from_dict(
+                    self.features, ["sync_rules", "advanced", "enabled"], default=False
                 )
             case Features.BASIC_RULES_OLD:
                 return self.features.get("filtering_rules", False)
@@ -516,21 +517,6 @@ class Features:
                 return self.features.get("filtering_advanced_config", False)
             case _:
                 return False
-
-    def _nested_feature_enabled(self, keys, default=None):
-        def nested_get(dictionary, keys_, default_=None):
-            if dictionary is None:
-                return default_
-
-            if not keys_:
-                return dictionary
-
-            if not isinstance(dictionary, dict):
-                return default_
-
-            return nested_get(dictionary.get(keys_[0]), keys_[1:], default_)
-
-        return nested_get(self.features, keys, default)
 
 
 class Connector(ESDocument):

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -798,7 +798,7 @@ class GitHubClient:
             )
             if not page_info.get("hasNextPage"):
                 break
-            variables["cursor"] = page_info["endCursor"]
+            variables["cursor"] = page_info["endCursor"]  # pyright: ignore
 
     def get_repo_details(self, repo_name):
         return repo_name.split("/")
@@ -1505,7 +1505,7 @@ class GitHubDataSource(BaseDataSource):
                 query=query,
                 keys=response_key,
             ):
-                for pull_request in nested_get_from_dict(
+                for pull_request in nested_get_from_dict(  # pyright: ignore
                     response, ["data"] + response_key + ["nodes"], default=[]
                 ):
                     async for pull_request_doc in self._extract_pull_request(
@@ -1521,7 +1521,7 @@ class GitHubDataSource(BaseDataSource):
             )
 
     async def _extract_issues(self, response, owner, repo, response_key):
-        for issue in nested_get_from_dict(
+        for issue in nested_get_from_dict(  # pyright: ignore
             response, ["data"] + response_key + ["nodes"], default=[]
         ):
             issue.update(self._prepare_issue_doc(issue=issue))

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -912,3 +912,19 @@ def func_human_readable_name(func):
         return func.__name__
     except AttributeError:
         return str(func)
+
+
+def nested_get_from_dict(dictionary, keys, default=None):
+    def nested_get(dictionary_, keys_, default_=None):
+        if dictionary_ is None:
+            return default_
+
+        if not keys_:
+            return dictionary_
+
+        if not isinstance(dictionary_, dict):
+            return default_
+
+        return nested_get(dictionary_.get(keys_[0]), keys_[1:], default_)
+
+    return nested_get(dictionary, keys, default)

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1846,33 +1846,6 @@ def test_incremental_sync_enabled(features_json, incremental_sync_enabled):
     assert features.incremental_sync_enabled() == incremental_sync_enabled
 
 
-@pytest.mark.parametrize(
-    "nested_dict, keys, default, expected",
-    [
-        # extract True
-        ({"a": {"b": {"c": True}}}, ["a", "b", "c"], False, True),
-        (
-            {"a": {"b": {"c": True}}},
-            # "d" doesn't exist -> fall back to False
-            ["a", "b", "c", "d"],
-            False,
-            False,
-        ),
-        (
-            {"a": {"b": {"c": True}}},
-            # "wrong_key" doesn't exist -> fall back to False
-            ["wrong_key", "b", "c"],
-            False,
-            False,
-        ),
-        # fallback to True
-        (None, ["a", "b", "c"], True, True),
-    ],
-)
-def test_nested_get(nested_dict, keys, default, expected):
-    assert expected == Features(nested_dict)._nested_feature_enabled(keys, default)
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "trigger_method",

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -17,6 +17,7 @@ from connectors.filtering.validation import SyncRuleValidationResult
 from connectors.protocol import Features, Filter
 from connectors.source import ConfigurableFieldValueError
 from connectors.sources.github import (
+    REPOSITORY_OBJECT,
     GitHubAdvancedRulesValidator,
     GitHubDataSource,
     UnauthorizedException,
@@ -1149,7 +1150,10 @@ async def test_fetch_issues():
                 AsyncIterator([MOCK_RESPONSE_ISSUE]),
             ],
         ):
-            async for issue in source._fetch_issues("demo_user/demo_repo"):
+            async for issue in source._fetch_issues(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "issues"],
+            ):
                 assert issue == EXPECTED_ISSUE
 
 
@@ -1158,7 +1162,10 @@ async def test_fetch_issues_with_unauthorized_exception():
     async with create_github_source() as source:
         source.github_client.post = Mock(side_effect=UnauthorizedException())
         with pytest.raises(UnauthorizedException):
-            async for _ in source._fetch_issues("demo_user/demo_repo"):
+            async for _ in source._fetch_issues(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "issues"],
+            ):
                 pass
 
 
@@ -1177,7 +1184,10 @@ async def test_fetch_pull_requests():
                 AsyncIterator([MOCK_REVIEWS_RESPONSE]),
             ],
         ):
-            async for pull in source._fetch_pull_requests("demo_user/demo_repo"):
+            async for pull in source._fetch_pull_requests(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "pullRequests"],
+            ):
                 assert pull == EXPECTED_PULL_RESPONSE
 
 
@@ -1186,7 +1196,10 @@ async def test_fetch_pull_requests_with_unauthorized_exception():
     async with create_github_source() as source:
         source.github_client.post = Mock(side_effect=UnauthorizedException())
         with pytest.raises(UnauthorizedException):
-            async for _ in source._fetch_pull_requests("demo_user/demo_repo"):
+            async for _ in source._fetch_pull_requests(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "pullRequests"],
+            ):
                 pass
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,6 +44,7 @@ from connectors.utils import (
     html_to_text,
     is_expired,
     iterable_batches_generator,
+    nested_get_from_dict,
     next_run,
     retryable,
     shorten_str,
@@ -1055,3 +1056,20 @@ async def test_time_to_sleep_between_retries_invalid_strategy():
         time_to_sleep_between_retries("lalala", 1, 1)
 
     assert e is not None
+
+
+@pytest.mark.parametrize(
+    "dictionary, default, expected",
+    [
+        (None, None, None),
+        ({}, None, None),
+        ({}, "default", "default"),
+        ({"foo": {}}, None, None),
+        ({"foo": {"bar": {}}}, None, None),
+        ({"foo": {"bar": {"baz": "result"}}}, None, "result"),
+    ],
+)
+def test_nested_get_from_dict(dictionary, default, expected):
+    keys = ["foo", "bar", "baz"]
+
+    assert nested_get_from_dict(dictionary, keys, default=default) == expected


### PR DESCRIPTION
I found the method [get_data_by_keys](https://github.com/elastic/connectors/blob/01d30bbcbeb1c4151ceb44d46cc008e8df0dc2e6/connectors/sources/github.py#L779) in GitHub should exist in `utils`. And there's another similar implementation [_nested_feature_enabled](https://github.com/elastic/connectors/blob/01d30bbcbeb1c4151ceb44d46cc008e8df0dc2e6/connectors/protocol/connectors.py#L520) in `Features` class.

This PR move the function to `utils`.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)