### PR TITLE
Provice example certificate path in the config.yml comment

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -54,7 +54,7 @@
 #elasticsearch.ssl: true
 #
 #
-##  Path to a CA bundle
+##  Path to a CA bundle, e.g. /path/to/ca.crt
 #elasticsearch.ca_certs: null
 #
 #


### PR DESCRIPTION
It took me a few tries to manually configure the cert (to connector to ES) for the connector correctly. It was not clear if we should pass a parent dir or a specific file in the path. 

The comment explains how to do it correctly. We should pass `/path/to/ca.crt`