### PR TITLE
[Jira] Map custom field ids with their names

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -950,8 +950,6 @@ class JiraDataSource(BaseDataSource):
             else projects_query
         )
 
-        self.custom_fields = await self.jira_client.get_jira_fields()
-
         async for issue in self.jira_client.get_issues_for_jql(jql=jql):
             await self.fetchers.put(partial(self._put_issue, issue))
             self.tasks += 1
@@ -1010,6 +1008,8 @@ class JiraDataSource(BaseDataSource):
         Yields:
             dictionary: dictionary containing meta-data of the files.
         """
+        self.custom_fields = await self.jira_client.get_jira_fields()
+
         if filtering and filtering.has_advanced_rules():
             advanced_rules = filtering.get_advanced_rules()
 

--- a/tests/sources/fixtures/jira/fixture.py
+++ b/tests/sources/fixtures/jira/fixture.py
@@ -149,5 +149,44 @@ def get_attachment_content(attachment_id):
     return io.BytesIO(bytes(fake_provider.get_html(), encoding="utf-8"))
 
 
+@app.route("/rest/api/2/field", methods=["GET"])
+def get_fields():
+    """Function to get all fields including default and custom fields from Jira"""
+    return [
+        {
+            "clauseNames": ["description"],
+            "custom": False,
+            "id": "description",
+            "name": "Description",
+            "navigable": True,
+            "orderable": True,
+            "schema": {"system": "description", "type": "string"},
+            "searchable": True,
+        },
+        {
+            "clauseNames": ["summary"],
+            "custom": True,
+            "id": "customfield_001",
+            "key": "summary",
+            "name": "Summary",
+            "navigable": True,
+            "orderable": True,
+            "schema": {"system": "summary", "type": "string"},
+            "searchable": True,
+        },
+        {
+            "clauseNames": ["author"],
+            "custom": True,
+            "id": "customfield_002",
+            "key": "author",
+            "name": "Author",
+            "navigable": True,
+            "orderable": True,
+            "schema": {"system": "author", "type": "string"},
+            "searchable": True,
+        },
+    ]
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080)

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -82,6 +82,7 @@ MOCK_ISSUE = {
         "issuerestriction": {
             "issuerestrictions": {},
         },
+        "customfield_001": "custom value",
     },
 }
 EXPECTED_ISSUE = {
@@ -102,6 +103,7 @@ EXPECTED_ISSUE = {
             }
         ],
         "issuerestriction": {"issuerestrictions": {}},
+        "Author": "custom value",
     },
 }
 
@@ -306,6 +308,19 @@ MOCK_PROJECT_ROLE_MEMBERS = {
     ],
 }
 
+MOCK_JIRA_FIELDS = [
+    {
+        "id": "summary",
+        "name": "Summary",
+        "custom": False,
+    },
+    {
+        "id": "customfield_001",
+        "name": "Author",
+        "custom": True,
+    },
+]
+
 ACCESS_CONTROL = "_allow_access_control"
 
 
@@ -373,6 +388,8 @@ def side_effect_function(url, ssl):
     if url == f"{HOST_URL}/rest/api/2/search?jql=&maxResults=100&startAt=0":
         mocked_issue_response = {"issues": [MOCK_ISSUE], "total": 101}
         return get_json_mock(mock_response=mocked_issue_response)
+    elif url == f"{HOST_URL}/rest/api/2/field":
+        return get_json_mock(mock_response=MOCK_JIRA_FIELDS)
     elif url == f"{HOST_URL}/rest/api/2/issue/TP-1":
         return get_json_mock(mock_response=MOCK_ISSUE)
     elif url == f"{HOST_URL}/rest/api/2/search?jql=&maxResults=100&startAt=100":


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/2415

Previously we're getting custom field ids in the API response, now we fetch all custom fields and mapping their names with the ids present in the response.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Notes

Maps custom fields' IDs of `issue` documents to the custom field names.