### PR TITLE
Fix how to add mappings to existing indices

### DIFF
--- a/connectors/es/management_client.py
+++ b/connectors/es/management_client.py
@@ -53,10 +53,10 @@ class _DeepChainMap(ChainMap):
 
     def to_dict(self):
         """Returns a new dict by merging the underlying mappings."""
-        return {k: self[k].to_dict()
-                    if isinstance(self[k], type(self))
-                    else self[k]
-                for k in self}
+        return {
+            k: self[k].to_dict() if isinstance(self[k], type(self)) else self[k]
+            for k in self
+        }
 
 
 class ESManagementClient(ESClient):
@@ -138,7 +138,6 @@ class ESManagementClient(ESClient):
             logger.warning(
                 f"Could not create mappings for index {index}, encountered error {e}"
             )
-
 
     async def ensure_content_index_settings(
         self, index_name, index, language_code=None

--- a/tests/es/test_management_client.py
+++ b/tests/es/test_management_client.py
@@ -64,14 +64,19 @@ class TestESManagementClient:
     ):
         index_name = "something"
         mappings = {}
-        existing_mappings_response = {index_name: {"mappings": ["something"]}}
+        existing_mappings_response = {index_name: {"mappings": {"properties": "something"}}}
 
         es_management_client.client.indices.get_mapping = AsyncMock(
             return_value=existing_mappings_response
         )
 
         await es_management_client.ensure_content_index_mappings(index_name, mappings)
-        es_management_client.client.indices.put_mapping.assert_not_called()
+        es_management_client.client.indices.put_mapping.assert_awaited_with(
+            index=index_name,
+            dynamic=False,
+            dynamic_templates=[],
+            properties="something",
+        )
 
     @pytest.mark.asyncio
     async def test_ensure_content_index_mappings_when_mappings_do_not_exist(

--- a/tests/es/test_management_client_deepchainmap.py
+++ b/tests/es/test_management_client_deepchainmap.py
@@ -1,0 +1,103 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#
+
+import pytest
+
+from connectors.es.management_client import _DeepChainMap
+
+
+def getter(*keys):
+    def inner(mapping):
+        ret = mapping
+        for key in keys:
+            ret = ret[key]
+        return ret
+    return inner
+
+
+MAPPINGS = (
+    {
+        "a": {
+            "b": {
+                "c": "a-b-c",
+            }
+        },
+        "X": {},
+        "Y": {
+            1: 1,
+        },
+    },
+    {
+        "A": {
+            "B": {
+                "C": "A-B-C",
+            }
+        },
+        "X": "non-mapping",
+        "Y": {
+            2: 2,
+        },
+        "Z": {
+            1: 1,
+        },
+    },
+    {
+        "A": {
+            "B'": {
+                "C'": "A-B'-C'",
+            }
+        },
+        "Y": {
+            2: None,
+        },
+        "Z": {
+            2: 2,
+        },
+    },
+)
+
+
+class TestDeepChainMap:
+    @pytest.mark.parametrize(
+        "getter, expect",
+        [
+            (getter("a", "b", "c"), "a-b-c"),
+            (getter("A", "B", "C"), "A-B-C"),
+            (getter("A", "B'", "C'"), "A-B'-C'"),
+            (getter("X"), {}),
+            (getter("Y", 1), 1),
+            (getter("Y", 2), 2),
+            (getter("Z", 2), 2),
+        ],
+    )
+    def test_get_nested_value(self, getter, expect):
+        assert getter(_DeepChainMap(*MAPPINGS)) == expect
+
+    def test_to_dict(self):
+        assert _DeepChainMap(*MAPPINGS).to_dict() == {
+            "a": {
+                "b": {
+                    "c": "a-b-c",
+                }
+            },
+            "A": {
+                "B": {
+                    "C": "A-B-C",
+                },
+                "B'": {
+                    "C'": "A-B'-C'",
+                }
+            },
+            "X": {},
+            "Y": {
+                1: 1,
+                2: 2,
+            },
+            "Z": {
+                1: 1,
+                2: 2,
+            },
+        }


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2581

This PR changes the behavior of `ensure_content_index_mappings()` when mappings exist in the content index.

- before this PR: `ensure_content_index_mappings()` does nothing.
- after this PR: `ensure_content_index_mappings()` puts a combination of existing and non-present mappings.

More specifically, the following mappings are ensured right before the sync for the reproducer mentioned in #2581.

```json
{
  "mappings": {
    "dynamic": "true",
    "dynamic_templates": [
      {
        "all_text_fields": {
          "match_mapping_type": "string",
          "mapping": {
            "analyzer": "iq_text_base",
            "fields": {
              "delimiter": {
                "analyzer": "iq_text_delimiter",
                "type": "text",
                "index_options": "freqs"
              },
              "joined": {
                "search_analyzer": "q_text_bigram",
                "analyzer": "i_text_bigram",
                "type": "text",
                "index_options": "freqs"
              },
              "prefix": {
                "search_analyzer": "q_prefix",
                "analyzer": "i_prefix",
                "type": "text",
                "index_options": "docs"
              },
              "enum": {
                "ignore_above": 2048,
                "type": "keyword"
              },
              "stem": {
                "analyzer": "iq_text_stem",
                "type": "text"
              }
            }
          }
        }
      }
    ],
    "properties": {
      "_subextracted_as_of": {
        "type": "date"
      },
      "_subextracted_version": {
        "type": "keyword"
      },
      "id": {
        "type": "keyword"
      }
    }
  }
}
```

## Checklists

#### Pre-Review Checklist
- [X] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [ ] Added a `release_note` label.

## Release Note

Fix how to add mappings to existing indices