### PR TITLE
[GraphQL] Rename "graphql_object_list" to "graphql_object_to_id_map"

### DIFF
--- a/docs/reference/graphql.md
+++ b/docs/reference/graphql.md
@@ -66,7 +66,7 @@ A json of key value pairs of variables used in the GraphQL query. The connector 
 
 Example: If the GraphQL query is `query getUser($id: ID!) { user(id: $id) { name } }` and the value of `graphql_variables` is `{"id": "123"}`, the final query will be `query getUser { user(id: "123") { name } }` and the connector will make a GraphQL query to the source with the modified query.
 
-#### `graphql_object_list` (required)
+#### `graphql_object_to_id_map` (required)
 
 A JSON mapping between GraphQL response objects to index and their ID fields. The connector will fetch data for each object (JSON key) and use the provided ID field (JSON value) to index the object into Elasticsearch. The connector will index all fields for each object specified in the mapping. Use a dot `(.)` notation to specify the full path from the root of the GraphQL response to the desired object.
 

--- a/tests/sources/fixtures/graphql/connector.json
+++ b/tests/sources/fixtures/graphql/connector.json
@@ -65,7 +65,7 @@
             "type": "str",
             "required": false
         },
-        "graphql_object_list": {
+        "graphql_object_to_id_map": {
             "label": "GraphQL Objects to ID mapping",
             "order": 9,
             "type": "str",

--- a/tests/sources/test_graphql.py
+++ b/tests/sources/test_graphql.py
@@ -42,14 +42,14 @@ async def create_graphql_source(
     headers=None,
     graphql_variables=None,
     graphql_query="{users {name {firstName } } }",
-    graphql_object_list='{"users": "id"}',
+    graphql_object_to_id_map='{"users": "id"}',
 ):
     async with create_source(
         GraphQLDataSource,
         http_endpoint="http://127.0.0.1:1234",
         authentication_method="none",
         graphql_query=graphql_query,
-        graphql_object_list=graphql_object_list,
+        graphql_object_to_id_map=graphql_object_to_id_map,
         headers=headers,
         graphql_variables=graphql_variables,
     ) as source:
@@ -88,7 +88,7 @@ async def create_graphql_source(
 async def test_extract_graphql_data_items(object_list, data, expected_result):
     actual_response = []
     async with create_graphql_source() as source:
-        source.graphql_client.graphql_object_list = object_list
+        source.graphql_client.graphql_object_to_id_map = object_list
         for doc in source.graphql_client.extract_graphql_data_items(data):
             actual_response.append(doc)
         assert actual_response == expected_result
@@ -244,7 +244,7 @@ async def test_fetch_data():
     actual_response = []
     async with create_graphql_source() as source:
         source.graphql_client.pagination_model = "no_pagination"
-        source.graphql_client.graphql_object_list = {"users": "id"}
+        source.graphql_client.graphql_object_to_id_map = {"users": "id"}
         source.graphql_client.post = AsyncMock(
             return_value={
                 "users": [{"id": "1", "name": {"firstName": "xyz"}, "_id": "1"}]
@@ -274,7 +274,7 @@ async def test_fetch_data_with_pagination():
     actual_response = []
     async with create_graphql_source() as source:
         source.graphql_client.pagination_model = "cursor_pagination"
-        source.graphql_client.graphql_object_list = {"users": "id"}
+        source.graphql_client.graphql_object_to_id_map = {"users": "id"}
         source.graphql_client.pagination_key = "users"
         source.graphql_client.post = AsyncMock(
             side_effect=[
@@ -307,7 +307,7 @@ async def test_fetch_data_with_pagination():
 async def test_fetch_data_without_pageinfo():
     async with create_graphql_source() as source:
         source.graphql_client.pagination_model = "cursor_pagination"
-        source.graphql_client.graphql_object_list = {"users": id}
+        source.graphql_client.graphql_object_to_id_map = {"users": id}
         source.graphql_client.post = AsyncMock(
             side_effect=[{"users": {"id": "123", "name": {"firstName": "xyz"}}}]
         )
@@ -372,7 +372,7 @@ async def test_get_docs_with_dict_id():
 @pytest.mark.asyncio
 async def test_extract_graphql_data_items_with_invalid_key():
     async with create_graphql_source() as source:
-        source.graphql_client.graphql_object_list = {"user": "id"}
+        source.graphql_client.graphql_object_to_id_map = {"user": "id"}
         data = {"users": {"namexyzid": "123"}}
         with pytest.raises(ConfigurableFieldValueError):
             for _ in source.graphql_client.extract_graphql_data_items(data):
@@ -411,7 +411,7 @@ async def test_validate_config_with_invalid_objects():
         source.graphql_client.graphql_query = (
             "query {organization {repository { issues {name}}}}"
         )
-        source.graphql_client.graphql_object_list = {
+        source.graphql_client.graphql_object_to_id_map = {
             "organization.repository.pullRequest": "id"
         }
         with pytest.raises(ConfigurableFieldValueError):
@@ -421,7 +421,7 @@ async def test_validate_config_with_invalid_objects():
 @pytest.mark.asyncio
 async def test_validate_config_with_invalid_pagination_key():
     async with create_graphql_source(
-        graphql_object_list='{"organization.repository.issues": "id"}'
+        graphql_object_to_id_map='{"organization.repository.issues": "id"}'
     ) as source:
         source.graphql_client.graphql_query = (
             "query {organization {repository { issues {id name}}}}"
@@ -435,7 +435,7 @@ async def test_validate_config_with_invalid_pagination_key():
 @pytest.mark.asyncio
 async def test_validate_config_with_missing_config_field():
     async with create_graphql_source(
-        graphql_object_list='{"organization.repository.issues": "id"}'
+        graphql_object_to_id_map='{"organization.repository.issues": "id"}'
     ) as source:
         source.graphql_client.graphql_query = (
             "query {organization {repository { issues {name}}}}"
@@ -447,7 +447,7 @@ async def test_validate_config_with_missing_config_field():
 @pytest.mark.asyncio
 async def test_validate_config_with_invalid_json():
     async with create_graphql_source(
-        graphql_object_list='{"organization.repository.issues": "id"'
+        graphql_object_to_id_map='{"organization.repository.issues": "id"'
     ) as source:
         source.graphql_client.graphql_query = (
             "query {organization {repository { issues {name}}}}"


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2420

Rename `graphql_object_list` to `graphql_object_to_id_map` for better understanding.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)
