### PR TITLE
Use same aiomysql version on different platforms

### DIFF
--- a/requirements/aarch64.txt
+++ b/requirements/aarch64.txt
@@ -1,7 +1,6 @@
 # Linux ARM
 -r framework.txt
 
-aiomysql==0.0.22
 aioboto3==10.3.0
 pymongo==4.6.3
 motor==3.4.0

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,5 +1,6 @@
 aiohttp==3.9.5
 aiofiles==23.2.1
+aiomysql==0.1.1
 elasticsearch[async]==8.13.0
 elastic-transport==8.13.0
 pyyaml==6.0

--- a/requirements/x86_64.txt
+++ b/requirements/x86_64.txt
@@ -1,7 +1,6 @@
 # X86 Linux or Mac
 -r framework.txt
 
-aiomysql==0.1.1
 pymongo==4.6.3
 motor==3.4.0
 aioboto3==10.3.0


### PR DESCRIPTION
This resolves a `PyMySQL` CVE which was shipped only with the version installed on aarch64.