### PR TITLE
[Outlook] Upgrade Exchangelib

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -25,7 +25,7 @@ beautifulsoup4==4.12.2
 gidgethub==5.2.1
 wcmatch==8.4.1
 msal==1.23.0
-exchangelib==5.0.3
+exchangelib==5.4.0
 ldap3==2.9.1
 lxml==4.9.3
 pywinrm==0.4.3


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2464

"Not allowed to access Non IPM folder" this error is fixed in the new version of Exchangelib, hence upgrading to the latest.

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

Due to issue in exchangelib, outlook connector was facing `Not allowed to access Non IPM folder` error. After upgrading to latest version of exchangelib, outlook connector is working fine.