### PR TITLE
Copy config.yml from config.yml.example

### DIFF
--- a/scripts/stack/copy-config.sh
+++ b/scripts/stack/copy-config.sh
@@ -17,7 +17,7 @@ fi
 
 is_example_config=false
 if [[ "${CONFIG_PATH:-}" == "" ]]; then
-    CONFIG_PATH="$PROJECT_ROOT/config.yml"
+    CONFIG_PATH="$PROJECT_ROOT/config.yml.example"
     is_example_config=true
 fi
 

--- a/scripts/stack/copy-config.sh
+++ b/scripts/stack/copy-config.sh
@@ -17,7 +17,8 @@ fi
 
 is_example_config=false
 if [[ "${CONFIG_PATH:-}" == "" ]]; then
-    CONFIG_PATH="$PROJECT_ROOT/config.yml.example"
+    cp -n "$PROJECT_ROOT/config.yml.example" "$PROJECT_ROOT/config.yml"
+    CONFIG_PATH="$PROJECT_ROOT/config.yml"
     is_example_config=true
 fi
 

--- a/scripts/stack/run-stack.sh
+++ b/scripts/stack/run-stack.sh
@@ -58,6 +58,7 @@ fi
 if [ "${no_connectors:-}" == false ]; then
   echo "Starting Elastic Connectors..."
 
+  source ./copy-config.sh
   config_dir="$PROJECT_ROOT/scripts/stack/connectors-config"
   script_config="$config_dir/config.yml"
   if [ ! -f "$script_config" ]; then

--- a/scripts/stack/run-stack.sh
+++ b/scripts/stack/run-stack.sh
@@ -39,6 +39,8 @@ if [[ "${connectors_only}" != true ]]; then
   source $CURDIR/update-kibana-user-password.sh
 fi
 
+source ./copy-config.sh
+
 run_configurator="no"
 if [[ "${bypass_config:-}" == false ]]; then
   while true; do
@@ -50,7 +52,6 @@ if [[ "${bypass_config:-}" == false ]]; then
     esac
   done
   if [ $run_configurator == "yes" ]; then
-    source ./copy-config.sh
     source ./configure-connectors.sh
   fi
 fi
@@ -58,7 +59,6 @@ fi
 if [ "${no_connectors:-}" == false ]; then
   echo "Starting Elastic Connectors..."
 
-  source ./copy-config.sh
   config_dir="$PROJECT_ROOT/scripts/stack/connectors-config"
   script_config="$config_dir/config.yml"
   if [ ! -f "$script_config" ]; then


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/7386

This PR makes 2 changes:

1. Copy `config.yml` from `config.yml.example` instead of `config.yml` due to change introduced in #2280 
2. Run `copy-config.sh` before starting Elastic connectors

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)