### PR TITLE
Add X-elastic-product-origin header

### DIFF
--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -103,6 +103,7 @@ class ESClient:
         self.backoff_multiplier = config.get("backoff_multiplier", 2)
         options["headers"] = config.get("headers", {})
         options["headers"]["user-agent"] = f"elastic-connectors-{__version__}"
+        options["headers"]["X-elastic-product-origin"] = "connectors"
         self.client = AsyncElasticsearch(**options)
         self._keep_waiting = True
 


### PR DESCRIPTION
Learned today about a header that is used by Beats, Kibana, and Fleet, to help breakdown telemetry and identify product traffic vs customer traffic.


## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
