### PR TITLE
[Service CLI] Migrate to click

### DIFF
--- a/connectors/service_cli.py
+++ b/connectors/service_cli.py
@@ -16,7 +16,9 @@ import json
 import logging
 import os
 import signal
-from argparse import ArgumentParser
+
+import click
+from click import ClickException, UsageError
 
 from connectors import __version__
 from connectors.config import load_config
@@ -29,86 +31,6 @@ from connectors.source import get_source_klass, get_source_klasses
 __all__ = ["main"]
 
 from connectors.utils import sleeps_for_retryable
-
-
-def _parser():
-    """Parses command-line arguments using ArgumentParser and returns it"""
-    parser = ArgumentParser(prog="elastic-ingest")
-
-    parser.add_argument(
-        "--action",
-        type=str,
-        default=[
-            "schedule",
-            "sync_content",
-            "sync_access_control",
-            "cleanup",
-        ],
-        choices=[
-            "schedule",
-            "sync_content",
-            "sync_access_control",
-            "list",
-            "config",
-            "cleanup",
-        ],
-        nargs="+",
-        help="What elastic-ingest should do",
-    )
-
-    parser.add_argument(
-        "-c",
-        "--config-file",
-        type=str,
-        help="Configuration file",
-        default=os.path.join(os.path.dirname(__file__), "..", "config.yml"),
-    )
-
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "--log-level",
-        type=str,
-        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        default=None,
-        help="Set log level for the service.",
-    )
-    group.add_argument(
-        "--debug",
-        dest="log_level",
-        action="store_const",
-        const="DEBUG",
-        help="Run the event loop in debug mode (alias for --log-level DEBUG)",
-    )
-
-    parser.add_argument(
-        "--filebeat",
-        action="store_true",
-        default=False,
-        help="Output in filebeat format.",
-    )
-
-    parser.add_argument(
-        "--version",
-        action="store_true",
-        default=False,
-        help="Display the version and exit.",
-    )
-
-    parser.add_argument(
-        "--service-type",
-        type=str,
-        default=None,
-        help="Service type to get default configuration for if action is config",
-    )
-
-    parser.add_argument(
-        "--uvloop",
-        action="store_true",
-        default=False,
-        help="Use uvloop if possible",
-    )
-
-    return parser
 
 
 async def _start_service(actions, config, loop):
@@ -168,7 +90,7 @@ def get_event_loop(uvloop=False):
     return loop
 
 
-def run(args):
+def run(action, config_file, log_level, filebeat, service_type, uvloop):
     """Loads the config file, sets the logger and executes an action.
 
     Actions:
@@ -180,7 +102,7 @@ def run(args):
     # load config
     config = {}
     try:
-        config = load_config(args.config_file)
+        config = load_config(config_file)
         ContentExtraction.set_extraction_config(
             config.get("extraction_service", None)
         )  # Not perfect, let's revisit
@@ -188,36 +110,34 @@ def run(args):
         # If something goes wrong while parsing config file, we still want
         # to set up the logger so that Cloud deployments report errors to
         # logs properly
-        set_logger(logging.INFO, filebeat=args.filebeat)
-        logger.exception(f"Could not parse {args.config_file}:\n{e}")
-        raise
+        set_logger(logging.INFO, filebeat=filebeat)
+        msg = f"Could not parse {config_file}. Check logs for more information"
+        logger.exception(f"{msg}.\n{e}")
+        raise ClickException(msg) from e
 
     # Precedence: CLI args >> Config Setting >> INFO
     set_logger(
-        args.log_level or config["service"]["log_level"] or logging.INFO,
-        filebeat=args.filebeat,
+        log_level or config["service"]["log_level"] or logging.INFO,
+        filebeat=filebeat,
     )
 
     # just display the list of connectors
-    if args.action == ["list"]:
+    if action == ("list",):
         print("Registered connectors:")  # noqa: T201
         for source in get_source_klasses(config):
             print(f"- {source.name}")  # noqa: T201
         print("Bye")  # noqa: T201
         return 0
 
-    if args.action == ["config"]:
-        service_type = args.service_type
+    if action == ("config",):
         print(  # noqa: T201
             f"Getting default configuration for service type {service_type}"
         )
 
         source_list = config["sources"]
         if service_type not in source_list:
-            print(  # noqa: T201
-                f"Could not find a connector for service type {service_type}"
-            )
-            return -1
+            msg = f"Could not find a connector for service type {service_type}"
+            raise UsageError(msg)
 
         source_klass = get_source_klass(source_list[service_type])
         print(  # noqa: T201
@@ -226,16 +146,16 @@ def run(args):
         print("Bye")  # noqa: T201
         return 0
 
-    if "list" in args.action:
-        print("Cannot use the `list` action with other actions")  # noqa: T201
-        return -1
+    if "list" in action:
+        msg = "Cannot use the `list` action with other actions"
+        raise UsageError(msg)
 
-    if "config" in args.action:
-        print("Cannot use the `config` action with other actions")  # noqa: T201
-        return -1
+    if "config" in action:
+        msg = "Cannot use the `config` action with other actions"
+        raise UsageError(msg)
 
-    loop = get_event_loop(args.uvloop)
-    coro = _start_service(args.action, config, loop)
+    loop = get_event_loop(uvloop)
+    coro = _start_service(action, config, loop)
 
     try:
         return loop.run_until_complete(coro)
@@ -244,19 +164,59 @@ def run(args):
     finally:
         logger.info("Bye")
 
-    return -1
 
-
-def main(args=None):
+@click.command()
+@click.version_option(__version__, "-v", "--version", message="%(version)s")
+@click.option(
+    "--action",
+    type=click.Choice(
+        [
+            "schedule",
+            "sync_content",
+            "sync_access_control",
+            "list",
+            "config",
+            "cleanup",
+        ],
+        case_sensitive=False,
+    ),
+    multiple=True,
+    default=["schedule", "sync_content", "sync_access_control", "cleanup"],
+    help="What elastic-ingest should do.",
+)
+@click.option(
+    "-c",
+    "--config-file",
+    type=click.Path(),
+    default=os.path.join(os.path.dirname(__file__), "..", "config.yml"),
+    show_default=True,
+    help="Configuration file.",
+)
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
+    help="Set log level for the service.",
+)
+@click.option(
+    "--debug",
+    "log_level",
+    flag_value="DEBUG",
+    help="Run the event loop in debug mode (alias for --log-level DEBUG).",
+)
+@click.option(
+    "--filebeat", is_flag=True, default=False, help="Output in filebeat format."
+)
+@click.option(
+    "--service-type",
+    type=str,
+    default=None,
+    help="Service type to get default configuration for if action is config.",
+)
+@click.option("--uvloop", is_flag=True, default=False, help="Use uvloop if possible.")
+def main(action, config_file, log_level, filebeat, service_type, uvloop):
     """Entry point to the service, responsible for all operations.
 
     Parses the arguments and calls `run` with them.
-    If `--version` is used, displays the version and exits.
     """
-    parser = _parser()
-    args = parser.parse_args(args=args)
-    if args.version:
-        print(__version__)  # noqa: T201
-        return 0
 
-    return run(args)
+    return run(action, config_file, log_level, filebeat, service_type, uvloop)

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -18,7 +18,7 @@ from connectors.service_cli import main
 
 SUCCESS_EXIT_CODE = 0
 CLICK_EXCEPTION_EXIT_CODE = ClickException.exit_code
-USAGE_ERROR_CODE = UsageError.exit_code
+USAGE_ERROR_EXIT_CODE = UsageError.exit_code
 
 HERE = os.path.dirname(__file__)
 FIXTURES_DIR = os.path.abspath(os.path.join(HERE, "fixtures"))
@@ -144,7 +144,7 @@ def test_list_cannot_be_used_with_other_actions(set_env):
         ],
     )
 
-    assert result.exit_code == USAGE_ERROR_CODE
+    assert result.exit_code == USAGE_ERROR_EXIT_CODE
     assert "Cannot use the `list` action with other actions" in result.output
 
 
@@ -167,7 +167,7 @@ def test_config_cannot_be_used_with_other_actions(set_env):
         ],
     )
 
-    assert result.exit_code == USAGE_ERROR_CODE
+    assert result.exit_code == USAGE_ERROR_EXIT_CODE
     assert "Cannot use the `config` action with other actions" in result.output
 
 
@@ -205,7 +205,7 @@ def test_unknown_service_type(set_env):
         ],
     )
 
-    assert result.exit_code == USAGE_ERROR_CODE
+    assert result.exit_code == USAGE_ERROR_EXIT_CODE
     assert (
         f"Could not find a connector for service type {unknown_service_type}"
         in result.output

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -7,27 +7,25 @@ import asyncio
 import logging
 import os
 import signal
-from io import StringIO
-from unittest import mock
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from click import ClickException, UsageError
+from click.testing import CliRunner
 
 from connectors import __version__
-from connectors.service_cli import main, run
+from connectors.service_cli import main
+
+SUCCESS_EXIT_CODE = 0
+CLICK_EXCEPTION_EXIT_CODE = ClickException.exit_code
+USAGE_ERROR_CODE = UsageError.exit_code
 
 HERE = os.path.dirname(__file__)
 FIXTURES_DIR = os.path.abspath(os.path.join(HERE, "fixtures"))
 CONFIG = os.path.join(FIXTURES_DIR, "config.yml")
 
 
-def test_main(catch_stdout):
-    assert main(["--version"]) == 0
-    catch_stdout.seek(0)
-    assert catch_stdout.read().strip() == __version__
-
-
-def test_main_and_kill(mock_responses):
+def test_main_exits_on_sigterm(mock_responses):
     headers = {"X-Elastic-Product": "Elasticsearch"}
     host = "http://localhost:9200"
 
@@ -46,7 +44,16 @@ def test_main_and_kill(mock_responses):
     asyncio.set_event_loop(loop)
     loop.create_task(kill())
 
-    main([])
+    CliRunner().invoke(main, [])
+
+
+@pytest.mark.parametrize("option", ["-v", "--version"])
+def test_version_action(option):
+    runner = CliRunner()
+    result = runner.invoke(main, [option])
+
+    assert result.exit_code == SUCCESS_EXIT_CODE
+    assert __version__ in result.output
 
 
 @pytest.mark.parametrize("sig", [signal.SIGINT, signal.SIGTERM])
@@ -64,51 +71,104 @@ def test_shutdown_called_on_shutdown_signal(
     asyncio.set_event_loop(loop)
     loop.create_task(emit_shutdown_signal())
 
-    main([])
+    CliRunner().invoke(main, [])
 
     patch_logger.assert_present(f"Caught {sig.name}. Graceful shutdown.")
     patch_logger.assert_present(f"Caught {sig.name}. Cancelling sleeps...")
 
 
-def test_run(mock_responses, set_env):
-    args = mock.MagicMock()
-    args.log_level = "DEBUG"
-    args.config_file = CONFIG
-    args.action = ["list"]
-    with patch("sys.stdout", new=StringIO()) as patched_stdout:
-        assert run(args) == 0
+def test_list_action(set_env):
+    runner = CliRunner()
 
-        output = patched_stdout.getvalue().strip()
+    config_file = CONFIG
+    action = "list"
 
-        assert "Registered connectors:" in output
-        assert "- Fakey" in output
-        assert "- Large Fake" in output
-        assert "Bye" in output
+    result = runner.invoke(
+        main,
+        ["--config-file", config_file, "--action", action],
+    )
 
+    assert result.exit_code == SUCCESS_EXIT_CODE
 
-def test_config_action(mock_responses, set_env):
-    args = mock.MagicMock()
-    args.log_level = "DEBUG"
-    args.config_file = CONFIG
-    args.action = ["config"]
-    args.service_type = "fake"
-    with patch("sys.stdout", new=StringIO()) as patched_stdout:
-        result = run(args)
-        output = patched_stdout.getvalue().strip()
-        assert result == 0
-        assert "Could not find a connector for service type" not in output
-        assert "Getting default configuration for service type fake" in output
+    output = result.output
+
+    assert "Registered connectors:" in output
+    assert "- Fakey" in output
+    assert "- Large Fake" in output
+    assert "Bye" in output
 
 
-def test_run_snowflake(mock_responses, set_env):
-    args = mock.MagicMock()
-    args.log_level = "DEBUG"
-    args.config_file = CONFIG
-    args.action = ["list", "poll"]
-    with patch("sys.stdout", new=StringIO()) as patched_stdout:
-        assert run(args) == -1
-        output = patched_stdout.getvalue().strip()
-        assert "Cannot use the `list` action with other actions" in output
+def test_config_with_service_type_actions(set_env):
+    runner = CliRunner()
+
+    config_file = CONFIG
+    action = "config"
+    service_type = "fake"
+
+    result = runner.invoke(
+        main,
+        [
+            "--config-file",
+            config_file,
+            "--action",
+            action,
+            "--service-type",
+            service_type,
+        ],
+    )
+
+    assert result.exit_code == SUCCESS_EXIT_CODE
+
+    output = result.output
+
+    assert "Could not find a connector for service type" not in output
+    assert "Getting default configuration for service type fake" in output
+
+
+def test_list_cannot_be_used_with_other_actions(set_env):
+    runner = CliRunner()
+
+    config_file = CONFIG
+    first_action = "cleanup"
+    second_action = "list"
+
+    result = runner.invoke(
+        main,
+        [
+            "--config-file",
+            config_file,
+            "--action",
+            first_action,
+            "--action",
+            second_action,
+        ],
+    )
+
+    assert result.exit_code == USAGE_ERROR_CODE
+    assert "Cannot use the `list` action with other actions" in result.output
+
+
+def test_config_cannot_be_used_with_other_actions(set_env):
+    runner = CliRunner()
+
+    config_file = CONFIG
+    first_action = "cleanup"
+    second_action = "config"
+
+    result = runner.invoke(
+        main,
+        [
+            "--config-file",
+            config_file,
+            "--action",
+            first_action,
+            "--action",
+            second_action,
+        ],
+    )
+
+    assert result.exit_code == USAGE_ERROR_CODE
+    assert "Cannot use the `config` action with other actions" in result.output
 
 
 @patch("connectors.service_cli.set_logger")
@@ -116,11 +176,37 @@ def test_run_snowflake(mock_responses, set_env):
     "connectors.service_cli.load_config", side_effect=Exception("something went wrong")
 )
 def test_main_with_invalid_configuration(load_config, set_logger):
-    args = mock.MagicMock()
-    args.log_level = logging.DEBUG  # should be ignored!
-    args.filebeat = True
+    runner = CliRunner()
 
-    with pytest.raises(Exception):
-        run(args)
+    log_level = "DEBUG"  # should be ignored!
 
+    result = runner.invoke(main, ["--log-level", log_level, "--filebeat"])
+
+    assert result.exit_code == CLICK_EXCEPTION_EXIT_CODE
     set_logger.assert_called_with(logging.INFO, filebeat=True)
+
+
+def test_unknown_service_type(set_env):
+    runner = CliRunner()
+
+    config_file = CONFIG
+    action = "config"
+    unknown_service_type = "unknown"
+
+    result = runner.invoke(
+        main,
+        [
+            "--config-file",
+            config_file,
+            "--action",
+            action,
+            "--service-type",
+            unknown_service_type,
+        ],
+    )
+
+    assert result.exit_code == USAGE_ERROR_CODE
+    assert (
+        f"Could not find a connector for service type {unknown_service_type}"
+        in result.output
+    )


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6442

This PR migrates the `service_cli.py` to use the `click` library without changing any messages or behavior. I've also closed some testing gaps. Follow-ups, which will be kept separate from this PR to keep reviews focused:

- Improve help messages
- Consolidate duplicate logic between `connectors_cli.py` and `services_cli.py`

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)