### PR TITLE
[Service CLI] Log exception, if uvloop couldn't be enabled

### DIFF
--- a/connectors/service_cli.py
+++ b/connectors/service_cli.py
@@ -153,9 +153,9 @@ def get_event_loop(uvloop=False):
             import uvloop
 
             asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
-        except Exception:
+        except Exception as e:
             logger.warning(
-                "Unable to enable uvloop: {e}. Running with default event loop"
+                f"Unable to enable uvloop: {e}. Running with default event loop"
             )
             pass
     try:


### PR DESCRIPTION
From the string it looks like we would've wanted to log the exception `[...] {e} [...]`, but we actually didn't, so adjusting it.