### PR TITLE
[8.14][Jira] Handle empty response when status code is 200 (#2506)

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -103,6 +103,12 @@ class InvalidJiraDataSourceTypeError(ValueError):
     pass
 
 
+class EmptyResponseError(Exception):
+    """Exception raised when the API response is empty."""
+
+    pass
+
+
 class JiraClient:
     """Jira client to handle API calls made to Jira"""
 
@@ -240,6 +246,9 @@ class JiraClient:
                     url=url,
                     ssl=self.ssl_ctx,
                 ) as response:
+                    if response.content_length == 0:
+                        msg = f"The response body is empty for url: {url}"
+                        raise EmptyResponseError(msg)
                     yield response
                     break
             except ServerConnectionError:

--- a/tests/sources/test_jira.py
+++ b/tests/sources/test_jira.py
@@ -23,6 +23,7 @@ from connectors.sources.jira import (
     JIRA_CLOUD,
     JIRA_DATA_CENTER,
     JIRA_SERVER,
+    EmptyResponseError,
     InternalServerError,
     InvalidJiraDataSourceTypeError,
     JiraClient,
@@ -481,6 +482,22 @@ async def test_api_call_when_server_is_down():
             side_effect=aiohttp.ServerDisconnectedError("Something went wrong"),
         ):
             with pytest.raises(aiohttp.ServerDisconnectedError):
+                await anext(source.jira_client.api_call(url_name="ping"))
+
+
+@pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
+async def test_api_call_with_empty_response():
+    """Tests the api_call function when response is empty."""
+
+    async with create_jira_source() as source:
+        empty_response_mock = AsyncMock()
+        empty_response_mock.__aenter__.return_value.content_length = 0
+
+        with patch.object(
+            aiohttp.ClientSession, "get", return_value=empty_response_mock
+        ):
+            with pytest.raises(EmptyResponseError):
                 await anext(source.jira_client.api_call(url_name="ping"))
 
 


### PR DESCRIPTION
Backports the following commits to 8.14:
- [Jira] Handle empty response when status code is 200 #2506