### PR TITLE
Sharepoint server incremental sync

### DIFF
--- a/connectors/sources/sharepoint_server.py
+++ b/connectors/sources/sharepoint_server.py
@@ -365,7 +365,7 @@ class SharepointServerClient:
                         is_list_item_has_attachment=True,
                     )
                     result["url"] = url
-                    if not self.check_timestamp or result.get('Modified') >= self.incremental_cursor:
+                    if not self.check_timestamp or result.get("Modified") >= self.incremental_cursor:
                         yield result, file_relative_url
                     continue
 
@@ -392,7 +392,7 @@ class SharepointServerClient:
                         relative_url=file_relative_url,
                     )
 
-                    if not self.check_timestamp or result.get('Modified') >= self.incremental_cursor:
+                    if not self.check_timestamp or result.get("Modified") >= self.incremental_cursor:
                         yield result, file_relative_url
 
     async def get_drive_items(self, list_id, site_url, server_relative_url, **kwargs):
@@ -428,7 +428,7 @@ class SharepointServerClient:
                     result["Length"] = result[item_type]["Length"]
                 result["item_type"] = item_type
 
-                if not self.check_timestamp or result.get('Modified') >= self.incremental_cursor:
+                if not self.check_timestamp or result.get("Modified") >= self.incremental_cursor:
                     yield result, file_relative_url
 
     async def ping(self):
@@ -787,7 +787,7 @@ class SharepointServerDataSource(BaseDataSource):
                 site_url=collection
             ):
                 server_relative_url.append(site_data["ServerRelativeUrl"])
-                if site_data.get('LastItemModifiedDate') >= self.last_sync_time():
+                if site_data.get("Created") >= self.last_sync_time():
                     yield self.format_sites(item=site_data), None, OP_INDEX
 
         for site_url in server_relative_url:
@@ -800,13 +800,13 @@ class SharepointServerDataSource(BaseDataSource):
                         if result.get("Title") == "Site Pages":
                             is_site_page = True
                             selected_field = SELECTED_FIELDS
-                        if result.get('LastItemModifiedDate') >= self.last_sync_time():
+                        if result.get("Created") >= self.last_sync_time():
                             yield self.format_lists(item=result, document_type=DOCUMENT_LIBRARY), None, OP_INDEX
                         server_url = None
                         func = self.sharepoint_client.get_drive_items
                         format_document = self.format_drive_item
                     else:
-                        if result.get('LastItemModifiedDate') >= self.last_sync_time():
+                        if result.get("Created") >= self.last_sync_time():
                             yield self.format_lists(item=result, document_type=LISTS), None, OP_INDEX
                         server_url = result["RootFolder"]["ServerRelativeUrl"]
                         func = self.sharepoint_client.get_list_items

--- a/connectors/sources/sharepoint_server.py
+++ b/connectors/sources/sharepoint_server.py
@@ -787,7 +787,7 @@ class SharepointServerDataSource(BaseDataSource):
                 site_url=collection
             ):
                 server_relative_url.append(site_data["ServerRelativeUrl"])
-                if site_data.get("Created") >= self.last_sync_time():
+                if site_data.get("LastItemModifiedDate") >= self.last_sync_time():
                     yield self.format_sites(item=site_data), None, OP_INDEX
 
         for site_url in server_relative_url:
@@ -800,13 +800,13 @@ class SharepointServerDataSource(BaseDataSource):
                         if result.get("Title") == "Site Pages":
                             is_site_page = True
                             selected_field = SELECTED_FIELDS
-                        if result.get("Created") >= self.last_sync_time():
+                        if result.get("RootFolder").get("TimeLastModified") >= self.last_sync_time():
                             yield self.format_lists(item=result, document_type=DOCUMENT_LIBRARY), None, OP_INDEX
                         server_url = None
                         func = self.sharepoint_client.get_drive_items
                         format_document = self.format_drive_item
                     else:
-                        if result.get("Created") >= self.last_sync_time():
+                        if result.get("RootFolder").get("TimeLastModified") >= self.last_sync_time():
                             yield self.format_lists(item=result, document_type=LISTS), None, OP_INDEX
                         server_url = result["RootFolder"]["ServerRelativeUrl"]
                         func = self.sharepoint_client.get_list_items


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2334

This allows users to run incremental syncs with the Sharepoint server connector. It uses the default timestamp cursor from the framework. Tested agains the Sharepoint 2019 (16.0.0.10337: 1). The test could use some improvement

What is included in the incremental sync:
- New objects (sites / libraries / lists / list_items / drive_items) since last sync
- Modified objects (sites / libraries / lists / list_items / drive_items) since last sync

What is not included in the incremental sync:
- Delete objects (sites / libraries / lists / list_items / drive_items)

## Checklists


#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)