### PR TITLE
Fixing connection issue when JIRA has a path in URL (like jira.company.com/jira)

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -213,9 +213,8 @@ class JiraClient:
         Yields:
             response: Return api response.
         """
-        url = url_kwargs.get("url") or parse.urljoin(
-            self.host_url, URLS[url_name].format(**url_kwargs)  # pyright: ignore
-        )
+        url = url_kwargs.get("url") or self.host_url.rstrip('/')+'/'+URLS[url_name].format(**url_kwargs).lstrip('/')
+
         self._logger.debug(f"Making a GET call for url: {url}")
         while True:
             try:

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -9,7 +9,6 @@ import asyncio
 from copy import copy
 from datetime import datetime
 from functools import partial
-from urllib import parse
 
 import aiohttp
 import pytz
@@ -228,14 +227,16 @@ class JiraClient:
         Yields:
             response: Return api response.
         """
-        url = url_kwargs.get("url") or self.host_url.rstrip('/') + '/' + URLS[url_name].format(**url_kwargs).lstrip('/')
+        url = url_kwargs.get("url") or self.host_url.rstrip("/") + "/" + URLS[
+            url_name
+        ].format(**url_kwargs).lstrip("/")
 
         self._logger.debug(f"Making a GET call for url: {url}")
         while True:
             try:
                 async with self._get_session().get(  # pyright: ignore
-                        url=url,
-                        ssl=self.ssl_ctx,
+                    url=url,
+                    ssl=self.ssl_ctx,
                 ) as response:
                     yield response
                     break
@@ -264,17 +265,23 @@ class JiraClient:
             try:
                 url = None
                 if kwargs.get("level_id"):
-                    url = self.host_url.rstrip('/') + '/' + URLS[url_name].format(
-                        max_results=FETCH_SIZE,
-                        start_at=start_at,
-                        level_id=kwargs.get("level_id")
-                    ).lstrip('/')
+                    url = (
+                        self.host_url.rstrip("/")
+                        + "/"
+                        + URLS[url_name]
+                        .format(
+                            max_results=FETCH_SIZE,
+                            start_at=start_at,
+                            level_id=kwargs.get("level_id"),
+                        )
+                        .lstrip("/")
+                    )
                 async for response in self.api_call(
-                        url_name=url_name,
-                        start_at=start_at,
-                        max_results=FETCH_SIZE,
-                        jql=jql,
-                        url=url,
+                    url_name=url_name,
+                    start_at=start_at,
+                    max_results=FETCH_SIZE,
+                    jql=jql,
+                    url=url,
                 ):
                     response_json = await response.json()
                     total = response_json["total"]
@@ -468,10 +475,10 @@ class JiraDataSource(BaseDataSource):
         start_at = 0
         while True:
             async for users in self.jira_client.api_call(
-                    url_name=PERMISSIONS_BY_KEY,
-                    key=key,
-                    start_at=start_at,
-                    max_results=MAX_USER_FETCH_LIMIT,
+                url_name=PERMISSIONS_BY_KEY,
+                key=key,
+                start_at=start_at,
+                max_results=MAX_USER_FETCH_LIMIT,
             ):
                 response = await users.json()
                 if len(response) == 0:
@@ -488,12 +495,12 @@ class JiraDataSource(BaseDataSource):
         )
         access_control = set()
         async for actors in self._user_information_list(
-                key=f"projectKey={project['key']}"
+            key=f"projectKey={project['key']}"
         ):
             for actor in actors:
                 if (
-                        self.jira_client.data_source_type == JIRA_CLOUD
-                        and actor["accountType"] == ATLASSIAN
+                    self.jira_client.data_source_type == JIRA_CLOUD
+                    and actor["accountType"] == ATLASSIAN
                 ):
                     access_control.add(
                         prefix_account_id(account_id=actor.get("accountId"))
@@ -514,14 +521,14 @@ class JiraDataSource(BaseDataSource):
     async def _issue_security_level(self, issue_key):
         self._logger.debug(f"Fetching security level for issue: {issue_key}")
         async for response in self.jira_client.api_call(
-                url_name=ISSUE_SECURITY_LEVEL, issue_key=issue_key
+            url_name=ISSUE_SECURITY_LEVEL, issue_key=issue_key
         ):
             yield await response.json()
 
     async def _issue_security_level_members(self, level_id):
         self._logger.debug(f"Fetching members for issue security level: {level_id}")
         async for response in self.jira_client.paginated_api_call(
-                url_name=SECURITY_LEVEL_MEMBERS, level_id=level_id
+            url_name=SECURITY_LEVEL_MEMBERS, level_id=level_id
         ):
             yield response
 
@@ -530,9 +537,9 @@ class JiraDataSource(BaseDataSource):
             f"Fetching users and groups with role ID '{role_id}' for project '{project['key']}'"
         )
         async for actor_response in self.jira_client.api_call(
-                url_name=PROJECT_ROLE_MEMBERS_BY_ROLE_ID,
-                project_key=project["key"],
-                role_id=role_id,
+            url_name=PROJECT_ROLE_MEMBERS_BY_ROLE_ID,
+            project_key=project["key"],
+            role_id=role_id,
         ):
             actors = await actor_response.json()
             for actor in actors.get("actors", []):
@@ -572,7 +579,7 @@ class JiraDataSource(BaseDataSource):
         access_control = set()
         if self.jira_client.data_source_type != JIRA_CLOUD:
             async for actors in self._user_information_list(
-                    key=f"issueKey={issue_key}"
+                key=f"issueKey={issue_key}"
             ):
                 for actor in actors:
                     access_control.add(prefix_account_id(account_id=actor.get("name")))
@@ -585,14 +592,14 @@ class JiraDataSource(BaseDataSource):
             if security := response.get("fields", {}).get("security"):
                 level_id = security.get("id")
                 async for members in self._issue_security_level_members(
-                        level_id=level_id
+                    level_id=level_id
                 ):
                     for actor in members["values"]:
                         actor_type = actor.get("holder", {}).get("type")
                         if actor_type == "user":
                             user = actor.get("holder", {}).get("user", {})
                             if self.atlassian_access_control.is_active_atlassian_user(
-                                    user_info=user
+                                user_info=user
                             ):
                                 access_control.add(
                                     prefix_account_id(account_id=user.get("accountId"))
@@ -609,9 +616,9 @@ class JiraDataSource(BaseDataSource):
                             access_control.add(prefix_group_id(group_id=group_id))
                         elif actor_type == "projectRole":
                             if (
-                                    role_id := actor.get("holder", {})
-                                            .get("projectRole", {})
-                                            .get("id")
+                                role_id := actor.get("holder", {})
+                                .get("projectRole", {})
+                                .get("id")
                             ):
                                 # Project Role - `atlassian-addons-project-access` with id 10003 is not needed for DLS
                                 is_addons_projects_access = role_id == 10003
@@ -657,7 +664,11 @@ class JiraDataSource(BaseDataSource):
             if self.jira_client.data_source_type == JIRA_CLOUD
             else URLS[USERS_FOR_DATA_CENTER]
         )
-        url = self.configuration["jira_url"].rstrip('/') + '/' + users_endpoint.lstrip('/')
+        url = (
+            self.configuration["jira_url"].rstrip("/")
+            + "/"
+            + users_endpoint.lstrip("/")
+        )
         async for users in self.atlassian_access_control.fetch_all_users(url=url):
             active_atlassian_users = filter(
                 self.atlassian_access_control.is_active_atlassian_user, users
@@ -829,7 +840,7 @@ class JiraDataSource(BaseDataSource):
                 )
                 for project_key in self.jira_client.projects:
                     async for response in self.jira_client.api_call(
-                            url_name=PROJECT_BY_KEY, key=project_key
+                        url_name=PROJECT_BY_KEY, key=project_key
                     ):
                         project = await response.json()
                         await self._put_projects(project=project, timestamp=timestamp)
@@ -847,7 +858,7 @@ class JiraDataSource(BaseDataSource):
         """
         try:
             async for response in self.jira_client.api_call(
-                    url_name=ISSUE_DATA, id=issue["key"]
+                url_name=ISSUE_DATA, id=issue["key"]
             ):
                 issue = await response.json()
                 response_fields = issue.get("fields")
@@ -860,8 +871,8 @@ class JiraDataSource(BaseDataSource):
                 if restrictions := [
                     restriction["restrictionValue"]
                     for restriction in response_fields.get("issuerestriction", {})
-                            .get("issuerestrictions", {})
-                            .get("projectrole", [])
+                    .get("issuerestrictions", {})
+                    .get("projectrole", [])
                 ]:
                     issue_access_control = []
                     for role_id in restrictions:
@@ -919,7 +930,7 @@ class JiraDataSource(BaseDataSource):
         )
         self._logger.info(info_msg)
         async for response in self.jira_client.paginated_api_call(
-                url_name=ISSUES, jql=jql
+            url_name=ISSUES, jql=jql
         ):
             for issue in response.get("issues", []):
                 await self.fetchers.put(partial(self._put_issue, issue))


### PR DESCRIPTION
parse.urljoin treats the first argument as host name only. Which won't work when it is host name + path (when JIRA is installed not as Root Web App). For example - https://jira.company.com/jira. The old code ignore path '/jira' and, as a result , fails to connect to JIRA on https://jira.company.com 

The proposed change free from this defect and allows to communicate with JIRA in both cases.