### PR TITLE
Fix id logging in basic filtering rules

### DIFF
--- a/connectors/filtering/basic_rule.py
+++ b/connectors/filtering/basic_rule.py
@@ -138,7 +138,7 @@ class BasicRuleEngine:
 
             if rule.matches(document):
                 logger.debug(
-                    f"Document (id: '{document.get('_id')}') matched basic rule (id: '{rule.id_}'). Document will be {rule.policy.value}d"
+                    f"Document (id: '{document.get('id')}') matched basic rule (id: '{rule.id_}'). Document will be {rule.policy.value}d"
                 )
 
                 self.rules_match_stats.setdefault(
@@ -151,7 +151,7 @@ class BasicRuleEngine:
         # default behavior: ingest document, if no rule matches ("default rule")
         self.rules_match_stats[BasicRule.DEFAULT_RULE_ID] += 1
         logger.debug(
-            f"Document (id: '{document.get('_id')}') didn't match any basic rule. Document will be included"
+            f"Document (id: '{document.get('id')}') didn't match any basic rule. Document will be included"
         )
         return True
 


### PR DESCRIPTION
Basic sync rules do not output document ids because they try to access it by `_id`, but documents already have their ids in `id` field.

This happens because of the [following code](https://github.com/elastic/connectors/blob/main/connectors/es/sink.py#L545-L551): 

```
                doc_id = doc["id"] = doc.pop("_id")

                if self.basic_rule_engine and not self.basic_rule_engine.should_ingest(
                    doc
                ):
                    self.counters.increment((DOCS_FILTERED))
                    continue
```

As you can see, before basic rule engine checks the document, it's `_id` is removed from the document and written into `id`.

Before the change:

```
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
[FMWK][13:18:38][DEBUG] Document (id: 'None') didn't match any basic rule. Document will be included
```

After:

```
[FMWK][13:21:01][DEBUG] Document (id: '4467174') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '457829') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '746088') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '7596078') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '7686940') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '7901546') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '7926712') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '32037744') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '32165831') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '32178403') didn't match any basic rule. Document will be included
[FMWK][13:21:01][DEBUG] Document (id: '32180516') didn't match any basic rule. Document will be included
```

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Fix basic rule debug logging not displaying document ids properly.