### PR TITLE
Update Oracle connector to support service name

### DIFF
--- a/tests/sources/fixtures/oracle/connector.json
+++ b/tests/sources/fixtures/oracle/connector.json
@@ -42,17 +42,36 @@
                         "type": "str",
                         "value": "Password_123"
                 },
-                "database": {
-                        "label": "Database",
+                "connection_source": {
+                        "display": "dropdown",
+                        "label": "Connection Source",
+                        "options": [
+                            {"label": "SID", "value": "sid"},
+                            {"label": "Service Name", "value": "service_name"}
+                        ],
                         "order": 5,
                         "type": "str",
-                        "value": "FREE"
+                        "value": "sid"
                 },
+                "sid": {
+                        "depends_on": [{"field": "connection_source", "value": "sid"}],
+                        "label": "SID",
+                        "order": 6,
+                        "type": "str",
+                        "value": "FREE"
+                    },
+                "service_name": {
+                        "depends_on": [{"field": "connection_source", "value": "service_name"}],
+                        "label": "Service Name",
+                        "order": 7,
+                        "type": "str",
+                        "value": "FREE"
+                    },
                 "tables": {
                         "display": "textarea",
                         "label": "Comma-separated list of tables",
                         "options": [],
-                        "order": 6,
+                        "order": 8,
                         "type": "list",
                         "value": "*"
                 },
@@ -60,7 +79,7 @@
                         "default_value": 50,
                         "display": "numeric",
                         "label": "Rows fetched per request",
-                        "order": 7,
+                        "order": 9,
                         "required": false,
                         "type": "int",
                         "ui_restrictions": ["advanced"],
@@ -70,7 +89,7 @@
                         "default_value": 3,
                         "display": "numeric",
                         "label": "Retries per request",
-                        "order": 8,
+                        "order": 10,
                         "required": false,
                         "type": "int",
                         "ui_restrictions": ["advanced"],
@@ -83,7 +102,7 @@
                                 {"label": "TCP", "value": "TCP"},
                                 {"label": "TCPS", "value": "TCPS"}
                         ],
-                        "order": 9,
+                        "order": 11,
                         "type": "str",
                         "value": "TCP",
                         "ui_restrictions": ["advanced"]
@@ -91,7 +110,7 @@
                 "oracle_home": {
                         "default_value": "",
                         "label": "Path to Oracle Home",
-                        "order": 10,
+                        "order": 12,
                         "required": false,
                         "type": "str",
                         "value": "",
@@ -100,7 +119,7 @@
                 "wallet_configuration_path": {
                         "default_value": "",
                         "label": "Path to SSL Wallet configuration files",
-                        "order": 11,
+                        "order": 13,
                         "required": false,
                         "type": "str",
                         "value": "",


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2382


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->
Added the new RCF for connecting to Oracle with Service name.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

