### PR TITLE
Use 8.3 mysql docker image for ftest

### DIFF
--- a/tests/sources/fixtures/mysql/docker-compose.yml
+++ b/tests/sources/fixtures/mysql/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   mysql:
     container_name: mysql
-    image: mysql:latest
+    image: mysql:8.3
     environment:
       MYSQL_ROOT_PASSWORD: changeme
     command: --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
Functional tests for MySQL started failing due to new image of mysql released. New image seems to have plugin changes and some of our settings that we use (namely, auth) are done differently.

For now let's just pin MySQL version we use for testing (does not affect connector, affects only functional tests).