### PR TITLE
Safely get author login for PR reviews

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -1481,11 +1481,14 @@ class GitHubDataSource(BaseDataSource):
         }
 
     def _prepare_review_doc(self, review):
+        # review.author can be None if the user was deleted, so need to be extra null-safe
+        author = review.get("author", {}) or {}
+
         return {
-            "author": review.get("author").get("login"),
+            "author": author.get("login"),
             "body": review.get("body"),
             "state": review.get("state"),
-            "comments": review.get("comments").get("nodes"),
+            "comments": review.get("comments", {}).get("nodes"),
         }
 
     async def _fetch_installations(self):

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -1305,7 +1305,7 @@ async def test_fetch_pull_requests_with_deleted_users():
                             "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
                             "nodes": [
                                 {
-                                    "author": None, # author will return None in this situation
+                                    "author": None,  # author will return None in this situation
                                     "state": "APPROVED",
                                     "body": "LGTM",
                                     "comments": {
@@ -1332,7 +1332,7 @@ async def test_fetch_pull_requests_with_deleted_users():
                 "comments": [{"body": "nice!!!"}],
             },
             {
-                "author": None, # deleted author
+                "author": None,  # deleted author
                 "body": "LGTM",
                 "state": "APPROVED",
                 "comments": [{"body": "LGTM"}],

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -1295,6 +1295,70 @@ async def test_fetch_pull_requests_with_unauthorized_exception():
 
 
 @pytest.mark.asyncio
+async def test_fetch_pull_requests_with_deleted_users():
+    async with create_github_source() as source:
+        mock_review_deleted_user = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviews": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
+                            "nodes": [
+                                {
+                                    "author": None, # author will return None in this situation
+                                    "state": "APPROVED",
+                                    "body": "LGTM",
+                                    "comments": {
+                                        "pageInfo": {
+                                            "hasNextPage": False,
+                                            "endCursor": "abcd",
+                                        },
+                                        "nodes": [{"body": "LGTM"}],
+                                    },
+                                },
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+
+        expected_pull_response_deleted_user = deepcopy(EXPECTED_PULL_RESPONSE)
+        expected_pull_response_deleted_user["reviews_comments"] = [
+            {
+                "author": "test_user",
+                "body": "add some comments",
+                "state": "COMMENTED",
+                "comments": [{"body": "nice!!!"}],
+            },
+            {
+                "author": None, # deleted author
+                "body": "LGTM",
+                "state": "APPROVED",
+                "comments": [{"body": "LGTM"}],
+            },
+        ]
+
+        with patch.object(
+            source.github_client,
+            "paginated_api_call",
+            side_effect=[
+                AsyncIterator([MOCK_RESPONSE_PULL]),
+                AsyncIterator([MOCK_COMMENTS_RESPONSE]),
+                AsyncIterator([MOCK_REVIEW_REQUESTED_RESPONSE]),
+                AsyncIterator([MOCK_LABELS_RESPONSE]),
+                AsyncIterator([MOCK_ASSIGNEE_RESPONSE]),
+                AsyncIterator([mock_review_deleted_user]),
+            ],
+        ):
+            async for pull in source._fetch_pull_requests(
+                repo_name="demo_user/demo_repo",
+                response_key=[REPOSITORY_OBJECT, "pullRequests"],
+            ):
+                assert pull == expected_pull_response_deleted_user
+
+
+@pytest.mark.asyncio
 async def test_fetch_files():
     expected_response = (
         {


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2427

Allows for cases where the PR review author is `None` to not crash the sync.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)
