### PR TITLE
Update setuptools package on installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ config.yml:
 bin/python: config.yml
 	$(PYTHON) -m venv .
 	bin/pip install --upgrade pip
+	bin/pip install --upgrade setuptools
 
 install: bin/python bin/elastic-ingest
 


### PR DESCRIPTION
Part of security hardening: we need to upgrade `setuptools` on installation. We don't directly install `setuptools`, we get it as a part of `venv` distribution.