### PR TITLE
Catch job claim failures, and result in job termination

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -18,6 +18,8 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from enum import Enum
 
+from elasticsearch import ApiError
+
 from connectors.es import ESDocument, ESIndex
 from connectors.es.client import with_concurrency_control
 from connectors.filtering.validation import (
@@ -140,6 +142,10 @@ class DataSourceError(Exception):
 
 
 class InvalidConnectorSetupError(Exception):
+    pass
+
+
+class ProtocolError(Exception):
     pass
 
 
@@ -306,56 +312,85 @@ class SyncJob(ESDocument):
             msg = f"Filtering in state {validation_result.state}, errors: {validation_result.errors}."
             raise InvalidFilteringError(msg)
 
+    def _wrap_errors(self, operation_name, e):
+        if isinstance(e, ApiError):
+            reason = None
+            if e.info is not None and "error" in e.info and "reason" in e.info["error"]:
+                reason = e.info["error"]["reason"]
+            msg = f"Failed to {operation_name} for job {self.id} because Elasticsearch responded with status {e.status_code}.{f' Reason: {reason}' if reason else ''}"
+            raise ProtocolError(msg) from e
+        else:
+            msg = f"Failed to {operation_name} for job {self.id} because of {e.__class__.__name__}: {str(e)}"
+            raise ProtocolError(msg) from e
+
     async def claim(self, sync_cursor=None):
-        doc = {
-            "status": JobStatus.IN_PROGRESS.value,
-            "started_at": iso_utc(),
-            "last_seen": iso_utc(),
-            "worker_hostname": socket.gethostname(),
-            "connector.sync_cursor": sync_cursor,
-        }
-        await self.index.update(doc_id=self.id, doc=doc)
+        try:
+            doc = {
+                "status": JobStatus.IN_PROGRESS.value,
+                "started_at": iso_utc(),
+                "last_seen": iso_utc(),
+                "worker_hostname": socket.gethostname(),
+                "connector.sync_cursor": sync_cursor,
+            }
+            await self.index.update(doc_id=self.id, doc=doc)
+        except Exception as e:
+            self._wrap_errors("claim job", e)
 
     async def update_metadata(self, ingestion_stats=None, connector_metadata=None):
-        ingestion_stats = filter_ingestion_stats(ingestion_stats)
-        if connector_metadata is None:
-            connector_metadata = {}
+        try:
+            ingestion_stats = filter_ingestion_stats(ingestion_stats)
+            if connector_metadata is None:
+                connector_metadata = {}
 
-        doc = {
-            "last_seen": iso_utc(),
-        }
-        doc.update(ingestion_stats)
-        if len(connector_metadata) > 0:
-            doc["metadata"] = connector_metadata
-        await self.index.update(doc_id=self.id, doc=doc)
+            doc = {
+                "last_seen": iso_utc(),
+            }
+            doc.update(ingestion_stats)
+            if len(connector_metadata) > 0:
+                doc["metadata"] = connector_metadata
+            await self.index.update(doc_id=self.id, doc=doc)
+        except Exception as e:
+            self._wrap_errors("update metadata and stats", e)
 
     async def done(self, ingestion_stats=None, connector_metadata=None):
-        await self._terminate(
-            JobStatus.COMPLETED, None, ingestion_stats, connector_metadata
-        )
+        try:
+            await self._terminate(
+                JobStatus.COMPLETED, None, ingestion_stats, connector_metadata
+            )
+        except Exception as e:
+            self._wrap_errors("terminate as completed", e)
 
     async def fail(self, error, ingestion_stats=None, connector_metadata=None):
-        if isinstance(error, str):
-            message = error
-        elif isinstance(error, Exception):
-            message = f"{error.__class__.__name__}"
-            if str(error):
-                message += f": {str(error)}"
-        else:
-            message = str(error)
-        await self._terminate(
-            JobStatus.ERROR, message, ingestion_stats, connector_metadata
-        )
+        try:
+            if isinstance(error, str):
+                message = error
+            elif isinstance(error, Exception):
+                message = f"{error.__class__.__name__}"
+                if str(error):
+                    message += f": {str(error)}"
+            else:
+                message = str(error)
+            await self._terminate(
+                JobStatus.ERROR, message, ingestion_stats, connector_metadata
+            )
+        except Exception as e:
+            self._wrap_errors("terminate as failed", e)
 
     async def cancel(self, ingestion_stats=None, connector_metadata=None):
-        await self._terminate(
-            JobStatus.CANCELED, None, ingestion_stats, connector_metadata
-        )
+        try:
+            await self._terminate(
+                JobStatus.CANCELED, None, ingestion_stats, connector_metadata
+            )
+        except Exception as e:
+            self._wrap_errors("terminate as canceled", e)
 
     async def suspend(self, ingestion_stats=None, connector_metadata=None):
-        await self._terminate(
-            JobStatus.SUSPENDED, None, ingestion_stats, connector_metadata
-        )
+        try:
+            await self._terminate(
+                JobStatus.SUSPENDED, None, ingestion_stats, connector_metadata
+            )
+        except Exception as e:
+            self._wrap_errors("terminate as suspended", e)
 
     async def _terminate(
         self, status, error=None, ingestion_stats=None, connector_metadata=None

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -809,9 +809,9 @@ async def test_sync_job_claim_fails():
     )
 
     sync_job = SyncJob(elastic_index=index, doc_source=source)
-    with pytest.raises(ProtocolError):
+    with pytest.raises(ProtocolError) as e:
         await sync_job.claim(sync_cursor=SYNC_CURSOR)
-        "because Elasticsearch responded with status 413. Reason: mocked test failure"
+        "because Elasticsearch responded with status 413. Reason: mocked test failure" in str(e)
 
 
 @pytest.mark.asyncio

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
-from elasticsearch import ConflictError
+from elasticsearch import ApiError, ConflictError
 
 from connectors.config import load_config
 from connectors.filtering.validation import (
@@ -39,6 +39,7 @@ from connectors.protocol import (
     SyncJob,
     SyncJobIndex,
 )
+from connectors.protocol.connectors import ProtocolError
 from connectors.source import BaseDataSource
 from connectors.utils import ACCESS_CONTROL_INDEX_PREFIX, iso_utc
 from tests.commons import AsyncIterator
@@ -792,6 +793,25 @@ async def test_sync_job_claim():
     await sync_job.claim(sync_cursor=SYNC_CURSOR)
 
     index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_claim_fails():
+    source = {"_id": "1"}
+    index = Mock()
+    api_meta = Mock()
+    api_meta.status = 413
+    error_body = {"error": {"reason": "mocked test failure"}}
+    index.update = AsyncMock(
+        side_effect=ApiError(
+            message="this is an error message", body=error_body, meta=api_meta
+        )
+    )
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    with pytest.raises(ProtocolError):
+        await sync_job.claim(sync_cursor=SYNC_CURSOR)
+        "because Elasticsearch responded with status 413. Reason: mocked test failure"
 
 
 @pytest.mark.asyncio

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -811,7 +811,7 @@ async def test_sync_job_claim_fails():
     sync_job = SyncJob(elastic_index=index, doc_source=source)
     with pytest.raises(ProtocolError) as e:
         await sync_job.claim(sync_cursor=SYNC_CURSOR)
-        "because Elasticsearch responded with status 413. Reason: mocked test failure" in str(e)
+        assert "because Elasticsearch responded with status 413. Reason: mocked test failure" in str(e)
 
 
 @pytest.mark.asyncio

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -811,7 +811,10 @@ async def test_sync_job_claim_fails():
     sync_job = SyncJob(elastic_index=index, doc_source=source)
     with pytest.raises(ProtocolError) as e:
         await sync_job.claim(sync_cursor=SYNC_CURSOR)
-        assert "because Elasticsearch responded with status 413. Reason: mocked test failure" in str(e)
+        assert (
+            "because Elasticsearch responded with status 413. Reason: mocked test failure"
+            in str(e)
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/2604

If a connector thinks a job is running for it, we'd better ensure that a job either starts or fails. Before this PR, if `sync_job.claim()` failed, the connector would not be informed that there was nothing running the job, and the job it expected to start running would never transition out of the pending state. This PR does a few things:

1. Ensures that after the connector record has been informed that the sync is starting, that everything past that is in a `try/except` block to handle any errors and fail the job.
2. wraps all SyncJob methods individually in `try/except` to ensure that any surfaced error messages are as actionable as possible
3. Adds tests

This PR does not yet address the root issue of the linked ticket, which is _why_ we're getting to a place where `claim()` is resulting in ES throwing a 413 error.

## Checklists



#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)


## Release Note

Fixes a bug where sync jobs can be permanently  stuck in "pending" (until manually canceled) because of an unfortunately timed Elasticsearch exception. Now such exceptions will cause jobs to fail and provide actionable error messaging.
