### PR TITLE
Add action workflow for community issues

### DIFF
--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -1,0 +1,29 @@
+name: Label Community Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  run-python-script:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: python3 -m pip install aiohttp gidgethub
+
+    - name: Run Python script
+      run: python .github/workflows/scripts/label_community_issues.py
+      env:
+        ACTOR: ${{ github.actor }}
+        NUMBER: ${{ github.event.issue.number }}
+        REPO: ${{ github.repository }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/label_community_issues.py
+++ b/.github/workflows/scripts/label_community_issues.py
@@ -26,10 +26,10 @@ async def main():
         try:
             # this API returns a None response, but will raise if the user isn't a collaborator
             await gh.getitem(f"/repos/{REPO}/collaborators/{ACTOR}")
-            print(f"User is a collaborator, not applying labels.")
+            print("User is a collaborator, not applying labels.")
         except BadRequest as e:
             # if this fails we want it to be noisy, so no try/except
-            print(f"User is not a collaborator, applying labels...")
+            print("User is not a collaborator, applying labels...")
             await gh.post(f"/repos/{REPO}/issues/{NUMBER}/labels", data={"labels": LABELS})
 
 if __name__ == "__main__":

--- a/.github/workflows/scripts/label_community_issues.py
+++ b/.github/workflows/scripts/label_community_issues.py
@@ -24,14 +24,13 @@ async def main():
         print("********")
 
         try:
-            # this API returns a None response, but will raise if the user isn"t a collaborator
+            # this API returns a None response, but will raise if the user isn't a collaborator
             await gh.getitem(f"/repos/{REPO}/collaborators/{ACTOR}")
             print(f"User is a collaborator, not applying labels.")
         except BadRequest as e:
-            # user is not a collaborator; do nothing
+            # if this fails we want it to be noisy, so no try/except
             print(f"User is not a collaborator, applying labels...")
             await gh.post(f"/repos/{REPO}/issues/{NUMBER}/labels", data={"labels": LABELS})
-            return
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/.github/workflows/scripts/label_community_issues.py
+++ b/.github/workflows/scripts/label_community_issues.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import aiohttp
+import asyncio
+import os
+from gidgethub.aiohttp import GitHubAPI
+from gidgethub import BadRequest
+
+ACTOR = os.getenv("ACTOR")
+NUMBER = os.getenv("NUMBER")
+REPO = os.getenv("REPO")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+
+LABELS = ["community-driven", "needs-triage"]
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        gh = GitHubAPI(session, requester="", base_url="https://api.github.com", oauth_token=GITHUB_TOKEN)
+
+        print("********")
+        print(f"ACTOR: {ACTOR}")
+        print(f"NUMBER: {NUMBER}")
+        print(f"REPO: {REPO}")
+        print("********")
+
+        try:
+            # this API returns a None response, but will raise if the user isn"t a collaborator
+            await gh.getitem(f"/repos/{REPO}/collaborators/{ACTOR}")
+            print(f"User is a collaborator, not applying labels.")
+        except BadRequest as e:
+            # user is not a collaborator; do nothing
+            print(f"User is not a collaborator, applying labels...")
+            await gh.post(f"/repos/{REPO}/issues/{NUMBER}/labels", data={"labels": LABELS})
+            return
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Adds an action workflow to tag issues created by external contributors with the labels:

- `community-driven`
- `needs-triage`

I tested this on a personal repo https://github.com/navarone-feekery/crawler-test-static-site

Example external user issue: https://github.com/navarone-feekery/crawler-test-static-site/issues/26
Example collaborator issue: https://github.com/navarone-feekery/crawler-test-static-site/issues/24