### PR TITLE
[CLI] Show help page for "-h" argument

### DIFF
--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -45,7 +45,10 @@ def load_config(ctx, config):
 
 
 # Main group
-@click.group(invoke_without_command=True)
+@click.group(
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
 @click.version_option(__version__, "-v", "--version", message="%(version)s")
 @click.option("-c", "--config", type=click.File("rb"))
 @click.pass_context

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -34,7 +34,7 @@ Example:
 
 ## Available commands
 ### Getting help
-Connectors CLI provides a `--help` argument that can be used with any command to get more information.
+Connectors CLI provides a `--help`/`-h` argument that can be used with any command to get more information.
 
 For example:
 ```bash

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -44,10 +44,10 @@ def test_version():
     assert result.output.strip() == __version__
 
 
-@pytest.mark.parametrize("command", ["-h", "--help", None])
-def test_help_page(command):
+@pytest.mark.parametrize("commands", [["-h"], ["--help"], [None]])
+def test_help_page(commands):
     runner = CliRunner()
-    result = runner.invoke(cli, [command])
+    result = runner.invoke(cli, commands)
     assert "Usage:" in result.output
     assert "Options:" in result.output
     assert "Commands:" in result.output

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -44,7 +44,7 @@ def test_version():
     assert result.output.strip() == __version__
 
 
-@pytest.mark.parametrize("command", ["-h", "--help", ""])
+@pytest.mark.parametrize("command", ["-h", "--help", None])
 def test_help_page(command):
     runner = CliRunner()
     result = runner.invoke(cli, [command])

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -44,17 +44,10 @@ def test_version():
     assert result.output.strip() == __version__
 
 
-def test_help_page():
+@pytest.mark.parametrize("command", ["-h", "--help", ""])
+def test_help_page(command):
     runner = CliRunner()
-    result = runner.invoke(cli, ["--help"])
-    assert "Usage:" in result.output
-    assert "Options:" in result.output
-    assert "Commands:" in result.output
-
-
-def test_help_page_when_no_arguments():
-    runner = CliRunner()
-    result = runner.invoke(cli, [])
+    result = runner.invoke(cli, [command])
     assert "Usage:" in result.output
     assert "Options:" in result.output
     assert "Commands:" in result.output

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -44,7 +44,7 @@ def test_version():
     assert result.output.strip() == __version__
 
 
-@pytest.mark.parametrize("commands", [["-h"], ["--help"], [None]])
+@pytest.mark.parametrize("commands", [["-h"], ["--help"], []])
 def test_help_page(commands):
     runner = CliRunner()
     result = runner.invoke(cli, commands)


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6442

This PR adds `-h` as a flag to the connectors CLI as part of the CLI tech improvements.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)