### PR TITLE
bump certifi

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -37,3 +37,4 @@ redis==5.0.1
 simple-term-menu==1.6.4
 graphql-core==3.2.3
 notion-client==2.2.1
+certifi==2023.7.22


### PR DESCRIPTION
Related to https://github.com/advisories/GHSA-xqr8-7jwr-rhp7

It's a transitive dep that isn't currently explicitly in our requirements. This PR changes that, and pins it to a patched version.

## Checklists



#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)
