### PR TITLE
[CLI] Improve config missing error handling

### DIFF
--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -40,7 +40,7 @@ def load_config(ctx, config):
     elif ctx.invoked_subcommand == "login":
         pass
     else:
-        msg = f"{CONFIG_FILE_PATH} is not found"
+        msg = f"{CONFIG_FILE_PATH} was not found."
         raise FileNotFoundError(msg)
 
 
@@ -56,7 +56,13 @@ def cli(ctx, config):
         return
 
     ctx.ensure_object(dict)
-    ctx.obj["config"] = load_config(ctx, config)
+    try:
+        ctx.obj["config"] = load_config(ctx, config)
+    except FileNotFoundError as e:
+        click.echo(
+            f"{e} Make sure that the config is either present at the default location ({CONFIG_FILE_PATH}) or it's passed via the '-c' or '--config' option."
+        )
+        ctx.exit(1)
 
 
 @click.command(help="Authenticate Connectors CLI with an Elasticsearch instance")


### PR DESCRIPTION
## Related to https://github.com/elastic/enterprise-search-team/issues/6442

As part of the CLI tech improvements I've adapted the error message to not show a raw stack strace with the error message, but only show the error with a more actionable message.

Before change:
```
./bin/connectors job                                                                                                                                                                                      ─╯
Traceback (most recent call last):
  File "/Users/timgrein/Repositories/connectors/./bin/connectors", line 33, in <module>
    sys.exit(load_entry_point('elasticsearch-connectors', 'console_scripts', 'connectors')())
  File "/Users/timgrein/Repositories/connectors/connectors/connectors_cli.py", line 627, in main
    cli()
  File "/Users/timgrein/Repositories/connectors/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/timgrein/Repositories/connectors/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/timgrein/Repositories/connectors/lib/python3.10/site-packages/click/core.py", line 1685, in invoke
    super().invoke(ctx)
  File "/Users/timgrein/Repositories/connectors/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/timgrein/Repositories/connectors/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/timgrein/Repositories/connectors/lib/python3.10/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/timgrein/Repositories/connectors/connectors/connectors_cli.py", line 59, in cli
    ctx.obj["config"] = load_config(ctx, config)
  File "/Users/timgrein/Repositories/connectors/connectors/connectors_cli.py", line 44, in load_config
    raise FileNotFoundError(msg)
FileNotFoundError: .cli/config.yml is not found
```

After change:
```
./bin/connectors job                                                                                                                                                                                      ─╯
.cli/config.yml was not found. Make sure that the config is either present at the default location (.cli/config.yml) or it's passed via the '-c' or '--config' option.

```

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)