### PR TITLE
Implement feature flag for Elasticsearch API + use for connector heartbeat

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -151,6 +151,13 @@
 ##    This will be logged on 'DEBUG' log level. Note: this depends on the service.log_level, not elasticsearch.log_level
 #elasticsearch.bulk.enable_operations_logging: false
 #
+## ------------------------------- Elasticsearch: Experimental ------------------------
+#
+##  Experimental configuration options for Elasticsearch interactions.
+#
+#
+##  Enable usage of Connectors API instead of calling connectors indices directly
+#elasticsearch.feature_use_connectors_api: false
 ## ------------------------------- Service ----------------------------------
 #
 ##  Connector service/framework related configurations

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -78,6 +78,7 @@ def _default_config():
             "initial_backoff_duration": 1,
             "backoff_multiplier": 2,
             "log_level": "info",
+            "feature_use_connectors_api": False
         },
         "service": {
             "idling": 30,

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -78,7 +78,7 @@ def _default_config():
             "initial_backoff_duration": 1,
             "backoff_multiplier": 2,
             "log_level": "info",
-            "feature_use_connectors_api": False
+            "feature_use_connectors_api": False,
         },
         "service": {
             "idling": 30,

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -16,12 +16,14 @@ DEFAULT_PAGE_SIZE = 100
 class DocumentNotFoundError(Exception):
     pass
 
+
 class TemporaryConnectorApiWrapper(ESClient):
     """Temporary class to wrap calls to Connectors API.
 
     When connectors API becomes part of official client
     this class will be removed.
     """
+
     def __init__(self, elastic_config):
         super().__init__(elastic_config)
 
@@ -29,8 +31,9 @@ class TemporaryConnectorApiWrapper(ESClient):
         await self.client.perform_request(
             "PUT",
             f"/_connector/{connector_id}/_check_in",
-            headers = {"accept": "application/json"}
+            headers={"accept": "application/json"},
         )
+
 
 class ESApi(ESClient):
     def __init__(self, elastic_config):
@@ -41,6 +44,7 @@ class ESApi(ESClient):
         await self._retrier.execute_with_retry(
             partial(self._api_wrapper.connector_check_in, connector_id)
         )
+
 
 class ESIndex(ESClient):
     """

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -16,6 +16,31 @@ DEFAULT_PAGE_SIZE = 100
 class DocumentNotFoundError(Exception):
     pass
 
+class TemporaryConnectorApiWrapper(ESClient):
+    """Temporary class to wrap calls to Connectors API.
+
+    When connectors API becomes part of official client
+    this class will be removed.
+    """
+    def __init__(self, elastic_config):
+        super().__init__(elastic_config)
+
+    async def connector_check_in(self, connector_id):
+        await self.client.perform_request(
+            "PUT",
+            f"/_connector/{connector_id}/_check_in",
+            headers = {"accept": "application/json"}
+        )
+
+class ESApi(ESClient):
+    def __init__(self, elastic_config):
+        super().__init__(elastic_config)
+        self._api_wrapper = TemporaryConnectorApiWrapper(elastic_config)
+
+    async def connector_check_in(self, connector_id):
+        await self._retrier.execute_with_retry(
+            partial(self._api_wrapper.connector_check_in, connector_id)
+        )
 
 class ESIndex(ESClient):
     """
@@ -32,6 +57,7 @@ class ESIndex(ESClient):
     def __init__(self, index_name, elastic_config):
         # initialize elasticsearch client
         super().__init__(elastic_config)
+        self.api = ESApi(elastic_config)
         self.index_name = index_name
         self.elastic_config = elastic_config
 

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -37,6 +37,7 @@ from connectors.utils import (
     iso_utc,
     nested_get_from_dict,
     next_run,
+    parse_datetime_string
 )
 
 __all__ = [
@@ -146,9 +147,13 @@ class ConnectorIndex(ESIndex):
         logger.debug(f"ConnectorIndex connecting to {elastic_config['host']}")
         # initialize ESIndex instance
         super().__init__(index_name=CONNECTORS_INDEX, elastic_config=elastic_config)
+        self.feature_use_connectors_api = elastic_config.get("feature_use_connectors_api")
 
     async def heartbeat(self, doc_id):
-        await self.update(doc_id=doc_id, doc={"last_seen": iso_utc()})
+        if self.feature_use_connectors_api:
+            await self.api.connector_check_in(doc_id)
+        else:
+            await self.update(doc_id=doc_id, doc={"last_seen": iso_utc()})
 
     async def supported_connectors(self, native_service_types=None, connector_ids=None):
         if native_service_types is None:
@@ -535,10 +540,7 @@ class Connector(ESDocument):
 
     @property
     def last_seen(self):
-        last_seen = self.get("last_seen")
-        if last_seen is not None:
-            last_seen = datetime.fromisoformat(last_seen)  # pyright: ignore
-        return last_seen
+        return self._property_as_datetime("last_seen")
 
     @property
     def native(self):
@@ -591,7 +593,7 @@ class Connector(ESDocument):
     def _property_as_datetime(self, key):
         value = self.get(key)
         if value is not None:
-            value = datetime.fromisoformat(value)  # pyright: ignore
+            value = parse_datetime_string(value)  # pyright: ignore
         return value
 
     @property

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -37,7 +37,7 @@ from connectors.utils import (
     iso_utc,
     nested_get_from_dict,
     next_run,
-    parse_datetime_string
+    parse_datetime_string,
 )
 
 __all__ = [
@@ -147,7 +147,9 @@ class ConnectorIndex(ESIndex):
         logger.debug(f"ConnectorIndex connecting to {elastic_config['host']}")
         # initialize ESIndex instance
         super().__init__(index_name=CONNECTORS_INDEX, elastic_config=elastic_config)
-        self.feature_use_connectors_api = elastic_config.get("feature_use_connectors_api")
+        self.feature_use_connectors_api = elastic_config.get(
+            "feature_use_connectors_api"
+        )
 
     async def heartbeat(self, doc_id):
         if self.feature_use_connectors_api:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -18,10 +18,10 @@ import time
 import urllib.parse
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
-import dateutil.parser as parser
 from enum import Enum
 from time import strftime
 
+import dateutil.parser as parser
 from base64io import Base64IO
 from bs4 import BeautifulSoup
 from cstriggers.core.trigger import QuartzCron
@@ -82,8 +82,10 @@ class Format(Enum):
     VERBOSE = "verbose"
     SHORT = "short"
 
+
 def parse_datetime_string(datetime):
     return parser.parse(datetime)
+
 
 def iso_utc(when=None):
     if when is None:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -18,6 +18,7 @@ import time
 import urllib.parse
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
+import dateutil.parser as parser
 from enum import Enum
 from time import strftime
 
@@ -81,6 +82,8 @@ class Format(Enum):
     VERBOSE = "verbose"
     SHORT = "short"
 
+def parse_datetime_string(datetime):
+    return parser.parse(datetime)
 
 def iso_utc(when=None):
     if when is None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,11 +15,11 @@ import string
 import tempfile
 import time
 import timeit
-from datetime import datetime, timezone
-from dateutil.tz import tzutc
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 import pytest
+from dateutil.tz import tzutc
 from freezegun import freeze_time
 from pympler import asizeof
 
@@ -47,6 +47,7 @@ from connectors.utils import (
     iterable_batches_generator,
     nested_get_from_dict,
     next_run,
+    parse_datetime_string,
     retryable,
     shorten_str,
     ssl_context,
@@ -55,7 +56,6 @@ from connectors.utils import (
     url_encode,
     validate_email_address,
     validate_index_name,
-    parse_datetime_string
 )
 
 
@@ -1147,11 +1147,19 @@ def test_nested_get_from_dict(dictionary, default, expected):
 
     assert nested_get_from_dict(dictionary, keys, default=default) == expected
 
-@pytest.mark.parametrize("string, parsed_datetime",
-     [
-         ("2024-05-15T12:37:52.429924009Z", datetime(2024, 5, 15, 12, 37, 52, 429924, tzutc())),
-         ("2024-05-15T12:37:52.429Z", datetime(2024, 5, 15, 12, 37, 52, 429000, tzutc())),
-     ]
- )
+
+@pytest.mark.parametrize(
+    "string, parsed_datetime",
+    [
+        (
+            "2024-05-15T12:37:52.429924009Z",
+            datetime(2024, 5, 15, 12, 37, 52, 429924, tzutc()),
+        ),
+        (
+            "2024-05-15T12:37:52.429Z",
+            datetime(2024, 5, 15, 12, 37, 52, 429000, tzutc()),
+        ),
+    ],
+)
 def test_parse_datetime_string_compatibility(string, parsed_datetime):
     assert parse_datetime_string(string) == parsed_datetime

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,8 @@ import string
 import tempfile
 import time
 import timeit
-from datetime import datetime
+from datetime import datetime, timezone
+from dateutil.tz import tzutc
 from unittest.mock import Mock, patch
 
 import pytest
@@ -54,6 +55,7 @@ from connectors.utils import (
     url_encode,
     validate_email_address,
     validate_index_name,
+    parse_datetime_string
 )
 
 
@@ -1144,3 +1146,12 @@ def test_nested_get_from_dict(dictionary, default, expected):
     keys = ["foo", "bar", "baz"]
 
     assert nested_get_from_dict(dictionary, keys, default=default) == expected
+
+@pytest.mark.parametrize("string, parsed_datetime",
+     [
+         ("2024-05-15T12:37:52.429924009Z", datetime(2024, 5, 15, 12, 37, 52, 429924, tzutc())),
+         ("2024-05-15T12:37:52.429Z", datetime(2024, 5, 15, 12, 37, 52, 429000, tzutc())),
+     ]
+ )
+def test_parse_datetime_string_compatibility(string, parsed_datetime):
+    assert parse_datetime_string(string) == parsed_datetime


### PR DESCRIPTION
### Closes https://github.com/elastic/enterprise-search-team/issues/7468
### Closes https://github.com/elastic/enterprise-search-team/issues/7469

This PR attempt to do the following things:
- Add `elasticsearch.feature_use_connectors_api` config option that turns of usage of connectors API if on. Turned off by default
- Use this feature flag to call Connectors API for connector health check function as a demonstration of implementation.

Some notes:

I went for the path of least resistance here keeping in mind that current design of classes and code is more ORM-style with `ESIndex` abstraction actually encapsulating calls to specific indices. With Connectors API it changes - instead of indices it _might_ work in future on the route basis, E.G. one class for calls to Connector endpoints, one class for calls to Connector Sync job endpoints and so on.

Decisions for the above can be done later, especially when Connectors API will be natively available in Python Elasticsearch client. When it happens, we can do design of the API classes better.

Additionally, with feature flag we'll need to maintain both versions of code - calling indices and API until we're ready to make indices hidden. The path forward is:

1. Make Connectors API production-ready
2. Mark feature as deprecated
3. In appropriate time deprecate feature and make indices not accessible publicly based on Elastic policies of deprecation
4. Clean up the code

This means that abstractions will have to least for one more year, so I opted in for simplest way forward that's also easy to clean up - one class `ESApi` with all methods to call APIs that are wrapped in retry policies + use this class in `ESIndex` class - seemed like the cleanest way ahead. All of that might change as we switch more endpoints to the API, but for now it seems like simplest way forward.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes

## Release Note

Add a preview feature for connectors to switch to Elasticsearch Connectors API
