### PR TITLE
[CLI] Track CLI usage through user agent header

### DIFF
--- a/connectors/cli/auth.py
+++ b/connectors/cli/auth.py
@@ -4,7 +4,7 @@ import os
 import yaml
 from elasticsearch import ApiError
 
-from connectors.es.management_client import ESManagementClient
+from connectors.es.cli_client import CLIClient
 
 CONFIG_FILE_PATH = ".cli/config.yml"
 
@@ -21,7 +21,7 @@ class Auth:
         # remove empty values
         self.elastic_config = {k: v for k, v in elastic_config.items() if v is not None}
 
-        self.es_management_client = ESManagementClient(self.elastic_config)
+        self.cli_client = CLIClient(self.elastic_config)
 
     def authenticate(self):
         if asyncio.run(self.__ping_es_client()):
@@ -35,11 +35,11 @@ class Auth:
 
     async def __ping_es_client(self):
         try:
-            return await self.es_management_client.ping()
+            return await self.cli_client.ping()
         except ApiError:
             return False
         finally:
-            await self.es_management_client.close()
+            await self.cli_client.close()
 
     def __save_config(self):
         yaml_content = yaml.dump({"elasticsearch": self.elastic_config})

--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections import OrderedDict
 
-from connectors.es.management_client import ESManagementClient
+from connectors.es.cli_client import CLIClient
 from connectors.es.settings import DEFAULT_LANGUAGE
 from connectors.protocol import (
     CONCRETE_CONNECTORS_INDEX,
@@ -24,14 +24,14 @@ class Connector:
         self.config = config
 
         # initialize ES client
-        self.es_management_client = ESManagementClient(self.config)
+        self.cli_client = CLIClient(self.config)
 
         self.connector_index = ConnectorIndex(self.config)
 
     async def list_connectors(self):
         # TODO move this on top
         try:
-            await self.es_management_client.ensure_exists(
+            await self.cli_client.ensure_exists(
                 indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
             )
 
@@ -42,7 +42,7 @@ class Connector:
         # TODO catch exceptions
         finally:
             await self.connector_index.close()
-            await self.es_management_client.close()
+            await self.cli_client.close()
 
     def service_type_configuration(self, source_class):
         source_klass = get_source_klass(source_class)
@@ -95,7 +95,7 @@ class Connector:
         except Exception as e:
             raise e
         finally:
-            await self.es_management_client.close()
+            await self.cli_client.close()
 
     async def __create_connector(
         self,
@@ -108,15 +108,13 @@ class Connector:
         from_index,
     ):
         try:
-            await self.es_management_client.ensure_exists(
+            await self.cli_client.ensure_exists(
                 indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX]
             )
             timestamp = iso_utc()
 
             if not from_index:
-                await self.es_management_client.create_content_index(
-                    index_name, language
-                )
+                await self.cli_client.create_content_index(index_name, language)
 
             api_key_id = None
             api_key_secret_id = None
@@ -180,7 +178,7 @@ class Connector:
                 "api_key_error": api_key_error,
             }
         finally:
-            await self.es_management_client.close()
+            await self.cli_client.close()
             await self.connector_index.close()
 
     def default_scheduling(self):
@@ -255,11 +253,11 @@ class Connector:
                 ],
             },
         }
-        return await self.es_management_client.client.security.create_api_key(
+        return await self.cli_client.client.security.create_api_key(
             name=f"{name}-connector",
             role_descriptors=role_descriptors,
             metadata=metadata,
         )
 
     async def __store_api_key(self, encoded_api_key):
-        return await self.es_management_client.create_connector_secret(encoded_api_key)
+        return await self.cli_client.create_connector_secret(encoded_api_key)

--- a/connectors/cli/job.py
+++ b/connectors/cli/job.py
@@ -2,7 +2,7 @@ import asyncio
 
 from elasticsearch import ApiError
 
-from connectors.es.management_client import ESManagementClient
+from connectors.es.cli_client import CLIClient
 from connectors.protocol import (
     CONCRETE_CONNECTORS_INDEX,
     CONCRETE_JOBS_INDEX,
@@ -18,7 +18,7 @@ from connectors.protocol import (
 class Job:
     def __init__(self, config):
         self.config = config
-        self.es_management_client = ESManagementClient(self.config)
+        self.cli_client = CLIClient(self.config)
         self.sync_job_index = SyncJobIndex(self.config)
         self.connector_index = ConnectorIndex(self.config)
 
@@ -36,14 +36,14 @@ class Job:
 
     async def __async_job(self, job_id):
         try:
-            await self.es_management_client.ensure_exists(
+            await self.cli_client.ensure_exists(
                 indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
             )
             job = await self.sync_job_index.fetch_by_id(job_id)
             return job
         finally:
             await self.sync_job_index.close()
-            await self.es_management_client.close()
+            await self.cli_client.close()
 
     async def __async_start(self, connector_id, job_type):
         try:
@@ -58,11 +58,11 @@ class Job:
         finally:
             await self.sync_job_index.close()
             await self.connector_index.close()
-            await self.es_management_client.close()
+            await self.cli_client.close()
 
     async def __async_list_jobs(self, connector_id, index_name, job_id):
         try:
-            await self.es_management_client.ensure_exists(
+            await self.cli_client.ensure_exists(
                 indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
             )
             jobs = self.sync_job_index.get_all_docs(
@@ -75,11 +75,11 @@ class Job:
         # TODO catch exceptions
         finally:
             await self.sync_job_index.close()
-            await self.es_management_client.close()
+            await self.cli_client.close()
 
     async def __async_cancel_jobs(self, connector_id, index_name, job_id):
         try:
-            await self.es_management_client.ensure_exists(
+            await self.cli_client.ensure_exists(
                 indices=[CONCRETE_CONNECTORS_INDEX, CONCRETE_JOBS_INDEX],
             )
             jobs = self.sync_job_index.get_all_docs(
@@ -95,7 +95,7 @@ class Job:
             return False
         finally:
             await self.sync_job_index.close()
-            await self.es_management_client.close()
+            await self.cli_client.close()
 
     def __job_list_query(self, connector_id, index_name, job_id):
         if job_id:

--- a/connectors/es/cli_client.py
+++ b/connectors/es/cli_client.py
@@ -3,8 +3,9 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+from connectors.es import ESClient
 from connectors.es.management_client import ESManagementClient
 
 
 class CLIClient(ESManagementClient):
-    product_origin = "connectors-cli"
+    user_agent = f"{ESClient.user_agent}/cli"

--- a/connectors/es/cli_client.py
+++ b/connectors/es/cli_client.py
@@ -1,0 +1,10 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+from connectors.es.management_client import ESManagementClient
+
+
+class CLIClient(ESManagementClient):
+    product_origin = "connectors-cli"

--- a/connectors/es/cli_client.py
+++ b/connectors/es/cli_client.py
@@ -3,9 +3,9 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from connectors.es import ESClient
+from connectors.es.client import USER_AGENT_BASE
 from connectors.es.management_client import ESManagementClient
 
 
 class CLIClient(ESManagementClient):
-    user_agent = f"{ESClient.user_agent}/cli"
+    user_agent = f"{USER_AGENT_BASE}/cli"

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -29,8 +29,6 @@ from connectors.utils import (
     time_to_sleep_between_retries,
 )
 
-X_ELASTIC_PRODUCT_ORIGIN_HEADER = "X-elastic-product-origin"
-
 
 class License(Enum):
     ENTERPRISE = "enterprise"
@@ -43,7 +41,7 @@ class License(Enum):
 
 
 class ESClient:
-    product_origin = "connectors"
+    user_agent = f"elastic-connectors-{__version__}"
 
     def __init__(self, config):
         # We don't have a way to ask the server, but it's planned
@@ -107,10 +105,8 @@ class ESClient:
         self.backoff_multiplier = config.get("backoff_multiplier", 2)
 
         options["headers"] = config.get("headers", {})
-        options["headers"]["user-agent"] = f"elastic-connectors-{__version__}"
-        options["headers"][
-            X_ELASTIC_PRODUCT_ORIGIN_HEADER
-        ] = self.__class__.product_origin
+        options["headers"]["user-agent"] = self.__class__.user_agent
+        options["headers"]["X-elastic-product-origin"] = "connectors"
 
         self.client = AsyncElasticsearch(**options)
         self._keep_waiting = True

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -105,7 +105,7 @@ class ESClient:
         self.backoff_multiplier = config.get("backoff_multiplier", 2)
 
         options["headers"] = config.get("headers", {})
-        options["headers"]["user-agent"] = self.__class__.user_agent
+        options["headers"]["user-agent"] = f"{self.__class__.user_agent}/service"
         options["headers"]["X-elastic-product-origin"] = "connectors"
 
         self.client = AsyncElasticsearch(**options)

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -105,9 +105,9 @@ class ESClient:
         self.max_wait_duration = config.get("max_wait_duration", 60)
         self.initial_backoff_duration = config.get("initial_backoff_duration", 5)
         self.backoff_multiplier = config.get("backoff_multiplier", 2)
+
         options["headers"] = config.get("headers", {})
         options["headers"]["user-agent"] = f"elastic-connectors-{__version__}"
-
         options["headers"][
             X_ELASTIC_PRODUCT_ORIGIN_HEADER
         ] = self.__class__.product_origin

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -40,8 +40,11 @@ class License(Enum):
     UNSET = None
 
 
+USER_AGENT_BASE = f"elastic-connectors-{__version__}"
+
+
 class ESClient:
-    user_agent = f"elastic-connectors-{__version__}"
+    user_agent = f"{USER_AGENT_BASE}/service"
 
     def __init__(self, config):
         # We don't have a way to ask the server, but it's planned
@@ -105,7 +108,7 @@ class ESClient:
         self.backoff_multiplier = config.get("backoff_multiplier", 2)
 
         options["headers"] = config.get("headers", {})
-        options["headers"]["user-agent"] = f"{self.__class__.user_agent}/service"
+        options["headers"]["user-agent"] = self.__class__.user_agent
         options["headers"]["X-elastic-product-origin"] = "connectors"
 
         self.client = AsyncElasticsearch(**options)

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -29,6 +29,8 @@ from connectors.utils import (
     time_to_sleep_between_retries,
 )
 
+X_ELASTIC_PRODUCT_ORIGIN_HEADER = "X-elastic-product-origin"
+
 
 class License(Enum):
     ENTERPRISE = "enterprise"
@@ -41,6 +43,8 @@ class License(Enum):
 
 
 class ESClient:
+    product_origin = "connectors"
+
     def __init__(self, config):
         # We don't have a way to ask the server, but it's planned
         # for now we just use an env flag
@@ -103,7 +107,11 @@ class ESClient:
         self.backoff_multiplier = config.get("backoff_multiplier", 2)
         options["headers"] = config.get("headers", {})
         options["headers"]["user-agent"] = f"elastic-connectors-{__version__}"
-        options["headers"]["X-elastic-product-origin"] = "connectors"
+
+        options["headers"][
+            X_ELASTIC_PRODUCT_ORIGIN_HEADER
+        ] = self.__class__.product_origin
+
         self.client = AsyncElasticsearch(**options)
         self._keep_waiting = True
 

--- a/tests/es/test_cli_client.py
+++ b/tests/es/test_cli_client.py
@@ -1,0 +1,15 @@
+from connectors.es.cli_client import CLIClient
+from connectors.es.client import X_ELASTIC_PRODUCT_ORIGIN_HEADER
+
+
+def test_overrides_product_origin_header():
+    config = {
+        "username": "elastic",
+        "password": "changeme",
+        "host": "http://nowhere.com:9200",
+    }
+    cli_client = CLIClient(config)
+
+    assert (
+        cli_client.client._headers[X_ELASTIC_PRODUCT_ORIGIN_HEADER] == "connectors-cli"
+    )

--- a/tests/es/test_cli_client.py
+++ b/tests/es/test_cli_client.py
@@ -1,3 +1,4 @@
+from connectors import __version__
 from connectors.es.cli_client import CLIClient
 
 
@@ -9,4 +10,7 @@ def test_overrides_user_agent_header():
     }
     cli_client = CLIClient(config)
 
-    assert cli_client.client._headers["user-agent"] == CLIClient.user_agent
+    assert (
+        cli_client.client._headers["user-agent"]
+        == f"elastic-connectors-{__version__}/cli"
+    )

--- a/tests/es/test_cli_client.py
+++ b/tests/es/test_cli_client.py
@@ -1,7 +1,7 @@
 from connectors.es.cli_client import CLIClient
 
 
-def test_overrides_product_origin_header():
+def test_overrides_user_agent_header():
     config = {
         "username": "elastic",
         "password": "changeme",

--- a/tests/es/test_cli_client.py
+++ b/tests/es/test_cli_client.py
@@ -1,5 +1,4 @@
 from connectors.es.cli_client import CLIClient
-from connectors.es.client import X_ELASTIC_PRODUCT_ORIGIN_HEADER
 
 
 def test_overrides_product_origin_header():
@@ -10,6 +9,4 @@ def test_overrides_product_origin_header():
     }
     cli_client = CLIClient(config)
 
-    assert (
-        cli_client.client._headers[X_ELASTIC_PRODUCT_ORIGIN_HEADER] == "connectors-cli"
-    )
+    assert cli_client.client._headers["user-agent"] == CLIClient.user_agent

--- a/tests/es/test_client.py
+++ b/tests/es/test_client.py
@@ -12,6 +12,7 @@ import pytest
 from elasticsearch import ApiError, ConflictError, ConnectionError, ConnectionTimeout
 
 from connectors.es.client import (
+    X_ELASTIC_PRODUCT_ORIGIN_HEADER,
     ESClient,
     License,
     RetryInterruptedError,
@@ -235,6 +236,15 @@ class TestESClient:
             # Execute
             assert not await es_client.ping()
             await es_client.close()
+
+    def test_sets_product_origin_header(self):
+        config = {"headers": {"some-header": "some-value"}}
+
+        es_client = ESClient(config)
+
+        assert (
+            es_client.client._headers[X_ELASTIC_PRODUCT_ORIGIN_HEADER] == "connectors"
+        )
 
 
 class TestTransientElasticsearchRetrier:

--- a/tests/es/test_client.py
+++ b/tests/es/test_client.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from elasticsearch import ApiError, ConflictError, ConnectionError, ConnectionTimeout
 
+from connectors import __version__
 from connectors.es.client import (
     ESClient,
     License,
@@ -248,7 +249,10 @@ class TestESClient:
 
         es_client = ESClient(config)
 
-        assert es_client.client._headers["user-agent"] == ESClient.user_agent
+        assert (
+            es_client.client._headers["user-agent"]
+            == f"elastic-connectors-{__version__}/service"
+        )
 
 
 class TestTransientElasticsearchRetrier:

--- a/tests/es/test_client.py
+++ b/tests/es/test_client.py
@@ -12,7 +12,6 @@ import pytest
 from elasticsearch import ApiError, ConflictError, ConnectionError, ConnectionTimeout
 
 from connectors.es.client import (
-    X_ELASTIC_PRODUCT_ORIGIN_HEADER,
     ESClient,
     License,
     RetryInterruptedError,
@@ -242,9 +241,14 @@ class TestESClient:
 
         es_client = ESClient(config)
 
-        assert (
-            es_client.client._headers[X_ELASTIC_PRODUCT_ORIGIN_HEADER] == "connectors"
-        )
+        assert es_client.client._headers["X-elastic-product-origin"] == "connectors"
+
+    def test_sets_user_agent(self):
+        config = {"headers": {"some-header": "some-value"}}
+
+        es_client = ESClient(config)
+
+        assert es_client.client._headers["user-agent"] == ESClient.user_agent
 
 
 class TestTransientElasticsearchRetrier:

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -25,14 +25,14 @@ def mock_cli_config():
 
 @pytest.fixture(autouse=True)
 def mock_connector_es_client():
-    with patch("connectors.cli.connector.ESManagementClient") as mock:
+    with patch("connectors.cli.connector.CLIClient") as mock:
         mock.return_value = AsyncMock()
         yield mock
 
 
 @pytest.fixture(autouse=True)
 def mock_job_es_client():
-    with patch("connectors.cli.job.ESManagementClient") as mock:
+    with patch("connectors.cli.job.CLIClient") as mock:
         mock.return_value = AsyncMock()
         yield mock
 
@@ -545,7 +545,7 @@ def test_index_list_one_index():
     indices = {"indices": {"test_index": {"primaries": {"docs": {"count": 10}}}}}
 
     with patch(
-        "connectors.es.management_client.ESManagementClient.list_indices",
+        "connectors.es.cli_client.CLIClient.list_indices",
         AsyncMock(return_value=indices),
     ):
         result = runner.invoke(cli, ["index", "list"])
@@ -559,7 +559,7 @@ def test_index_clean():
     runner = CliRunner()
     index_name = "test_index"
     with patch(
-        "connectors.es.management_client.ESManagementClient.clean_index",
+        "connectors.es.cli_client.CLIClient.clean_index",
         AsyncMock(return_value=True),
     ) as mocked_method:
         result = runner.invoke(cli, ["index", "clean", index_name])
@@ -574,7 +574,7 @@ def test_index_clean_error():
     runner = CliRunner()
     index_name = "test_index"
     with patch(
-        "connectors.es.management_client.ESManagementClient.clean_index",
+        "connectors.es.cli_client.CLIClient.clean_index",
         side_effect=ApiError(500, meta="meta", body="error"),
     ):
         result = runner.invoke(cli, ["index", "clean", index_name])
@@ -588,7 +588,7 @@ def test_index_delete():
     runner = CliRunner()
     index_name = "test_index"
     with patch(
-        "connectors.es.management_client.ESManagementClient.delete_indices",
+        "connectors.es.cli_client.CLIClient.delete_indices",
         AsyncMock(return_value=None),
     ) as mocked_method:
         result = runner.invoke(cli, ["index", "delete", index_name])
@@ -603,7 +603,7 @@ def test_delete_index_error():
     runner = CliRunner()
     index_name = "test_index"
     with patch(
-        "connectors.es.management_client.ESManagementClient.delete_indices",
+        "connectors.es.cli_client.CLIClient.delete_indices",
         side_effect=ApiError(500, meta="meta", body="error"),
     ):
         result = runner.invoke(cli, ["index", "delete", index_name])


### PR DESCRIPTION
## Part of https://github.com/elastic/enterprise-search-team/issues/6442

This PR adds a new property `user_agent` to the `ESClient` class, which can be overridden, so we're able to track different origins. `CLIClient` overrides this property to `connectors-cli` so we're able to track CLI usage. Also added one missing test to `ESClient`.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)