### PR TITLE
[Jira] show custom fields seperately

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -903,7 +903,7 @@ class JiraDataSource(BaseDataSource):
                 "Key": issue_metadata.get("key"),
                 "Type": response_fields.get("issuetype", {}).get("name"),
                 "Issue": response_fields,
-                "Custom Fields": response_custom_fields,
+                "Custom_Fields": response_custom_fields,
             }
 
             if restrictions := [

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -416,13 +416,13 @@ class JiraClient:
         await anext(self.api_call(url_name=PING))
 
     async def get_jira_fields(self):
-        response = await anext(self.api_call(url_name=ALL_FIELDS))
-        jira_fields = await response.json()
-        return {
-            field["id"]: field["name"]
-            for field in jira_fields
-            if field["custom"] is True
-        }
+        async for response in self.api_call(url_name=ALL_FIELDS):
+            jira_fields = await response.json()
+            yield {
+                field["id"]: field["name"]
+                for field in jira_fields
+                if field["custom"] is True
+            }
 
 
 class JiraDataSource(BaseDataSource):
@@ -1009,7 +1009,7 @@ class JiraDataSource(BaseDataSource):
         Yields:
             dictionary: dictionary containing meta-data of the files.
         """
-        self.custom_fields = await self.jira_client.get_jira_fields()
+        self.custom_fields = await anext(self.jira_client.get_jira_fields())
 
         if filtering and filtering.has_advanced_rules():
             advanced_rules = filtering.get_advanced_rules()

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -896,7 +896,6 @@ class JiraDataSource(BaseDataSource):
             for k in self.custom_fields.keys():
                 if k in response_fields:
                     del response_fields[k]
-            
 
             document = {
                 "_id": f"{response_fields.get('project', {}).get('name')}-{issue_metadata.get('key')}",
@@ -904,9 +903,9 @@ class JiraDataSource(BaseDataSource):
                 "Key": issue_metadata.get("key"),
                 "Type": response_fields.get("issuetype", {}).get("name"),
                 "Issue": response_fields,
-                "Custom Fields": response_custom_fields
+                "Custom Fields": response_custom_fields,
             }
-            
+
             if restrictions := [
                 restriction.get("restrictionValue")
                 for restriction in response_fields.get("issuerestriction", {})

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -103,8 +103,8 @@ EXPECTED_ISSUE = {
             }
         ],
         "issuerestriction": {"issuerestrictions": {}},
-        "Author": "custom value",
     },
+    "Custom Fields": {"Author": "custom value"}
 }
 
 MOCK_ISSUE_TYPE_BUG = {
@@ -156,6 +156,7 @@ EXPECTED_ISSUE_TYPE_BUG = {
             }
         },
     },
+    "Custom Fields": {}
 }
 
 EXPECTED_ATTACHMENT_TYPE_BUG = {

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -322,7 +322,7 @@ MOCK_JIRA_FIELDS = [
     },
 ]
 
-EXPECTED_CUSTOM_FIELDS = {'customfield_001': 'Author'}
+EXPECTED_CUSTOM_FIELDS = {"customfield_001": "Author"}
 
 ACCESS_CONTROL = "_allow_access_control"
 

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -104,7 +104,7 @@ EXPECTED_ISSUE = {
         ],
         "issuerestriction": {"issuerestrictions": {}},
     },
-    "Custom Fields": {"Author": "custom value"},
+    "Custom_Fields": {"Author": "custom value"},
 }
 
 MOCK_ISSUE_TYPE_BUG = {
@@ -156,7 +156,7 @@ EXPECTED_ISSUE_TYPE_BUG = {
             }
         },
     },
-    "Custom Fields": {},
+    "Custom_Fields": {},
 }
 
 EXPECTED_ATTACHMENT_TYPE_BUG = {
@@ -321,6 +321,8 @@ MOCK_JIRA_FIELDS = [
         "custom": True,
     },
 ]
+
+EXPECTED_CUSTOM_FIELDS = {'customfield_001': 'Author'}
 
 ACCESS_CONTROL = "_allow_access_control"
 
@@ -804,6 +806,14 @@ async def test_put_issue():
         with patch("aiohttp.ClientSession.get", side_effect=side_effect_function):
             await source._put_issue(issue=MOCK_ISSUE)
             assert source.queue.qsize() == 3
+
+
+@pytest.mark.asyncio
+async def test_get_custom_fields():
+    async with create_jira_source() as source:
+        with patch("aiohttp.ClientSession.get", side_effect=side_effect_function):
+            custom_fields = await anext(source.jira_client.get_jira_fields())
+            assert custom_fields == EXPECTED_CUSTOM_FIELDS
 
 
 @pytest.mark.asyncio

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -104,7 +104,7 @@ EXPECTED_ISSUE = {
         ],
         "issuerestriction": {"issuerestrictions": {}},
     },
-    "Custom Fields": {"Author": "custom value"}
+    "Custom Fields": {"Author": "custom value"},
 }
 
 MOCK_ISSUE_TYPE_BUG = {
@@ -156,7 +156,7 @@ EXPECTED_ISSUE_TYPE_BUG = {
             }
         },
     },
-    "Custom Fields": {}
+    "Custom Fields": {},
 }
 
 EXPECTED_ATTACHMENT_TYPE_BUG = {


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2415

This PR has the following changes:
- converting `get_jira_fields` method from coroutine to generator
- adding a new field in ingestion document for showing custom fields

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Adds a new field for custom field. The elasticsearch issue document will look like as follows:
```python
{
    "id": <id>,
    "key": <key>,
    "Issues": <issues>,
    "Custom_Fields": <customFields>,
    ...
}
``` 
