### PR TITLE
[8.14] [Confluence] Ingest full body of documents in sync rules (#2602)

### DIFF
--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -52,7 +52,7 @@ USERS_FOR_SERVER = "users_for_server"
 SPACE_QUERY = "limit=100&expand=permissions"
 ATTACHMENT_QUERY = "limit=100&expand=version"
 CONTENT_QUERY = "limit=50&expand=children.attachment,history.lastUpdated,body.storage,space,space.permissions,restrictions.read.restrictions.user,restrictions.read.restrictions.group"
-SEARCH_QUERY = "limit=100&expand=content.extensions,content.container,content.space,space.description"
+SEARCH_QUERY = "limit=100&expand=content.extensions,content.container,content.space,content.body.storage,space.description"
 USER_QUERY = "expand=groups,applicationRoles"
 
 URLS = {
@@ -892,7 +892,7 @@ class ConfluenceDataSource(BaseDataSource):
                 "_id": entity_details.get("id"),
                 "title": entity.get("title"),
                 "_timestamp": entity.get("lastModified"),
-                "body": entity.get("excerpt"),
+                "body": entity_details.get("body", {}).get("storage", {}).get("value"),
                 "type": entity.get("entityType"),
                 "url": os.path.join(
                     self.confluence_client.host_url, entity.get("url")[1:]

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -204,6 +204,14 @@ RESPONSE_SEARCH_RESULT = {
                 "id": "983046",
                 "type": "page",
                 "space": {"name": "Software Development"},
+                "body": {
+                    "storage": {
+                        "value": "Confluence Connector currently supports below objects for ingestion of data in ElasticSearch.\nBlogs\nAttachments\nPages\nSpaces",
+                        "representation": "storage",
+                        "embeddedContent": [],
+                        "_expandable": {"content": "/rest/api/content/6455384"},
+                    },
+                },
             },
             "title": "Product Details",
             "excerpt": "Confluence Connector currently supports below objects for ingestion of data in ElasticSearch.\nBlogs\nAttachments\nPages\nSpaces",
@@ -220,6 +228,14 @@ RESPONSE_SEARCH_RESULT = {
                     "fileSize": 1119256,
                 },
                 "space": {"name": "Software Development"},
+                "body": {
+                    "storage": {
+                        "value": "",
+                        "representation": "storage",
+                        "embeddedContent": [],
+                        "_expandable": {"content": "/rest/api/content"},
+                    },
+                },
                 "container": {"type": "page", "title": "Product Details"},
                 "_links": {"download": "/download/attachments/196717/Potential.pdf"},
             },
@@ -268,7 +284,7 @@ EXPECTED_SEARCH_RESULT = [
         "_id": 196612,
         "title": "Software Development",
         "_timestamp": "2022-12-13T09:49:01.000Z",
-        "body": "",
+        "body": None,
         "type": "space",
         "url": f"{HOST_URL}/spaces/SD",
     },


### PR DESCRIPTION
## Backport
This will backport the following commits from main to 8.14:

- https://github.com/elastic/connectors/pull/2602
