### PR TITLE
[Framework] Use Cancellable sleeps in retryable

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -152,7 +152,12 @@ class CancellableSleeps:
 
         await _sleep(delay, result=result, loop=loop)
 
-    def cancel(self):
+    def cancel(self, sig=None):
+        if sig:
+            logger.debug(f"Caught {sig}. Cancelling sleeps...")
+        else:
+            logger.debug("Cancelling sleeps...")
+
         for task in self._sleeps:
             task.cancel()
 
@@ -480,6 +485,9 @@ class UnknownRetryStrategyError(Exception):
     pass
 
 
+sleeps_for_retryable = CancellableSleeps()
+
+
 def retryable(
     retries=3,
     interval=1.0,
@@ -526,7 +534,7 @@ def retryable_async_function(func, retries, interval, strategy, skipped_exceptio
                 logger.debug(
                     f"Retrying ({retry} of {retries}) with interval: {interval} and strategy: {strategy.name}"
                 )
-                await asyncio.sleep(
+                await sleeps_for_retryable.sleep(
                     time_to_sleep_between_retries(strategy, interval, retry)
                 )
                 retry += 1
@@ -550,7 +558,7 @@ def retryable_async_generator(func, retries, interval, strategy, skipped_excepti
                 logger.debug(
                     f"Retrying ({retry} of {retries}) with interval: {interval} and strategy: {strategy.name}"
                 )
-                await asyncio.sleep(
+                await sleeps_for_retryable.sleep(
                     time_to_sleep_between_retries(strategy, interval, retry)
                 )
                 retry += 1

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -9,7 +9,7 @@ import os
 import signal
 from io import StringIO
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -47,6 +47,27 @@ def test_main_and_kill(mock_responses):
     loop.create_task(kill())
 
     main([])
+
+
+@pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM])
+@patch("connectors.service_cli.PreflightCheck")
+def test_shutdown_called_on_shutdown_signal(
+    patch_preflight_check, sig, patch_logger, mock_responses, set_env
+):
+    patch_preflight_check.return_value.run = AsyncMock()
+
+    async def emit_shutdown_signal():
+        await asyncio.sleep(0.2)
+        os.kill(os.getpid(), sig)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.create_task(emit_shutdown_signal())
+
+    main([])
+
+    patch_logger.assert_present(f"Caught {sig.name}. Graceful shutdown.")
+    patch_logger.assert_present(f"Caught {sig.name}. Cancelling sleeps...")
 
 
 def test_run(mock_responses, set_env):


### PR DESCRIPTION
## Closes [#4016](https://github.com/elastic/enterprise-search-team/issues/4016)

This PR addresses the problem that if you `CTRL+C` out of the service while a long running sleep originating from `retryable` is running, the service won't exit until the sleep has finished. Therefore I've introduced one global object for all sleeps from `retryable` which can be cancelled, when `SIGINT` or `SIGTERM` are caught.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)