### PR TITLE
Migration for timezone aware timestamps

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -597,7 +597,9 @@ class Connector(ESDocument):
         value = self.get(key)
         if value is not None:
             value = parse_datetime_string(value)  # pyright: ignore
-            # ensure that the datetime is in UTC timezone
+            # Ensure the datetime is in UTC. This handles historically naive timestamps
+            # that might be present in the index, ensuring the job scheduling logic with
+            # offset-aware timestamps works correctly.
             value = with_utc_tz(value)
         return value
 

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -38,6 +38,7 @@ from connectors.utils import (
     nested_get_from_dict,
     next_run,
     parse_datetime_string,
+    with_utc_tz,
 )
 
 __all__ = [
@@ -596,6 +597,8 @@ class Connector(ESDocument):
         value = self.get(key)
         if value is not None:
             value = parse_datetime_string(value)  # pyright: ignore
+            # ensure that the datetime is in UTC timezone
+            value = with_utc_tz(value)
         return value
 
     @property

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -597,9 +597,8 @@ class Connector(ESDocument):
         value = self.get(key)
         if value is not None:
             value = parse_datetime_string(value)  # pyright: ignore
-            # Ensure the datetime is in UTC. This handles historically naive timestamps
-            # that might be present in the index, ensuring the job scheduling logic with
-            # offset-aware timestamps works correctly.
+            # Ensure the datetime is in UTC for backward compatibility with historically naive timestamps.
+            # This guarantees that job scheduling logic with offset-aware timestamps works correctly.
             value = with_utc_tz(value)
         return value
 


### PR DESCRIPTION
## Relates to https://github.com/elastic/connectors/issues/2067

Followup to #2067. I realised that migrating from naive to offset aware timestamps for job scheduling might break existing connectors that had scheduling enabled and were using naive datatime (no tz info) representation. 

I tried this scenario, as expected after migrating to new offset aware logic the scheduling was broken ... I got a following error from a scheduler

```
  File "/Users/jedr/connectors-python/connectors/services/job_scheduling.py", line 207, in _should_schedule
    and last_sync_scheduled_at > last_wake_up_time
TypeError: can't compare offset-naive and offset-aware datetimes
```

The fix is to try to cast naive datetimes, to offset aware datetimes when reading `last_access_control_sync_scheduled_at`, `last_incremental_sync_scheduled_at` and  `last_sync_scheduled_at` from ES index. This essentially takes care of the migration. 

I modified `_property_as_datetime` function to try to set datetime to UTC timezone, with the `with_utc_tz` function. 

The `_property_as_datetime` is used by following properties in protocol logic:
- `last_incremental_sync_scheduled_at` this migration
- `last_access_control_sync_scheduled_at` this migration
- `last_sync_scheduled_at` this migration
- `last_seen` - already [indexed as offset aware timezone](https://github.com/elastic/connectors/blob/main/connectors/protocol/connectors.py#L158) (no effect on logic)

### Verification
- Tested migration manually (enable all sync scheduling, execute some syncs, upgrade connectors, scheduling still works fine)
- Unit tests


## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
