### PR TITLE
[GitHub] Add author to issue and pull request docs

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -1692,10 +1692,7 @@ class GitHubDataSource(BaseDataSource):
                             self._prepare_review_doc(review=review)
                         )
                 else:
-                    if response is not None:
-                        type_obj[sample_dict[field_type]["es_field"]].extend(response)
-                    else:
-                        self._logger.info("Response was None!")
+                    type_obj[sample_dict[field_type]["es_field"]].extend(response)
 
     async def _extract_pull_request(self, pull_request, owner, repo):
         reviews = [

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -1473,7 +1473,6 @@ class GitHubDataSource(BaseDataSource):
         }
 
     def _prepare_pull_request_doc(self, pull_request, reviews):
-        author = pull_request.get("author", {}) or {}
         return {
             "_id": pull_request.pop("id"),
             "_timestamp": pull_request.pop("updatedAt"),
@@ -1483,11 +1482,9 @@ class GitHubDataSource(BaseDataSource):
             "labels_field": pull_request.get("labels", {}).get("nodes"),
             "assignees_list": pull_request.get("assignees", {}).get("nodes"),
             "requested_reviewers": pull_request.get("reviewRequests", {}).get("nodes"),
-            "author": author.get("login"),
         }
 
     def _prepare_issue_doc(self, issue):
-        author = issue.get("author", {}) or {}
         return {
             "_id": issue.pop("id"),
             "type": ObjectType.ISSUE.value,
@@ -1495,7 +1492,6 @@ class GitHubDataSource(BaseDataSource):
             "issue_comments": issue.get("comments", {}).get("nodes"),
             "labels_field": issue.get("labels", {}).get("nodes"),
             "assignees_list": issue.get("assignees", {}).get("nodes"),
-            "author": author.get("login"),
         }
 
     def _prepare_review_doc(self, review):
@@ -1763,7 +1759,6 @@ class GitHubDataSource(BaseDataSource):
             )
 
     async def _extract_issues(self, response, owner, repo, response_key):
-        self._logger.warning(response)
         for issue in nested_get_from_dict(  # pyright: ignore
             response, response_key + ["nodes"], default=[]
         ):
@@ -1806,11 +1801,9 @@ class GitHubDataSource(BaseDataSource):
                 variables=issue_variables,
                 keys=response_key,
             ):
-                self._logger.warning(response)
                 async for issue in self._extract_issues(
                     response=response, owner=owner, repo=repo, response_key=response_key
                 ):
-                    self._logger.warning(issue)
                     yield issue
         except UnauthorizedException:
             raise

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -69,6 +69,7 @@ def pull_request():
                             "body": "test pull request",
                             "state": "OPEN",
                             "mergedAt": "None",
+                            "author": "author-authorson",
                             "assignees": {
                                 "pageInfo": {"hasNextPage": True, "endCursor": "abcd"},
                                 "nodes": [{"login": "test_user"}],
@@ -275,46 +276,47 @@ MOCK_RESPONSE_REPO = [
 ]
 
 MOCK_RESPONSE_ISSUE = {
-    "data": {
-        "repository": {
-            "issues": {
-                "nodes": [
-                    {
-                        "number": 1,
-                        "url": "https://github.com/demo_user/demo_repo/issues/1",
-                        "createdAt": "2023-04-18T10:12:21Z",
-                        "closedAt": None,
-                        "title": "demo issues",
-                        "body": "demo issues test",
-                        "state": "OPEN",
-                        "id": "I_kwDOJXuc8M5jtMsK",
-                        "type": "Issue",
-                        "updatedAt": "2023-04-19T08:56:23Z",
-                        "comments": {
-                            "pageInfo": {"hasNextPage": False, "endCursor": "abcd4321"},
-                            "nodes": [
-                                {
-                                    "author": {"login": "demo_user"},
-                                    "body": "demo comments updated!!",
-                                }
-                            ],
-                        },
-                        "labels": {
-                            "pageInfo": {"hasNextPage": False, "endCursor": "abcd4321"},
-                            "nodes": [
-                                {
-                                    "name": "enhancement",
-                                    "description": "New feature or request",
-                                }
-                            ],
-                        },
-                        "assignees": {
-                            "pageInfo": {"hasNextPage": False, "endCursor": "abcd4321"},
-                            "nodes": [{"login": "demo_user"}],
-                        },
-                    }
-                ]
-            }
+    "repository": {
+        "issues": {
+            "nodes": [
+                {
+                    "number": 1,
+                    "url": "https://github.com/demo_user/demo_repo/issues/1",
+                    "createdAt": "2023-04-18T10:12:21Z",
+                    "closedAt": None,
+                    "title": "demo issues",
+                    "body": "demo issues test",
+                    "state": "OPEN",
+                    "id": "I_kwDOJXuc8M5jtMsK",
+                    "type": "Issue",
+                    "updatedAt": "2023-04-19T08:56:23Z",
+                    "author": {
+                        "login": "I'm a real user!",
+                    },
+                    "comments": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "abcd4321"},
+                        "nodes": [
+                            {
+                                "author": {"login": "demo_user"},
+                                "body": "demo comments updated!!",
+                            }
+                        ],
+                    },
+                    "labels": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "abcd4321"},
+                        "nodes": [
+                            {
+                                "name": "enhancement",
+                                "description": "New feature or request",
+                            }
+                        ],
+                    },
+                    "assignees": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "abcd4321"},
+                        "nodes": [{"login": "demo_user"}],
+                    },
+                }
+            ]
         }
     }
 }
@@ -329,6 +331,7 @@ EXPECTED_ISSUE = {
     "type": "Issue",
     "_id": "I_kwDOJXuc8M5jtMsK",
     "_timestamp": "2023-04-19T08:56:23Z",
+    "author": "I'm a real user!",
     "issue_comments": [
         {"author": {"login": "demo_user"}, "body": "demo comments updated!!"}
     ],
@@ -336,70 +339,69 @@ EXPECTED_ISSUE = {
     "assignees_list": [{"login": "demo_user"}],
 }
 MOCK_RESPONSE_PULL = {
-    "data": {
-        "repository": {
-            "pullRequests": {
-                "nodes": [
-                    {
-                        "id": "1",
-                        "updatedAt": "2023-07-03T12:24:16Z",
-                        "number": 2,
-                        "url": "https://github.com/demo_repo/demo_repo/pull/2",
-                        "createdAt": "2023-04-19T09:06:01Z",
-                        "closedAt": "None",
-                        "title": "test pull request",
-                        "body": "test pull request",
-                        "state": "OPEN",
-                        "mergedAt": "None",
-                        "assignees": {
-                            "pageInfo": {"hasNextPage": True, "endCursor": "abcd"},
-                            "nodes": [{"login": "test_user"}],
-                        },
-                        "labels": {
-                            "pageInfo": {"hasNextPage": True, "endCursor": "abcd"},
-                            "nodes": [
-                                {
-                                    "name": "bug",
-                                    "description": "Something isn't working",
-                                },
-                            ],
-                        },
-                        "reviewRequests": {
-                            "pageInfo": {"hasNextPage": True, "endCursor": "abcd1234"},
-                            "nodes": [{"requestedReviewer": {"login": "test_user"}}],
-                        },
-                        "comments": {
-                            "pageInfo": {
-                                "hasNextPage": True,
-                                "endCursor": "Y3Vyc29yOnYyOpHOXmz8gA==",
+    "repository": {
+        "pullRequests": {
+            "nodes": [
+                {
+                    "id": "1",
+                    "updatedAt": "2023-07-03T12:24:16Z",
+                    "number": 2,
+                    "url": "https://github.com/demo_repo/demo_repo/pull/2",
+                    "createdAt": "2023-04-19T09:06:01Z",
+                    "closedAt": "None",
+                    "title": "test pull request",
+                    "body": "test pull request",
+                    "state": "OPEN",
+                    "mergedAt": "None",
+                    "author": {"login": "author-authorson"},
+                    "assignees": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "abcd"},
+                        "nodes": [{"login": "test_user"}],
+                    },
+                    "labels": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "abcd"},
+                        "nodes": [
+                            {
+                                "name": "bug",
+                                "description": "Something isn't working",
                             },
-                            "nodes": [
-                                {
-                                    "author": {"login": "test_user"},
-                                    "body": "issues comments",
-                                },
-                            ],
+                        ],
+                    },
+                    "reviewRequests": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "abcd1234"},
+                        "nodes": [{"requestedReviewer": {"login": "test_user"}}],
+                    },
+                    "comments": {
+                        "pageInfo": {
+                            "hasNextPage": True,
+                            "endCursor": "Y3Vyc29yOnYyOpHOXmz8gA==",
                         },
-                        "reviews": {
-                            "pageInfo": {"hasNextPage": True, "endCursor": "abcd"},
-                            "nodes": [
-                                {
-                                    "author": {"login": "test_user"},
-                                    "state": "COMMENTED",
-                                    "body": "add some comments",
-                                    "comments": {
-                                        "pageInfo": {
-                                            "hasNextPage": False,
-                                            "endCursor": "abcd",
-                                        },
-                                        "nodes": [{"body": "nice!!!"}],
+                        "nodes": [
+                            {
+                                "author": {"login": "test_user"},
+                                "body": "issues comments",
+                            },
+                        ],
+                    },
+                    "reviews": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "abcd"},
+                        "nodes": [
+                            {
+                                "author": {"login": "test_user"},
+                                "state": "COMMENTED",
+                                "body": "add some comments",
+                                "comments": {
+                                    "pageInfo": {
+                                        "hasNextPage": False,
+                                        "endCursor": "abcd",
                                     },
+                                    "nodes": [{"body": "nice!!!"}],
                                 },
-                            ],
-                        },
-                    }
-                ]
-            }
+                            },
+                        ],
+                    },
+                }
+            ]
         }
     }
 }
@@ -415,6 +417,7 @@ EXPECTED_PULL_RESPONSE = {
     "_id": "1",
     "_timestamp": "2023-07-03T12:24:16Z",
     "type": "Pull request",
+    "author": "author-authorson",
     "issue_comments": [
         {"author": {"login": "test_user"}, "body": "issues comments"},
         {"author": {"login": "test_user"}, "body": "more_comments"},
@@ -444,86 +447,76 @@ EXPECTED_PULL_RESPONSE = {
     ],
 }
 MOCK_REVIEWS_RESPONSE = {
-    "data": {
-        "repository": {
-            "pullRequest": {
-                "reviews": {
-                    "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
-                    "nodes": [
-                        {
-                            "author": {"login": "test_user"},
-                            "state": "APPROVED",
-                            "body": "LGTM",
-                            "comments": {
-                                "pageInfo": {
-                                    "hasNextPage": False,
-                                    "endCursor": "abcd",
-                                },
-                                "nodes": [{"body": "LGTM"}],
+    "repository": {
+        "pullRequest": {
+            "reviews": {
+                "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
+                "nodes": [
+                    {
+                        "author": {"login": "test_user"},
+                        "state": "APPROVED",
+                        "body": "LGTM",
+                        "comments": {
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "endCursor": "abcd",
                             },
+                            "nodes": [{"body": "LGTM"}],
                         },
-                    ],
-                }
+                    },
+                ],
             }
         }
     }
 }
 MOCK_REVIEW_REQUESTED_RESPONSE = {
-    "data": {
-        "repository": {
-            "pullRequest": {
-                "reviewRequests": {
-                    "pageInfo": {"hasNextPage": False, "endCursor": "abcd1234"},
-                    "nodes": [{"requestedReviewer": {"login": "other_user"}}],
-                }
+    "repository": {
+        "pullRequest": {
+            "reviewRequests": {
+                "pageInfo": {"hasNextPage": False, "endCursor": "abcd1234"},
+                "nodes": [{"requestedReviewer": {"login": "other_user"}}],
             }
         }
     }
 }
 MOCK_COMMENTS_RESPONSE = {
-    "data": {
-        "repository": {
-            "pullRequest": {
-                "comments": {
-                    "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
-                    "nodes": [
-                        {
-                            "author": {"login": "test_user"},
-                            "body": "more_comments",
-                        },
-                    ],
-                }
+    "repository": {
+        "pullRequest": {
+            "comments": {
+                "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
+                "nodes": [
+                    {
+                        "author": {"login": "test_user"},
+                        "body": "more_comments",
+                    },
+                ],
             }
         }
     }
 }
 MOCK_LABELS_RESPONSE = {
-    "data": {
-        "repository": {
-            "pullRequest": {
-                "labels": {
-                    "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
-                    "nodes": [
-                        {
-                            "name": "8.8.0",
-                            "description": "8.8 Version",
-                        },
-                    ],
-                }
+    "repository": {
+        "pullRequest": {
+            "labels": {
+                "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
+                "nodes": [
+                    {
+                        "name": "8.8.0",
+                        "description": "8.8 Version",
+                    },
+                ],
             }
         }
     }
 }
 MOCK_ASSIGNEE_RESPONSE = {
-    "data": {
-        "repository": {
-            "pullRequest": {
-                "assignees": {
-                    "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
-                    "nodes": [
-                        {"login": "test_user"},
-                    ],
-                }
+    "repository": {
+        "pullRequest": {
+            "assignees": {
+                "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
+                "nodes": [
+                    {"login": "test_user"},
+                ],
             }
         }
     }
@@ -1219,25 +1212,16 @@ async def test_fetch_repos():
 @pytest.mark.asyncio
 async def test_fetch_repos_organization():
     async with create_github_source(
-        repo_type="organization", org_name="org1"
+        repo_type="organization", org_name="org_1"
     ) as source:
         source.github_client.graphql = AsyncMock(
             return_value={"data": {"viewer": {"login": "owner1"}}}
         )
-        source.org_repos = {
-            "org1/repo1": {
-                "id": "123",
-                "nameWithOwner": "org1/repo1",
-                "updatedAt": "2023-04-17T12:55:01Z",
-            }
-        }
+        source.github_client.get_org_repos = Mock(
+            side_effect=AsyncIterator([MOCK_REPO_1])
+        )
         async for repo in source._fetch_repos():
-            assert repo == {
-                "nameWithOwner": "org1/repo1",
-                "_id": "123",
-                "_timestamp": "2023-04-17T12:55:01Z",
-                "type": "Repository",
-            }
+            assert repo == MOCK_REPO_1_DOC
 
 
 @pytest.mark.asyncio
@@ -1383,26 +1367,24 @@ async def test_fetch_pull_requests_with_unauthorized_exception():
 async def test_fetch_pull_requests_with_deleted_users():
     async with create_github_source() as source:
         mock_review_deleted_user = {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "reviews": {
-                            "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
-                            "nodes": [
-                                {
-                                    "author": None,  # author will return None in this situation
-                                    "state": "APPROVED",
-                                    "body": "LGTM",
-                                    "comments": {
-                                        "pageInfo": {
-                                            "hasNextPage": False,
-                                            "endCursor": "abcd",
-                                        },
-                                        "nodes": [{"body": "LGTM"}],
+            "repository": {
+                "pullRequest": {
+                    "reviews": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": "abcd"},
+                        "nodes": [
+                            {
+                                "author": None,  # author will return None in this situation
+                                "state": "APPROVED",
+                                "body": "LGTM",
+                                "comments": {
+                                    "pageInfo": {
+                                        "hasNextPage": False,
+                                        "endCursor": "abcd",
                                     },
+                                    "nodes": [{"body": "LGTM"}],
                                 },
-                            ],
-                        }
+                            },
+                        ],
                     }
                 }
             }

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -69,7 +69,9 @@ def pull_request():
                             "body": "test pull request",
                             "state": "OPEN",
                             "mergedAt": "None",
-                            "author": "author-authorson",
+                            "author": {
+                                "login": "author-authorson",
+                            },
                             "assignees": {
                                 "pageInfo": {"hasNextPage": True, "endCursor": "abcd"},
                                 "nodes": [{"login": "test_user"}],
@@ -291,7 +293,7 @@ MOCK_RESPONSE_ISSUE = {
                     "type": "Issue",
                     "updatedAt": "2023-04-19T08:56:23Z",
                     "author": {
-                        "login": "I'm a real user!",
+                        "login": "author-mac-author",
                     },
                     "comments": {
                         "pageInfo": {"hasNextPage": False, "endCursor": "abcd4321"},
@@ -331,7 +333,7 @@ EXPECTED_ISSUE = {
     "type": "Issue",
     "_id": "I_kwDOJXuc8M5jtMsK",
     "_timestamp": "2023-04-19T08:56:23Z",
-    "author": "I'm a real user!",
+    "author": {"login": "author-mac-author"},
     "issue_comments": [
         {"author": {"login": "demo_user"}, "body": "demo comments updated!!"}
     ],
@@ -417,7 +419,9 @@ EXPECTED_PULL_RESPONSE = {
     "_id": "1",
     "_timestamp": "2023-07-03T12:24:16Z",
     "type": "Pull request",
-    "author": "author-authorson",
+    "author": {
+        "login": "author-authorson",
+    },
     "issue_comments": [
         {"author": {"login": "test_user"}, "body": "issues comments"},
         {"author": {"login": "test_user"}, "body": "more_comments"},


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2451

The author is missing from docs of types `issue` and `pull_request`. This change adds `{ "login": "<name>" }` to the `author` fields for these docs.
I considered directly adding `author.login` to the `author` field as a text-type, but I thought that might add unnecessary complexity if we want to add more `author.x` keys in the future.

Also doing this change exposed some tests that didn't work as expected for this source, so I also fixed those up.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)
