### PR TITLE
Add logging for cloud based connectors

### DIFF
--- a/connectors/sources/box.py
+++ b/connectors/sources/box.py
@@ -79,11 +79,13 @@ class AccessToken:
 
     async def get(self):
         if cached_value := self._token_cache.get_value():
+            logger.debug("Retrieving access token from the cache")
             return cached_value
         await self._set_access_token()
         return self.access_token
 
     async def _set_access_token(self):
+        logger.debug("Generating an access token")
         try:
             if self.is_enterprise == BOX_FREE:
                 global refresh_token
@@ -176,6 +178,7 @@ class BoxClient:
         skipped_exceptions=NotFound,
     )
     async def get(self, url, headers, params=None):
+        self._logger.debug(f"Making a GET call for url: {url} with params: {params}")
         try:
             access_token = await self.token.get()
             headers.update({"Authorization": f"Bearer {access_token}"})
@@ -308,13 +311,17 @@ class BoxDataSource(BaseDataSource):
             self._logger.exception("Error while connecting to Box.")
             raise
 
-    async def get_user_ids(self):
+    async def get_users_id(self):
+        self._logger.debug("Fetching users")
         async for user in self.client.paginated_call(
             url=ENDPOINTS["USERS"], params={}, headers={}
         ):
             yield user.get("id")
 
     async def _fetch(self, doc_id, user_id=None):
+        self._logger.info(
+            f"Fetching files and folders recursively for folder ID: {doc_id}"
+        )
         try:
             params = {
                 "fields": FIELDS,
@@ -455,32 +462,26 @@ class BoxDataSource(BaseDataSource):
                 yield item
 
     async def get_docs(self, filtering=None):
-        already_processed_ids = set()
-        root_folder = "0"
-
+        stored_id = set()
         if self.is_enterprise == BOX_ENTERPRISE:
-            async for user_id in self.get_user_ids():
-                logger.debug(
-                    f"Fetching content for user with id '{user_id}' starting from root folder"
-                )
+            self._logger.info("Fetching data from Box's Enterprise Account")
+            async for user_id in self.get_users_id():
+                # "0" refers to the root folder
                 await self.fetchers.put(
-                    partial(self._fetch, doc_id=root_folder, user_id=user_id)
+                    partial(self._fetch, doc_id="0", user_id=user_id)
                 )
                 self.tasks += 1
         else:
-            logger.debug("Fetching content starting from root folder")
-            await self.fetchers.put(partial(self._fetch, doc_id=root_folder))
+            self._logger.info("Fetching data from Box's Free Account")
+            await self.fetchers.put(partial(self._fetch, doc_id="0"))
             self.tasks += 1
 
         async for item in self._consumer():
             current_id = item[0].get("_id")
-            if current_id in already_processed_ids:
-                logger.debug(
-                    f"Already processed item with id '{current_id}'. Skipping item..."
-                )
+            if current_id in stored_id:
                 continue
             else:
-                already_processed_ids.add(current_id)
+                stored_id.add(current_id)
                 yield item
 
         await self.fetchers.join()

--- a/connectors/sources/dropbox.py
+++ b/connectors/sources/dropbox.py
@@ -189,6 +189,9 @@ class DropboxClient:
         if self.token_expiration_time and (
             not isinstance(self.token_expiration_time, datetime)
         ):
+            self._logger.debug(
+                f"Token expiration time '{self.token_expiration_time}' is not in the correct format. Converting it into ISO format"
+            )
             self.token_expiration_time = datetime.fromisoformat(
                 self.token_expiration_time
             )
@@ -203,6 +206,9 @@ class DropboxClient:
             "client_secret": self.app_secret,
         }
 
+        self._logger.debug(
+            f"Generating an access token with url: {url}, headers: {headers}"
+        )
         async with aiohttp.ClientSession() as session:
             async with session.post(url=url, headers=headers, data=data) as response:
                 response_data = await response.json()
@@ -315,6 +321,9 @@ class DropboxClient:
                 await self._set_access_token()
                 headers = self._get_request_headers(
                     file_type=file_type, url_name=url_name, kwargs=kwargs
+                )
+                self._logger.debug(
+                    f"Making a POST call for url: {url} with a payload: {data}"
                 )
                 async with self._get_session.post(
                     url=url, headers=headers, data=data
@@ -801,7 +810,7 @@ class DropboxDataSource(BaseDataSource):
             self._logger.warning("DLS is not enabled. Skipping")
             return
 
-        self._logger.info("Fetching members")
+        self._logger.info("Fetching users for Access Control sync")
         async for users in self.dropbox_client.list_members():
             for user in users.get("members", []):
                 yield await self._user_access_control_doc(user=user)
@@ -880,10 +889,11 @@ class DropboxDataSource(BaseDataSource):
         download_func = self.download_func(is_shared, attachment, filename, folder_id)
         if not download_func:
             self._logger.warning(
-                f"Skipping the file: {filename} since it is not in the downloadable format."
+                f"Skipping file '{filename}' since it is not downloadable."
             )
             return
 
+        self._logger.debug(f"Downloading content for file: {filename}")
         document = {
             "_id": attachment["id"],
             "_timestamp": attachment["server_modified"],
@@ -944,6 +954,7 @@ class DropboxDataSource(BaseDataSource):
         }
 
     async def _fetch_files_folders(self, path, folder_id=None):
+        self._logger.info(f"Fetching files and folders from path: '{path}'")
         async for response in self.dropbox_client.get_files_folders(
             path=path, folder_id=folder_id
         ):
@@ -951,6 +962,7 @@ class DropboxDataSource(BaseDataSource):
                 yield self._adapt_dropbox_doc_to_es_doc(response=entry), entry
 
     async def _fetch_shared_files(self):
+        self._logger.info("Fetching shared files")
         async for response in self.dropbox_client.get_shared_files():
             for entry in response.get("entries"):
                 async for metadata in self.dropbox_client.get_received_file_metadata(
@@ -962,6 +974,7 @@ class DropboxDataSource(BaseDataSource):
                     ), json_metadata
 
     async def advanced_sync(self, rule):
+        self._logger.debug(f"Fetching files/folders for sync rule: {rule}")
         async for response in self.dropbox_client.search_files_folders(rule=rule):
             for entry in response.get("matches"):
                 data = entry.get("metadata", {}).get("metadata")
@@ -987,6 +1000,7 @@ class DropboxDataSource(BaseDataSource):
     async def get_permission(self, permission, account_id):
         permissions = []
         if identities := permission.get("users"):
+            self._logger.debug("Fetching users")
             for identity in identities:
                 permissions.append(
                     _prefix_user_id(identity.get("user", {}).get("account_id"))
@@ -1010,6 +1024,7 @@ class DropboxDataSource(BaseDataSource):
         return permissions
 
     async def get_folder_permission(self, shared_folder_id, account_id):
+        self._logger.debug(f"Fetching permissions for folder: {shared_folder_id}")
         if not shared_folder_id:
             return [account_id]
 
@@ -1021,6 +1036,7 @@ class DropboxDataSource(BaseDataSource):
             )
 
     async def get_file_permission_without_batching(self, file_id, account_id):
+        self._logger.debug(f"Fetching permissions for file: {file_id}")
         async for permission in self.dropbox_client.list_file_permission_without_batching(
             file_id=file_id
         ):
@@ -1029,6 +1045,7 @@ class DropboxDataSource(BaseDataSource):
             )
 
     async def get_account_details(self):
+        self._logger.debug("Retrieving account details")
         response = await anext(
             self.dropbox_client.api_call(
                 base_url=BASE_URLS["FILES_FOLDERS_BASE_URL"],
@@ -1042,6 +1059,7 @@ class DropboxDataSource(BaseDataSource):
         return account_id, member_id
 
     async def get_permission_list(self, item_type, item, account_id):
+        self._logger.debug(f"Retrieving permissions for {item_type}")
         if item_type == FOLDER:
             shared_folder_id = item.get("shared_folder_id") or item.get(
                 "parent_shared_folder_id"
@@ -1049,6 +1067,7 @@ class DropboxDataSource(BaseDataSource):
             return await self.get_folder_permission(
                 shared_folder_id=shared_folder_id, account_id=account_id
             )
+
         return await self.get_file_permission_without_batching(
             file_id=item.get("id"), account_id=account_id
         )
@@ -1144,9 +1163,11 @@ class DropboxDataSource(BaseDataSource):
             batched_document = {}
 
     async def fetch_file_folders_with_dls(self):
+        self._logger.info("Fetching permissions for files and folders")
         account_id, member_id = await self.get_account_details()
         self.dropbox_client.member_id = member_id
         async for folder_id in self.get_team_folder_id():
+            self._logger.info(f"Iterating through folder with id '{folder_id}'")
             async for mapped_document in self.add_document_to_list(
                 func=self._fetch_files_folders,
                 account_id=account_id,
@@ -1177,9 +1198,10 @@ class DropboxDataSource(BaseDataSource):
 
         elif filtering and filtering.has_advanced_rules():
             advanced_rules = filtering.get_advanced_rules()
+            self._logger.debug(
+                f"Retrieving documents using configured advanced sync rules: {advanced_rules}"
+            )
             for rule in advanced_rules:
-                self._logger.debug(f"Fetching files using advanced sync rule: {rule}")
-
                 async for document, attachment in self.advanced_sync(rule=rule):
                     yield self.document_tuple(document=document, attachment=attachment)
         else:


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/2299

This PR includes some cloud-storage based connectors as follows:
1. Box
2. Dropbox
3. Google Cloud Storage
4. OneDrive
5. S3

This is a follow up PR of https://github.com/elastic/connectors/pull/2329

Drive folder for log files with DEBUG log_level: https://drive.google.com/drive/folders/13-P99PjgjFdjI9hrmPsuhNst6Kdu5C0-

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
~- [ ] Covered the changes with automated tests~
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)