### PR TITLE
Fix glob in artifact_paths steps for release

### DIFF
--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -19,7 +19,7 @@ steps:
           DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-debian"
         command: ".buildkite/publish/build-docker.sh"
         key: "build_docker_image_amd64"
-        artifact_paths: ".artifacts/${DOCKER_ARTIFACT_KEY}-*.tar.gz"
+        artifact_paths: ".artifacts/*.tar.gz"
       - label: "Testing amd64 Docker image"
         agents:
           provider: aws
@@ -51,7 +51,7 @@ steps:
           DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-debian"
         command: ".buildkite/publish/build-docker.sh"
         key: "build_docker_image_arm64"
-        artifact_paths: ".artifacts/${DOCKER_ARTIFACT_KEY}-*.tar.gz"
+        artifact_paths: ".artifacts/*.tar.gz"
       - label: "Testing arm64 Docker image"
         agents:
           provider: aws
@@ -132,7 +132,7 @@ steps:
           DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-wolfi"
         command: ".buildkite/publish/build-docker.sh"
         key: "build_docker_image_amd64_wolfi"
-        artifact_paths: ".artifacts/${DOCKER_ARTIFACT_KEY}-*.tar.gz"
+        artifact_paths: ".artifacts/*.tar.gz"
       - label: "Testing amd64 Docker image based on Wolfi"
         agents:
           provider: aws
@@ -169,7 +169,7 @@ steps:
           DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-wolfi"
         command: ".buildkite/publish/build-docker.sh"
         key: "build_docker_image_arm64_wolfi"
-        artifact_paths: ".artifacts/${DOCKER_ARTIFACT_KEY}-*.tar.gz"
+        artifact_paths: ".artifacts/*.tar.gz"
       - label: "Testing arm64 Docker image based on Wolfi"
         agents:
           provider: aws


### PR DESCRIPTION
This PR fixes the release pipeline we will use soon to release a new version: env variables are not replaced in `artifact_paths` values.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/2399
