### PR TITLE
Ensure that SSL CA is not required, is formatted correctly, and has a tooltip

### DIFF
--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -461,6 +461,9 @@ class ConfluenceDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 11,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Confluence server.",
             },
             "retry_count": {
                 "default_value": 3,

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -1187,6 +1187,9 @@ class GitHubDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 11,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Github server.",
             },
             "retry_count": {
                 "display_value": RETRIES,

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -527,6 +527,9 @@ class JiraDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 11,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Jira server.",
             },
             "retry_count": {
                 "default_value": 3,

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -154,9 +154,10 @@ class MongoDataSource(BaseDataSource):
                 "depends_on": [{"field": "ssl_enabled", "value": True}],
                 "label": "Certificate Authority (.pem)",
                 "order": 8,
-                "required": False,
-                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the MongoDB instance.",
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Mongo server.",
             },
             "tls_insecure": {
                 "display": "toggle",

--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -457,6 +457,9 @@ class MSSQLDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 11,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the MSSQL server.",
             },
             "validate_host": {
                 "display": "toggle",

--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -386,6 +386,9 @@ class MySqlDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 8,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the MySQL server.",
             },
             "fetch_size": {
                 "default_value": DEFAULT_FETCH_SIZE,

--- a/connectors/sources/opentext_documentum.py
+++ b/connectors/sources/opentext_documentum.py
@@ -276,6 +276,9 @@ class OpentextDocumentumDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 6,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Opentext Documentum server.",
             },
             "use_text_extraction_service": {
                 "display": "toggle",

--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -756,6 +756,9 @@ class OutlookDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 11,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Outlook server.",
             },
             "use_text_extraction_service": {
                 "display": "toggle",

--- a/connectors/sources/postgresql.py
+++ b/connectors/sources/postgresql.py
@@ -467,6 +467,9 @@ class PostgreSQLDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 11,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the PostgreSQL server.",
             },
         }
 

--- a/connectors/sources/sharepoint_server.py
+++ b/connectors/sources/sharepoint_server.py
@@ -496,6 +496,9 @@ class SharepointServerDataSource(BaseDataSource):
                 "label": "SSL certificate",
                 "order": 6,
                 "type": "str",
+                "required": False,
+                "display": "textarea",
+                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Sharepoint server.",
             },
             "retry_count": {
                 "default_value": RETRIES,


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/2438


This adds
```
  "required": False,
  "display": "textarea",
  "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the <service type> server.",
```

to all `ssl_ca` RCF fields for all our connectors.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)



## Related Pull Requests

* Kibana PR for native connectors: TODO
* docs PR to note optional nature: TODO

## Release Note

Allows connectors that optionally may enable SSL to not require a certificate to be specified. Previously, this was only optional for Mongodb, but all other connectors required a cert if ssl was enabled.
