### PR TITLE
[CLI] Extend version test

### DIFF
--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -37,9 +37,10 @@ def mock_job_es_client():
         yield mock
 
 
-def test_version():
+@pytest.mark.parametrize("commands", [["-v"], ["--version"]])
+def test_version(commands):
     runner = CliRunner()
-    result = runner.invoke(cli, ["-v"])
+    result = runner.invoke(cli, commands)
     assert result.exit_code == 0
     assert result.output.strip() == __version__
 


### PR DESCRIPTION
Small extension of `test_version` to also test that `--version` is a valid command to show the version