### PR TITLE
[GitHub] Raising 403 exception

### DIFF
--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -829,7 +829,7 @@ class GitHubClient:
                 msg = "Your Github token is either expired or revoked. Please check again."
                 raise UnauthorizedException(msg) from exception
             elif exception.status == FORBIDDEN:
-                msg = f"Provided GitHub token does not have the necessary permissions to perform the request for the URL: {url} and query: {query}."
+                msg = f"Provided GitHub token does not have the necessary permissions to perform the request for the URL: {resource}."
                 raise ForbiddenException(msg) from exception
             else:
                 raise

--- a/connectors/sources/github.py
+++ b/connectors/sources/github.py
@@ -792,7 +792,7 @@ class GitHubClient:
             if self.get_rate_limit_encountered(exception.status_code, exception):
                 await self._put_to_sleep(resource_type="graphql")
             elif exception.status == FORBIDDEN:
-                msg = "Provided GitHub token does not have the necessary permissions to perform the request."
+                msg = f"Provided GitHub token does not have the necessary permissions to perform the request for the URL: {url} and query: {query}."
                 raise ForbiddenException(msg) from exception
         except Exception:
             raise
@@ -829,7 +829,7 @@ class GitHubClient:
                 msg = "Your Github token is either expired or revoked. Please check again."
                 raise UnauthorizedException(msg) from exception
             elif exception.status == FORBIDDEN:
-                msg = "Provided GitHub token does not have the necessary permissions to perform the request."
+                msg = f"Provided GitHub token does not have the necessary permissions to perform the request for the URL: {url} and query: {query}."
                 raise ForbiddenException(msg) from exception
             else:
                 raise

--- a/tests/sources/test_github.py
+++ b/tests/sources/test_github.py
@@ -21,6 +21,7 @@ from connectors.sources.github import (
     GITHUB_APP,
     PERSONAL_ACCESS_TOKEN,
     REPOSITORY_OBJECT,
+    ForbiddenException,
     GitHubAdvancedRulesValidator,
     GitHubDataSource,
     UnauthorizedException,
@@ -1253,10 +1254,14 @@ async def test_fetch_repos_when_user_repos_is_available():
 
 
 @pytest.mark.asyncio
-async def test_fetch_repos_with_unauthorized_exception():
+@pytest.mark.parametrize(
+    "exception",
+    [UnauthorizedException, ForbiddenException],
+)
+async def test_fetch_repos_with_client_exception(exception):
     async with create_github_source() as source:
-        source.github_client.graphql = Mock(side_effect=UnauthorizedException())
-        with pytest.raises(UnauthorizedException):
+        source.github_client.graphql = Mock(side_effect=exception())
+        with pytest.raises(exception):
             async for _ in source._fetch_repos():
                 pass
 
@@ -1322,10 +1327,14 @@ async def test_fetch_issues():
 
 
 @pytest.mark.asyncio
-async def test_fetch_issues_with_unauthorized_exception():
+@pytest.mark.parametrize(
+    "exception",
+    [UnauthorizedException, ForbiddenException],
+)
+async def test_fetch_issues_with_client_exception(exception):
     async with create_github_source() as source:
-        source.github_client.graphql = Mock(side_effect=UnauthorizedException())
-        with pytest.raises(UnauthorizedException):
+        source.github_client.graphql = Mock(side_effect=exception())
+        with pytest.raises(exception):
             async for _ in source._fetch_issues(
                 repo_name="demo_user/demo_repo",
                 response_key=[REPOSITORY_OBJECT, "issues"],
@@ -1356,10 +1365,14 @@ async def test_fetch_pull_requests():
 
 
 @pytest.mark.asyncio
-async def test_fetch_pull_requests_with_unauthorized_exception():
+@pytest.mark.parametrize(
+    "exception",
+    [UnauthorizedException, ForbiddenException],
+)
+async def test_fetch_pull_requests_with_client_exception(exception):
     async with create_github_source() as source:
-        source.github_client.graphql = Mock(side_effect=UnauthorizedException())
-        with pytest.raises(UnauthorizedException):
+        source.github_client.graphql = Mock(side_effect=exception())
+        with pytest.raises(exception):
             async for _ in source._fetch_pull_requests(
                 repo_name="demo_user/demo_repo",
                 response_key=[REPOSITORY_OBJECT, "pullRequests"],


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2397

Raising 403 exception same as unauthorized exception in Github

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

## Release Note

Raises 403 as ForbiddenException in GitHub connector. Previously, the connector skipped the 403 status code.