### PR TITLE
Support serverless in index list command

### DIFF
--- a/connectors/cli/index.py
+++ b/connectors/cli/index.py
@@ -17,7 +17,7 @@ class Index:
         self.connectors_index = ConnectorIndex(self.elastic_config)
 
     def list_indices(self):
-        return asyncio.run(self.__list_indices())["indices"]
+        return asyncio.run(self.__list_indices())
 
     def clean(self, index_name):
         return asyncio.run(self.__clean_index(index_name))

--- a/connectors/cli/index.py
+++ b/connectors/cli/index.py
@@ -36,6 +36,9 @@ class Index:
         try:
             return await self.cli_client.list_indices()
         except ApiError as e:
+            # If the API is not available, we are in serverless mode
+            if e.error == "api_not_available_exception":
+                return await self.cli_client.list_indices_serverless()
             raise e
         finally:
             await self.__close()

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -406,7 +406,7 @@ def list_indices(obj):
     for index in indices:
         formatted_index = [
             click.style(index, fg="white"),
-            click.style(indices[index]["primaries"]["docs"]["count"]),
+            click.style(indices[index]["docs_count"], fg="white"),
         ]
         table_rows.append(formatted_index)
 

--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -406,7 +406,7 @@ def list_indices(obj):
     for index in indices:
         formatted_index = [
             click.style(index, fg="white"),
-            click.style(indices[index]["docs_count"], fg="white"),
+            click.style(indices[index].get("docs_count", "unknown"), fg="white"),
         ]
         table_rows.append(formatted_index)
 

--- a/connectors/es/management_client.py
+++ b/connectors/es/management_client.py
@@ -6,6 +6,7 @@
 
 from functools import partial
 
+from elasticsearch import ApiError
 from elasticsearch import (
     NotFoundError as ElasticNotFoundError,
 )
@@ -14,7 +15,6 @@ from elasticsearch.helpers import async_scan
 from connectors.es.client import ESClient
 from connectors.es.settings import TIMESTAMP_FIELD, Mappings, Settings
 from connectors.logger import logger
-from elasticsearch import ApiError
 
 
 class ESManagementClient(ESClient):
@@ -196,7 +196,7 @@ class ESManagementClient(ESClient):
         )
 
         for index in response["indices"].items():
-            indices[index[0]] = { "docs_count": index[1]["primaries"]["docs"]["count"] }
+            indices[index[0]] = {"docs_count": index[1]["primaries"]["docs"]["count"]}
 
         return indices
 

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -542,7 +542,7 @@ def test_index_list_no_indexes():
 
 def test_index_list_one_index():
     runner = CliRunner()
-    indices = {"indices": {"test_index": {"primaries": {"docs": {"count": 10}}}}}
+    indices = {"test_index": {"docs_count": 10}}
 
     with patch(
         "connectors.es.cli_client.CLIClient.list_indices",

--- a/tests/test_connectors_cli.py
+++ b/tests/test_connectors_cli.py
@@ -554,6 +554,26 @@ def test_index_list_one_index():
     assert "test_index" in result.output
 
 
+def test_index_list_one_index_in_serverless():
+    runner = CliRunner()
+    indices = {"test_index": {"docs_count": 10}}
+
+    with patch(
+        "connectors.es.cli_client.CLIClient.list_indices"
+    ) as mocked_list_indices:
+        mocked_list_indices.side_effect = ApiError(
+            "api_not_available_exception", meta="meta", body="error"
+        )
+        with patch(
+            "connectors.es.cli_client.CLIClient.list_indices_serverless",
+            AsyncMock(return_value=indices),
+        ):
+            result = runner.invoke(cli, ["index", "list"])
+
+    assert result.exit_code == 0
+    assert "test_index" in result.output
+
+
 @patch("click.confirm", MagicMock(return_value=True))
 def test_index_clean():
     runner = CliRunner()


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/7441

`GET _stats` API isn't available in Elasticsearch serverless so this PR will introduce a workaround for `./bin/connectors index list` command. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

