### PR TITLE
[Jira] Fix NotFound when the path is present in host URL

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -104,7 +104,10 @@ class JiraClient:
         self.configuration = configuration
         self._logger = logger
         self.data_source_type = self.configuration["data_source"]
-        self.host_url = self.configuration["jira_url"] + "/"
+
+        jira_url = self.configuration["jira_url"]
+        self.host_url = jira_url if jira_url[-1] == "/" else jira_url + "/"
+
         self.projects = self.configuration["projects"]
         self.ssl_enabled = self.configuration["ssl_enabled"]
         self.certificate = self.configuration["ssl_ca"]

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -59,19 +59,19 @@ ISSUE_SECURITY_LEVEL = "issue_security_level"
 SECURITY_LEVEL_MEMBERS = "issue_security_members"
 PROJECT_ROLE_MEMBERS_BY_ROLE_ID = "project_role_members_by_role_id"
 URLS = {
-    PING: "/rest/api/2/myself",
-    PROJECT: "/rest/api/2/project?expand=description,lead,url",
-    PROJECT_BY_KEY: "/rest/api/2/project/{key}",
-    ISSUES: "/rest/api/2/search?jql={jql}&maxResults={max_results}&startAt={start_at}",
-    ISSUE_DATA: "/rest/api/2/issue/{id}",
-    ATTACHMENT_CLOUD: "/rest/api/2/attachment/content/{attachment_id}",
-    ATTACHMENT_SERVER: "/secure/attachment/{attachment_id}/{attachment_name}",
-    USERS: "/rest/api/3/users/search",
-    USERS_FOR_DATA_CENTER: "/rest/api/latest/user/search?username=''&startAt={start_at}&maxResults={max_results}",  # we can fetch only 1000 users for jira data center. Refer this doc see the limitations: https://auth0.com/docs/manage-users/user-search/retrieve-users-with-get-users-endpoint#limitations
-    PERMISSIONS_BY_KEY: "/rest/api/2/user/permission/search?{key}&permissions=BROWSE&maxResults={max_results}&startAt={start_at}",
-    PROJECT_ROLE_MEMBERS_BY_ROLE_ID: "/rest/api/3/project/{project_key}/role/{role_id}",
-    ISSUE_SECURITY_LEVEL: "/rest/api/2/issue/{issue_key}?fields=security",
-    SECURITY_LEVEL_MEMBERS: "/rest/api/3/issuesecurityschemes/level/member?maxResults={max_results}&startAt={start_at}&levelId={level_id}&expand=user,group,projectRole",
+    PING: "rest/api/2/myself",
+    PROJECT: "rest/api/2/project?expand=description,lead,url",
+    PROJECT_BY_KEY: "rest/api/2/project/{key}",
+    ISSUES: "rest/api/2/search?jql={jql}&maxResults={max_results}&startAt={start_at}",
+    ISSUE_DATA: "rest/api/2/issue/{id}",
+    ATTACHMENT_CLOUD: "rest/api/2/attachment/content/{attachment_id}",
+    ATTACHMENT_SERVER: "secure/attachment/{attachment_id}/{attachment_name}",
+    USERS: "rest/api/3/users/search",
+    USERS_FOR_DATA_CENTER: "rest/api/latest/user/search?username=''&startAt={start_at}&maxResults={max_results}",  # we can fetch only 1000 users for jira data center. Refer this doc see the limitations: https://auth0.com/docs/manage-users/user-search/retrieve-users-with-get-users-endpoint#limitations
+    PERMISSIONS_BY_KEY: "rest/api/2/user/permission/search?{key}&permissions=BROWSE&maxResults={max_results}&startAt={start_at}",
+    PROJECT_ROLE_MEMBERS_BY_ROLE_ID: "rest/api/3/project/{project_key}/role/{role_id}",
+    ISSUE_SECURITY_LEVEL: "rest/api/2/issue/{issue_key}?fields=security",
+    SECURITY_LEVEL_MEMBERS: "rest/api/3/issuesecurityschemes/level/member?maxResults={max_results}&startAt={start_at}&levelId={level_id}&expand=user,group,projectRole",
 }
 
 JIRA_CLOUD = "jira_cloud"
@@ -104,7 +104,7 @@ class JiraClient:
         self.configuration = configuration
         self._logger = logger
         self.data_source_type = self.configuration["data_source"]
-        self.host_url = self.configuration["jira_url"]
+        self.host_url = self.configuration["jira_url"] + "/"
         self.projects = self.configuration["projects"]
         self.ssl_enabled = self.configuration["ssl_enabled"]
         self.certificate = self.configuration["ssl_ca"]
@@ -646,7 +646,7 @@ class JiraDataSource(BaseDataSource):
             if self.jira_client.data_source_type == JIRA_CLOUD
             else URLS[USERS_FOR_DATA_CENTER]
         )
-        url = parse.urljoin(self.configuration["jira_url"], users_endpoint)
+        url = parse.urljoin(self.jira_client.host_url, users_endpoint)
         async for users in self.atlassian_access_control.fetch_all_users(url=url):
             active_atlassian_users = filter(
                 self.atlassian_access_control.is_active_atlassian_user, users

--- a/tests/sources/test_atlassian.py
+++ b/tests/sources/test_atlassian.py
@@ -138,7 +138,9 @@ async def test_advanced_rules_validation(advanced_rules, expected_validation_res
 )
 @pytest.mark.asyncio
 async def test_active_atlassian_user(user_info, result):
-    async with create_source(JiraDataSource) as source:
+    async with create_source(
+        JiraDataSource, jira_url="https://127.0.0.1:8080/test"
+    ) as source:
         validation_result = AtlassianAccessControl(
             source, JiraClient
         ).is_active_atlassian_user(user_info)

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -302,7 +302,9 @@ ACCESS_CONTROL = "_allow_access_control"
 
 
 @asynccontextmanager
-async def create_jira_source(use_text_extraction_service=False):
+async def create_jira_source(
+    use_text_extraction_service=False, jira_url="http://127.0.0.1:8080"
+):
     async with create_source(
         JiraDataSource,
         data_source="jira_cloud",
@@ -310,7 +312,7 @@ async def create_jira_source(use_text_extraction_service=False):
         password="changeme",
         account_email="me@example.com",
         api_token="abc#123",
-        jira_url="http://127.0.0.1:8080",
+        jira_url=jira_url,
         projects="*",
         ssl_enabled=False,
         use_text_extraction_service=use_text_extraction_service,
@@ -367,6 +369,8 @@ def side_effect_function(url, ssl):
         mocked_issue_data = {"issues": [MOCK_ISSUE_TYPE_BUG], "total": 1}
         return get_json_mock(mock_response=mocked_issue_data)
     elif url == f"{HOST_URL}/rest/api/2/myself":
+        return get_json_mock(mock_response=MOCK_MYSELF)
+    elif url == f"{HOST_URL}/test/rest/api/2/myself":
         return get_json_mock(mock_response=MOCK_MYSELF)
     elif url == f"{HOST_URL}/rest/api/2/project?expand=description,lead,url":
         return get_json_mock(mock_response=MOCK_PROJECT)
@@ -553,6 +557,15 @@ async def test_get_with_500_status():
                     url="http://localhost:1000/err"
                 ):
                     await response.json()
+
+
+@pytest.mark.asyncio
+async def test_ping_to_custom_path_server():
+    async with create_jira_source(jira_url="http://127.0.0.1:8080/test/") as source:
+        with patch.object(
+            aiohttp.ClientSession, "get", side_effect=side_effect_function
+        ):
+            await source.ping()
 
 
 @pytest.mark.asyncio

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -307,7 +307,9 @@ ACCESS_CONTROL = "_allow_access_control"
 
 @asynccontextmanager
 async def create_jira_source(
-    use_text_extraction_service=False, data_source="jira_cloud", jira_url="http://127.0.0.1:8080"
+    use_text_extraction_service=False,
+    data_source="jira_cloud",
+    jira_url="http://127.0.0.1:8080",
 ):
     async with create_source(
         JiraDataSource,
@@ -565,11 +567,22 @@ async def test_get_with_500_status():
 
 @pytest.mark.asyncio
 async def test_ping_to_custom_path_server():
-    async with create_jira_source(jira_url="http://127.0.0.1:8080/test/") as source:
+    expected_url = "http://127.0.0.1:8080/test/"
+
+    async with create_jira_source(jira_url=expected_url) as source:
         with patch.object(
-            aiohttp.ClientSession, "get", side_effect=side_effect_function
-        ):
+            aiohttp.ClientSession,
+            "get",
+            side_effect=side_effect_function,
+        ) as mock_get:
             await source.ping()
+
+            call_args = mock_get.call_args
+            actual_url = call_args.kwargs["url"]
+
+            # pinged URL: http://127.0.0.1:8080/test/rest/api/2/myself
+            # checking if expected_url - 'http://127.0.0.1:8080/test/' is a part of pinged URL
+            assert expected_url in actual_url
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2343

This PR removes leading slashes from the endpoints used in the connector and adding an extra '/' in the host url to prevent the NotFound error.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)


## Release Notes
Adds support for Jira Server and Jira Data Center where the root of the server is hosted behind a path, and not at a root of the host/domain.