### PR TITLE
[8.14] [Notion] Handle error on fetching children of external objects and Objects not shared with Integration

### DIFF
--- a/connectors/sources/notion.py
+++ b/connectors/sources/notion.py
@@ -201,6 +201,8 @@ class NotionClient:
                 self._logger.warning(
                     f"Encountered external object with id: {block_id}. Skipping : {error}"
                 )
+            elif error.code == "object_not_found":
+                self._logger.warning(f"Object not found: {error}")
             else:
                 raise
 

--- a/connectors/sources/notion.py
+++ b/connectors/sources/notion.py
@@ -5,7 +5,9 @@
 #
 """Notion source module responsible to fetch documents from the Notion Platform."""
 import asyncio
+import json
 import os
+import re
 from copy import copy
 from functools import cached_property, partial
 from typing import Any, Awaitable, Callable
@@ -176,17 +178,31 @@ class NotionClient:
                     ):  # pyright: ignore
                         yield grandchild
 
-        async for block in self.async_iterate_paginated_api(
-            self._get_client.blocks.children.list, block_id=block_id
-        ):
-            if block.get("type") not in ["child_database", "child_page", "unsupported"]:
-                yield block
-                if block.get("has_children") is True:
-                    async for child in fetch_children_recursively(block):
-                        yield child
-            if block.get("type") == "child_database":
-                async for record in self.query_database(block.get("id")):
-                    yield record
+        try:
+            async for block in self.async_iterate_paginated_api(
+                self._get_client.blocks.children.list, block_id=block_id
+            ):
+                if block.get("type") not in [
+                    "child_database",
+                    "child_page",
+                    "unsupported",
+                ]:
+                    yield block
+                    if block.get("has_children") is True:
+                        async for child in fetch_children_recursively(block):
+                            yield child
+                if block.get("type") == "child_database":
+                    async for record in self.query_database(block.get("id")):
+                        yield record
+        except APIResponseError as error:
+            if error.code == "validation_error" and "external_object" in json.loads(
+                error.body
+            ).get("message"):
+                self._logger.warning(
+                    f"Encountered external object with id: {block_id}. Skipping : {error}"
+                )
+            else:
+                raise
 
     async def fetch_by_query(self, query):
         async for document in self.async_iterate_paginated_api(
@@ -567,6 +583,16 @@ class NotionDataSource(BaseDataSource):
                     "filter": {"value": "database", "property": "object"},
                 }
 
+    def is_connected_property_block(self, page_database):
+        properties = page_database.get("properties")
+        if properties is None:
+            return False
+        for field in properties.keys():
+            if re.match(r"^Related to.*\(.*\)$", field):
+                return True
+
+        return False
+
     async def retrieve_and_process_blocks(self, query):
         block_ids_store = []
         async for page_database in self.notion_client.fetch_by_query(query=query):
@@ -576,6 +602,12 @@ class NotionDataSource(BaseDataSource):
 
             yield self._format_doc(page_database), None
             self._logger.info(f"Fetching child blocks for block {block_id}")
+
+            if self.is_connected_property_block(page_database):
+                self._logger.debug(
+                    f"Skipping children of block with id: {block_id} as not supported by API"
+                )
+                continue
 
             async for child_block in self.notion_client.fetch_child_blocks(
                 block_id=block_id

--- a/tests/sources/test_notion.py
+++ b/tests/sources/test_notion.py
@@ -864,3 +864,68 @@ async def test_original_async_iterate_paginated_api_not_called():
             ) as source:
                 async for _ in source.notion_client.query_database("database_id"):
                     assert not mock_async_iterate_paginated_api.called
+
+
+@pytest.mark.asyncio
+async def test_fetch_child_blocks_for_external_object_instance_page(caplog):
+    block_id = "block_id"
+    caplog.set_level("WARNING")
+    with patch(
+        "connectors.sources.notion.NotionClient.async_iterate_paginated_api",
+        side_effect=APIResponseError(
+            code="validation_error",
+            message="external_object_instance_page is not supported via the API",
+            response=Response(
+                status_code=400,
+                text='{"message": "external_object_instance_page is not supported via the API"}',
+            ),
+        ),
+    ):
+        async with create_source(
+            NotionDataSource, notion_secret_key="secret_key"
+        ) as source:
+            async for _ in source.notion_client.fetch_child_blocks(block_id):
+                assert (
+                    "external_object_instance_page is not supported via the API"
+                    in caplog.text
+                )
+
+
+@pytest.mark.asyncio
+async def test_is_connected_property_block():
+    mocked_connected_property_block = {
+        "object": "page",
+        "id": "12345678-1234-1234-1234-123456789012",
+        "last_edited_time": "2024-04-04T18:08:00.000Z",
+        "parent": {
+            "type": "database_id",
+            "database_id": "72ba2d00-eed1-4652-ae23-43e3d1df2e8c",
+        },
+        "properties": {
+            "Name": {
+                "id": "%20title",
+                "type": "title",
+                "title": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "to_contact.mp4",
+                        },
+                        "plain_text": "to_contact.mp4",
+                    }
+                ],
+            },
+            "Related to Google drive connected app (Google Drive File)": {
+                "id": "T%3CF%40",
+                "type": "relation",
+                "relation": [{"id": "63702908-1327-4e56-8ca9-992b2f78d782"}],
+            },
+        },
+        "url": "https://www.notion.so/to_contact-mp4-12345678123412341234123456789012",
+    }
+    async with create_source(
+        NotionDataSource, notion_secret_key="secret_key"
+    ) as source:
+        assert (
+            source.is_connected_property_block(mocked_connected_property_block) is True
+        )


### PR DESCRIPTION
## Backport

Backports the following commits from main to 8.14:

- [Notion] [Bugfix] Handle error on fetching children of external objects (https://github.com/elastic/connectors/pull/2337)
- [Bugfix] [Notion] Objects not shared with Integration or not found should not fail the sync (https://github.com/elastic/connectors/pull/2312)