### PR TITLE
Fix concurrent scheduling

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -202,7 +202,7 @@ class JobSchedulingService(BaseService):
 
             if (
                 last_sync_scheduled_at is not None
-                and last_sync_scheduled_at > this_wake_up_time
+                and last_sync_scheduled_at > last_wake_up_time
             ):
                 connector.log_debug(
                     f"A scheduled '{job_type_value}' sync is created by another connector instance, skipping..."

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -200,6 +200,8 @@ class JobSchedulingService(BaseService):
                 job_type
             )
 
+            self.logger.debug(f"Last sync was scheduled at {last_sync_scheduled_at}")
+
             if (
                 last_sync_scheduled_at is not None
                 and last_sync_scheduled_at > last_wake_up_time


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2351

While fixing a bug with jobs not being scheduled, I've broken concurrent scheduling. This PR aims to fix it.

Current scheduling logic is to look back when scheduling a job:

Let's say that connector is set up to schedule syncs every 15 minutes, so syncs will happen at minutes XX:00, XX:15, XX:30, XX:45 of every hour.

Connector wakes up every 30 seconds and checks whether sync should be started.

Let's simulate what happens from when service was started.

Service wakes up at 12:14:45. It sees that it just started, so it does not schedule anything.
Next time it wakes up at 12:15:16 (1 second is just arbitrary loop lag here). It checks when the sync should have been started by taking first wake up time (12:14:45) and running it against a cron definition - it will be 12:15:00. Service looks back at the period from last wake up till now (12:14:45 -> 12:15:16) and sees that 12:15:00 fits the interval. That signals that sync should start.

The bug was that when checking concurrency, service was checking whether the sync was scheduled from current wake up time (e.g. `datetime.now()`) rather than last time sync woke up.

To check the logic we can wrap it in these words:

Before the bug it was "I just woke up, has anyone already scheduled a job of this type since now? If so, I need to skip"
After it's "Since I woke up last time, has anyone already scheduled a job of this type? If so, I need to skip"

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description=
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)=

## Release Note

Fixed an issue with multiple sync jobs created by scheduler when running on multi-az deployments.
