### PR TITLE
Upgrade motor and pymongo[srv]

### DIFF
--- a/requirements/aarch64.txt
+++ b/requirements/aarch64.txt
@@ -4,6 +4,6 @@
 aiomysql==0.0.22
 aioboto3==10.3.0
 pymongo==4.6.3
-motor==2.5.1
+motor==3.4.0
 smbprotocol==1.9.0
-pymongo[srv]==3.13.0
+pymongo[srv]==4.6.3

--- a/requirements/arm64.txt
+++ b/requirements/arm64.txt
@@ -3,4 +3,4 @@
 -r aarch64.txt
 
 SQLAlchemy[asyncio]==2.0.1
-pymongo[srv]==3.13.0
+pymongo[srv]==4.6.3

--- a/requirements/x86_64.txt
+++ b/requirements/x86_64.txt
@@ -3,6 +3,6 @@
 
 aiomysql==0.1.1
 pymongo==4.6.3
-motor==3.0.0
+motor==3.4.0
 aioboto3==10.3.0
 smbprotocol==1.9.0


### PR DESCRIPTION
Previous version bump in [Bump pymongo from 3.13.0 to 4.6.3 in /requirements #2474](https://github.com/elastic/connectors/pull/2474) broke installation as dependent packages were not upgraded. Weirdly, tests did not catch this.

This PR upgrades relevant mongodb libraries to latest