### PR TITLE
[Jira] Add support for reserved keywords as a project key in `Jira project keys` RCF

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -927,7 +927,8 @@ class JiraDataSource(BaseDataSource):
             issue (dict): Issue response to fetch the attachments
         """
         wildcard_query = ""
-        projects_query = f"project in ({','.join(self.jira_client.projects)})"
+        comma_seperated_projects = '"' + '","'.join(self.jira_client.projects) + '"'
+        projects_query = f"project in ({comma_seperated_projects})"
 
         jql = custom_query or (
             wildcard_query


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2440

Adding a support for the configured project keys that belongs to the [reserved keywords](https://confluence.atlassian.com/gsgtest/advanced-searching-815566220.html#:~:text=summary%20~%20%22%5C%5C%5Bexample%5C%5C%5D%22-,Reserved%20words,-JQL%20also%20has) in `Jira project keys` configuration fields.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally

## Release Note

Handles reserved keywords (such as `IS`, `ACCESS`, etc.) present in `Jira Projects` configuration field.