### PR TITLE
[Confluence] Fix flaky test case

### DIFF
--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -218,17 +218,19 @@ class ConfluenceClient:
             response: Client response
         """
         self._logger.debug(f"Making a GET call for url: {url}")
-        try:
-            async with self._get_session().get(
-                url=url,
-                ssl=self.ssl_ctx,
-            ) as response:
-                yield response
-        except ServerDisconnectedError:
-            await self.close_session()
-            raise
-        except ClientResponseError as exception:
-            await self._handle_client_errors(url=url, exception=exception)
+        while True:
+            try:
+                async with self._get_session().get(
+                    url=url,
+                    ssl=self.ssl_ctx,
+                ) as response:
+                    yield response
+                    break
+            except ServerDisconnectedError:
+                await self.close_session()
+                raise
+            except ClientResponseError as exception:
+                await self._handle_client_errors(url=url, exception=exception)
 
     async def paginated_api_call(self, url_name, **url_kwargs):
         """Make a paginated API call for Confluence objects using the passed url_name.

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -218,19 +218,17 @@ class ConfluenceClient:
             response: Client response
         """
         self._logger.debug(f"Making a GET call for url: {url}")
-        while True:
-            try:
-                async with self._get_session().get(
-                    url=url,
-                    ssl=self.ssl_ctx,
-                ) as response:
-                    yield response
-                    break
-            except ServerDisconnectedError:
-                await self.close_session()
-                raise
-            except ClientResponseError as exception:
-                await self._handle_client_errors(url=url, exception=exception)
+        try:
+            async with self._get_session().get(
+                url=url,
+                ssl=self.ssl_ctx,
+            ) as response:
+                yield response
+        except ServerDisconnectedError:
+            await self.close_session()
+            raise
+        except ClientResponseError as exception:
+            await self._handle_client_errors(url=url, exception=exception)
 
     async def paginated_api_call(self, url_name, **url_kwargs):
         """Make a paginated API call for Confluence objects using the passed url_name.

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -723,6 +723,7 @@ async def test_get_with_429_status_without_retry_after_header():
     payload = {"value": "Test rate limit"}
 
     retried_response.__aenter__ = AsyncMock(return_value=JSONAsyncMock(payload))
+    retried_response.__aexit__ = AsyncMock(return_value=None)
     with patch("connectors.sources.confluence.DEFAULT_RETRY_SECONDS", 0):
         async with create_confluence_source() as source:
             with patch(


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2531

Flaky test failures had following error:  `async generator raised StopIteration`.  To fix it, this PR makes sure that __aexit__ is defined for the mock to simulate the full async context manager protocol.
