### PR TITLE
Add unit test for atlassian fetch_all_users

### DIFF
--- a/tests/sources/test_atlassian.py
+++ b/tests/sources/test_atlassian.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import json
 from unittest.mock import ANY
 
 import pytest
@@ -17,7 +18,7 @@ from connectors.sources.atlassian import (
 )
 from connectors.sources.jira import JiraClient, JiraDataSource
 from tests.sources.support import create_source
-
+from urllib import parse
 
 @pytest.mark.parametrize(
     "advanced_rules, expected_validation_result",
@@ -145,3 +146,55 @@ async def test_active_atlassian_user(user_info, result):
             source, JiraClient
         ).is_active_atlassian_user(user_info)
         assert validation_result == result
+
+user_response = """
+[
+  {
+    "accountId": "5b10a2844c20165700ede21g",
+    "accountType": "atlassian",
+    "active": false,
+    "avatarUrls": {
+      "16x16": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/MK-5.png?size=16&s=16",
+      "24x24": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/MK-5.png?size=24&s=24",
+      "32x32": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/MK-5.png?size=32&s=32",
+      "48x48": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/MK-5.png?size=48&s=48"
+    },
+    "displayName": "Mia Krystof",
+    "key": "",
+    "name": "",
+    "self": "https://your-domain.atlassian.net/rest/api/3/user?accountId=5b10a2844c20165700ede21g"
+  },
+  {
+    "accountId": "5b10ac8d82e05b22cc7d4ef5",
+    "accountType": "atlassian",
+    "active": false,
+    "avatarUrls": {
+      "16x16": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/AA-3.png?size=16&s=16",
+      "24x24": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/AA-3.png?size=24&s=24",
+      "32x32": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/AA-3.png?size=32&s=32",
+      "48x48": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/AA-3.png?size=48&s=48"
+    },
+    "displayName": "Emma Richards",
+    "key": "",
+    "name": "",
+    "self": "https://your-domain.atlassian.net/rest/api/3/user?accountId=5b10ac8d82e05b22cc7d4ef5"
+  }
+]
+"""
+@pytest.mark.asyncio
+async def test_fetch_all_users(mock_responses):
+    jira_host = "https://127.0.0.1:8080"
+    users_path = "rest/api/3/users/search"
+
+    mock_responses.get(f"{parse.urljoin(jira_host, users_path)}?startAt=0", status=200, payload=json.loads(user_response))
+    mock_responses.get(f"{parse.urljoin(jira_host, users_path)}?startAt=50", status=200, payload=[])
+    async with create_source(
+        JiraDataSource, jira_url=jira_host
+    ) as source:
+        access_control = AtlassianAccessControl(source, source.jira_client)
+        results = []
+        async for response in access_control.fetch_all_users(url=parse.urljoin(jira_host, users_path)):
+            for user in response:
+                results.append(user)
+
+        assert len(results) == 2


### PR DESCRIPTION
Adds a test for a previously untested function, since `atlassian.py` was our weakest link in the coverage report.

```
connectors/sources/atlassian.py                               96     16    83%   94, 111-133, 136-137
```

## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
