### PR TITLE
Saleforce client token generation error logging

### DIFF
--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -1105,12 +1105,13 @@ class SalesforceAPIToken:
         except ClientResponseError as e:
             if 400 <= e.status < 500:
                 # 400s have detailed error messages in body
-                error_message = response_body.get("error", "No error dscription found.")
+                error_message = response_body.get("error", "No error message found.")
+                error_description = response_body.get("error_description", "No error description found.")
                 if error_message == "invalid_client":
-                    msg = f"The `client_id` and `client_secret` provided could not be used to generate a token. Status: {e.status}, message: {e.message}, details: {error_message}"
+                    msg = f"The `client_id` and `client_secret` provided could not be used to generate a token. Status: {e.status}, message: {e.message}, details: {error_message}, description: {error_description}"
                     raise InvalidCredentialsException(msg) from e
                 else:
-                    msg = f"Could not fetch token from Salesforce: Status: {e.status}, message: {e.message}, details: {error_message}"
+                    msg = f"Could not fetch token from Salesforce: Status: {e.status}, message: {e.message}, details: {error_message}, description: {error_description}"
                     raise TokenFetchException(msg) from e
             else:
                 msg = f"Unexpected error while fetching Salesforce token. Status: {e.status}, message: {e.message}"

--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -1106,7 +1106,9 @@ class SalesforceAPIToken:
             if 400 <= e.status < 500:
                 # 400s have detailed error messages in body
                 error_message = response_body.get("error", "No error message found.")
-                error_description = response_body.get("error_description", "No error description found.")
+                error_description = response_body.get(
+                    "error_description", "No error description found."
+                )
                 if error_message == "invalid_client":
                     msg = f"The `client_id` and `client_secret` provided could not be used to generate a token. Status: {e.status}, message: {e.message}, details: {error_message}, description: {error_description}"
                     raise InvalidCredentialsException(msg) from e

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -825,8 +825,12 @@ async def test_generate_token_with_bad_credentials_raises_error(
             },
             repeat=True,
         )
-        with pytest.raises(InvalidCredentialsException):
+        with pytest.raises(InvalidCredentialsException) as error:
             await source.salesforce_client.api_token.token()
+        assert (
+            str(error.value)
+            == "The `client_id` and `client_secret` provided could not be used to generate a token. Status: 400, message: Bad Request, details: invalid_client, description: Invalid client credentials"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Capture `error_description` on token error from Salesforce.

## Closes https://github.com/elastic/connectors/issues/2592

The Salesforce connector does not handle the error_description field when a ClientResponseError is raised. This field can provide helpful information when debugging the connector.  This change captures this field, if available, and appends it to the exception message.

## Checklists

#### Pre-Review Checklist
- [X] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [X] this PR has a meaningful title
- [X] this PR links to all relevant github issues that it fixes or partially addresses


