### PR TITLE
[Jira] Handle empty response when status code is 200

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -249,7 +249,7 @@ class JiraClient:
                     ssl=self.ssl_ctx,
                 ) as response:
                     if response.content_length == 0:
-                        msg = "The response body is empty"
+                        msg = f"The response body is empty for url: {url}"
                         raise EmptyResponseError(msg)
                     yield response
                     break

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -249,7 +249,8 @@ class JiraClient:
                     ssl=self.ssl_ctx,
                 ) as response:
                     if response.content_length == 0:
-                        raise EmptyResponseError("The response body is empty")
+                        msg = "The response body is empty"
+                        raise EmptyResponseError(msg)
                     yield response
                     break
             except ServerConnectionError:

--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -105,6 +105,12 @@ class InvalidJiraDataSourceTypeError(ValueError):
     pass
 
 
+class EmptyResponseError(Exception):
+    """Exception raised when the API response is empty."""
+
+    pass
+
+
 class JiraClient:
     """Jira client to handle API calls made to Jira"""
 
@@ -242,6 +248,8 @@ class JiraClient:
                     url=url,
                     ssl=self.ssl_ctx,
                 ) as response:
+                    if response.content_length == 0:
+                        raise EmptyResponseError("The response body is empty")
                     yield response
                     break
             except ServerConnectionError:

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -23,6 +23,7 @@ from connectors.sources.jira import (
     JIRA_CLOUD,
     JIRA_DATA_CENTER,
     JIRA_SERVER,
+    EmptyResponseError,
     InternalServerError,
     InvalidJiraDataSourceTypeError,
     JiraClient,
@@ -498,6 +499,24 @@ async def test_api_call_when_server_is_down():
             side_effect=aiohttp.ServerDisconnectedError("Something went wrong"),
         ):
             with pytest.raises(aiohttp.ServerDisconnectedError):
+                await anext(source.jira_client.api_call(url_name="ping"))
+
+
+@pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+async def test_api_call_with_empty_response():
+    """Tests the api_call function when response is empty."""
+
+    async with create_jira_source() as source:
+        empty_response_mock = AsyncMock()
+        empty_response_mock.__aenter__.return_value.content_length = 0
+
+        with patch.object(
+            aiohttp.ClientSession,
+            "get",
+            return_value=empty_response_mock
+        ):
+            with pytest.raises(EmptyResponseError):
                 await anext(source.jira_client.api_call(url_name="ping"))
 
 

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -512,9 +512,7 @@ async def test_api_call_with_empty_response():
         empty_response_mock.__aenter__.return_value.content_length = 0
 
         with patch.object(
-            aiohttp.ClientSession,
-            "get",
-            return_value=empty_response_mock
+            aiohttp.ClientSession, "get", return_value=empty_response_mock
         ):
             with pytest.raises(EmptyResponseError):
                 await anext(source.jira_client.api_call(url_name="ping"))


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/2480

Raise EmptyResponseError if the response body is empty when the status code is 200.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
