### PR TITLE
[Job scheduling] Use UTC timezone with timestamps

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -639,7 +639,7 @@ class Connector(ESDocument):
             await self.index.heartbeat(doc_id=self.id)
 
     def next_sync(self, job_type, now):
-        """Returns the datetime when the next sync for a given job type will run, return None if it's disabled."""
+        """Returns the datetime in UTC timezone when the next sync for a given job type will run, return None if it's disabled."""
 
         match job_type:
             case JobType.ACCESS_CONTROL:
@@ -659,7 +659,7 @@ class Connector(ESDocument):
     async def _update_datetime(self, field, new_ts):
         await self.index.update(
             doc_id=self.id,
-            doc={field: new_ts.isoformat()},
+            doc={field: iso_utc(new_ts)},
             if_seq_no=self._seq_no,
             if_primary_term=self._primary_term,
         )

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -224,7 +224,7 @@ class JobSchedulingService(BaseService):
                 return False
 
             if this_wake_up_time < next_sync:
-                next_sync_due = (next_sync - datetime.utcnow()).total_seconds()
+                next_sync_due = (next_sync - datetime.now(datetime.UTC)).total_seconds()
                 connector.log_debug(
                     f"Next '{job_type_value}' sync due in {int(next_sync_due)} seconds"
                 )

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -93,6 +93,14 @@ def iso_utc(when=None):
     return when.isoformat()
 
 
+def with_utc_tz(ts):
+    """Ensure the timestmap has a timezone of UTC."""
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    else:
+        return ts.astimezone(timezone.utc)
+
+
 def iso_zulu():
     """Returns the current time in ISO Zulu format"""
     return datetime.now(timezone.utc).strftime(ISO_ZULU_TIMESTAMP_FORMAT)
@@ -104,9 +112,9 @@ def epoch_timestamp_zulu():
 
 
 def next_run(quartz_definition, now):
-    """Returns the datetime of the next run."""
+    """Returns the datetime in UTC timezone of the next run."""
     cron_obj = QuartzCron(quartz_definition, now)
-    return cron_obj.next_trigger()
+    return with_utc_tz(cron_obj.next_trigger())
 
 
 INVALID_CHARS = "\\", "/", "*", "?", '"', "<", ">", "|", " ", ",", "#"

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -3,7 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -3,7 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
-from datetime import datetime, timedelta
+from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -57,7 +57,7 @@ def sync_job_index_mock():
         yield sync_job_index_mock
 
 
-default_next_sync = datetime.utcnow() + timedelta(hours=1)
+default_next_sync = datetime.now(timezone.utc) + timedelta(hours=1)
 
 
 def mock_connector(
@@ -112,7 +112,7 @@ async def test_connector_ready_to_sync(
     sync_job_index_mock,
     set_env,
 ):
-    connector = mock_connector(next_sync=datetime.utcnow())
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     await create_and_run_service(JobSchedulingService)
 
@@ -136,13 +136,13 @@ async def test_connector_ready_to_sync_with_race_condition(
     sync_job_index_mock,
     set_env,
 ):
-    connector = mock_connector(next_sync=datetime.utcnow())
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
 
     # Do nothing in the first call(in _should_schedule_on_demand_sync) and second call(in _should_schedule_scheduled_sync), and the last_sync_scheduled_at is updated by another instance in the subsequent calls
     def _reset_last_sync_scheduled_at_by_job_type():
         if connector.reload.await_count > 2:
             connector.last_sync_scheduled_at_by_job_type = Mock(
-                return_value=datetime.utcnow() + timedelta(seconds=20)
+                return_value=datetime.now(timezone.utc) + timedelta(seconds=20)
             )
 
     connector.reload.side_effect = _reset_last_sync_scheduled_at_by_job_type
@@ -181,7 +181,7 @@ async def test_connector_scheduled_access_control_sync_with_dls_feature_disabled
     set_env,
 ):
     connector = mock_connector(
-        next_sync=datetime.utcnow(), document_level_security_enabled=False
+        next_sync=datetime.now(timezone.utc), document_level_security_enabled=False
     )
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     await create_and_run_service(JobSchedulingService)
@@ -205,7 +205,7 @@ async def test_connector_scheduled_access_control_sync_with_insufficient_license
     sync_job_index_mock,
     set_env,
 ):
-    connector = mock_connector(next_sync=datetime.utcnow())
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     connector_index_mock.has_active_license_enabled = AsyncMock(
         return_value=(False, License.BASIC)
@@ -246,7 +246,7 @@ async def test_connector_scheduled_incremental_sync(
 ):
     connector = mock_connector(
         service_type=service_type,
-        next_sync=datetime.utcnow(),
+        next_sync=datetime.now(timezone.utc),
         incremental_sync_enabled=incremental_sync_enabled,
         document_level_security_enabled=False,
     )
@@ -323,8 +323,8 @@ async def test_connector_prepare_failed(
 async def test_run_when_sync_fails_then_continues_service_execution(
     connector_index_mock, set_env
 ):
-    connector = mock_connector(next_sync=datetime.utcnow())
-    another_connector = mock_connector(next_sync=datetime.utcnow())
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
+    another_connector = mock_connector(next_sync=datetime.now(timezone.utc))
     connector_index_mock.supported_connectors.return_value = AsyncIterator(
         [connector, another_connector]
     )
@@ -365,7 +365,7 @@ async def test_run_when_connector_fields_are_invalid(
     data_source_mock.ping = AsyncMock()
     data_source_mock.close = AsyncMock()
 
-    connector = mock_connector(next_sync=datetime.utcnow())
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     await create_and_run_service(JobSchedulingService, stop_after=0.15)
 
@@ -397,7 +397,7 @@ async def test_run_when_connector_ping_fails(
     data_source_mock.ping = AsyncMock(side_effect=[actual_error])
     data_source_mock.close = AsyncMock()
 
-    connector = mock_connector(next_sync=datetime.utcnow())
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
     await create_and_run_service(JobSchedulingService, stop_after=0.15)
 
@@ -427,7 +427,7 @@ async def test_run_when_connector_validate_config_fails(
     data_source_mock.ping = AsyncMock()
     data_source_mock.close = AsyncMock()
 
-    connector = mock_connector(next_sync=datetime.utcnow())
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
     connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
 
     await create_and_run_service(JobSchedulingService, stop_after=0.15)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ import string
 import tempfile
 import time
 import timeit
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -56,6 +56,7 @@ from connectors.utils import (
     url_encode,
     validate_email_address,
     validate_index_name,
+    with_utc_tz,
 )
 
 
@@ -63,14 +64,54 @@ def test_next_run():
     now = datetime(2023, 1, 18, 17, 18, 56, 814)
     # can run within two minutes
     assert (
-        next_run("1 * * * * *", now).isoformat(" ", "seconds") == "2023-01-18 17:19:01"
+        next_run("1 * * * * *", now).isoformat(" ", "seconds")
+        == "2023-01-18 17:19:01+00:00"
     )
     assert (
-        next_run("* * * * * *", now).isoformat(" ", "seconds") == "2023-01-18 17:18:57"
+        next_run("* * * * * *", now).isoformat(" ", "seconds")
+        == "2023-01-18 17:18:57+00:00"
     )
 
     # this should get parsed
     next_run("0/5 14,18,52 * ? JAN,MAR,SEP MON-FRI 2010-2030", now)
+
+
+def test_with_utc_tz_naive_timestamp():
+    ts_naive = datetime(2024, 5, 27, 12, 0, 0)
+    ts_utc = with_utc_tz(ts_naive)
+    assert ts_utc.tzinfo == timezone.utc
+    assert ts_utc.year == 2024
+    assert ts_utc.month == 5
+    assert ts_utc.day == 27
+    assert ts_utc.hour == 12
+    assert ts_utc.minute == 0
+    assert ts_utc.second == 0
+
+
+def test_with_utc_tz_aware_timestamp():
+    ts_aware = datetime(
+        2024, 5, 27, 12, 0, 0, tzinfo=timezone(timedelta(hours=5))
+    )  # Timezone aware timestamp with +5 offset
+    ts_utc = with_utc_tz(ts_aware)
+    assert ts_utc.tzinfo == timezone.utc
+    assert ts_utc.year == 2024
+    assert ts_utc.month == 5
+    assert ts_utc.day == 27
+    assert ts_utc.hour == 7  # Converted to UTC
+    assert ts_utc.minute == 0
+    assert ts_utc.second == 0
+
+
+def test_with_utc_tz_timestamp_in_utc():
+    ts_aware = datetime(2024, 5, 27, 12, 0, 0, tzinfo=timezone.utc)
+    ts_utc = with_utc_tz(ts_aware)
+    assert ts_utc.tzinfo == timezone.utc
+    assert ts_utc.year == 2024
+    assert ts_utc.month == 5
+    assert ts_utc.day == 27
+    assert ts_utc.hour == 12
+    assert ts_utc.minute == 0
+    assert ts_utc.second == 0
 
 
 def test_invalid_names():


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2067

### Changes
- This PR ensures are timestamps of `last_access_control_sync_scheduled_at`, `last_incremental_sync_scheduled_at` and  `last_sync_scheduled_at` are written to ES index with explicit UTC timezone  `+00:00`
- Job scheduling service is adapted, all references to deprecated `utcnow()` are replaced with `now(timezone.utc)`, this forces the scheduling service to operate on timezoned datetime objects instead of naive system defaults
  - See good explanation by Miguel: https://blog.miguelgrinberg.com/post/it-s-time-for-a-change-datetime-utcnow-is-now-deprecated 


### Validation
- Added unit tests
- Manually tested, scheduled full, incremental and ac syncs, they were triggering correctly with 8.15 snapshot of the stack


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
