### PR TITLE
[Box] Fix end signal not enqueued

### DIFF
--- a/connectors/sources/box.py
+++ b/connectors/sources/box.py
@@ -340,6 +340,7 @@ class BoxDataSource(BaseDataSource):
                     )
                 elif folder_entry.get("type") == "folder":
                     await self.queue.put((doc, None))
+                    self.tasks += 1
                     await self.fetchers.put(
                         partial(
                             self._fetch,
@@ -347,12 +348,13 @@ class BoxDataSource(BaseDataSource):
                             user_id=user_id,
                         )
                     )
-                    self.tasks += 1
-            await self.queue.put(FINISHED)
         except Exception as exception:
             self._logger.info(
                 f"Something went wrong while fetching data from the folder ID: {doc_id}. Error: {exception}"
             )
+            raise
+        finally:
+            await self.queue.put(FINISHED)
 
     async def _get_document_with_content(self, url, attachment_name, document, user_id):
         file_data = await self.client.get(


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2559

Following changes are included in this PR:

- Ensure end-signals are put to queue even if error is encountered, in all relevant places.

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)
