### PR TITLE
SharePoint Server NTLM and Host Named Site Collections support

### DIFF
--- a/connectors/sources/sharepoint_server.py
+++ b/connectors/sources/sharepoint_server.py
@@ -415,7 +415,9 @@ class SharepointServerClient:
                     result["_id"] = attachment_data["UniqueId"]  # pyright: ignore
                     result["url"] = self.format_url(
                         site_url=site_url,
-                        relative_url=self.fix_relative_url(site_relative_url,attachment_file.get("ServerRelativeUrl")),
+                        relative_url=self.fix_relative_url(
+                            site_relative_url, attachment_file.get("ServerRelativeUrl")
+                        ),
                     )
                     result["file_name"] = attachment_file.get("FileName")
                     result["server_relative_url"] = attachment_file["ServerRelativeUrl"]
@@ -600,6 +602,7 @@ class SharepointServerDataSource(BaseDataSource):
             async for _ in self.sharepoint_client._api_call(
                 url_name=PING,
                 site_collections=collection,
+                site_url=collection,
                 host_url=self.sharepoint_client.host_url,
             ):
                 is_invalid = False

--- a/connectors/sources/sharepoint_server.py
+++ b/connectors/sources/sharepoint_server.py
@@ -5,7 +5,6 @@
 #
 """SharePoint source module responsible to fetch documents from SharePoint Server.
 """
-import asyncio
 import os
 from functools import partial
 from urllib.parse import quote

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,5 +1,7 @@
 aiohttp==3.9.1
 aiofiles==23.2.1
+httpx==0.27.0
+httpx-ntlm==1.4.0
 elasticsearch[async]==8.12.0
 elastic-transport==8.12.0
 pyyaml==6.0

--- a/tests/sources/fixtures/sharepoint_server/connector.json
+++ b/tests/sources/fixtures/sharepoint_server/connector.json
@@ -1,6 +1,17 @@
 {
     "api_key_id": "clvIfIgBFjJwEZQV7bda",
     "configuration": {
+      "authentication": {
+        "label": "Authentication mode",
+        "order": 1,
+        "type": "str",
+        "options": [
+            {"label": "Basic", "value": "Basic"},
+            {"label": "NTLM", "value": "NTLM"}
+        ],
+        "display": "dropdown",
+        "value": "Basic"
+      },
       "username": {
         "label": "SharePoint Server username",
         "order": 1,

--- a/tests/sources/test_sharepoint_server.py
+++ b/tests/sources/test_sharepoint_server.py
@@ -11,11 +11,8 @@ from unittest import mock
 from unittest.mock import Mock, patch
 
 import httpx
-from httpx import ByteStream
-
-import aiohttp
 import pytest
-from aiohttp import StreamReader
+from httpx import ByteStream
 
 from connectors.logger import logger
 from connectors.source import ConfigurableFieldValueError
@@ -205,7 +202,9 @@ async def test_prepare_drive_items_doc():
             "server_relative_url": "/site",
         }
 
-        target_response = source.format_drive_item(item=list_items,site_url=f"{HOST_URL}/site",site_relative_url="/site")
+        target_response = source.format_drive_item(
+            item=list_items, site_url=f"{HOST_URL}/site", site_relative_url="/site"
+        )
         assert target_response == expected_response
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2340

The existing connector only supports host header site collections and only the "sites" managed path, meaning site collections that derive their URL from the web application's URL. SharePoint supports host named site collections which can have any URL, so it doesn't make sense to force the user to only index a particular subset of sites. 
For NTLM, since aiohttp doesn't support NTLM authentication the only option with async support is "httpx", so this is what I used.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [x] New external service dependencies added.

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
