### PR TITLE
Fix multi-arch container image builds

### DIFF
--- a/.buildkite/publish/build-multiarch-docker.sh
+++ b/.buildkite/publish/build-multiarch-docker.sh
@@ -17,8 +17,8 @@ AMD64_TAG="${BASE_TAG_NAME}:${VERSION}-amd64"
 ARM64_TAG="${BASE_TAG_NAME}:${VERSION}-arm64"
 
 # Pull the images from the registry
-buildah pull $AMD64_TAG
-buildah pull $ARM64_TAG
+docker pull $AMD64_TAG
+docker pull $ARM64_TAG
 
 # ensure +x is set to avoid writing any sensitive information to the console
 set +x
@@ -29,18 +29,16 @@ DOCKER_PASSWORD=$(vault read -address "${VAULT_ADDR}" -field secret_20230609 sec
 echo "Logging into docker..."
 DOCKER_USER=$(vault read -address "${VAULT_ADDR}" -field user_20230609 secret/ci/elastic-connectors/${VAULT_USER})
 vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-connectors/${VAULT_USER} | \
-  buildah login --username="${DOCKER_USER}" --password-stdin docker.elastic.co
+  docker login --username="${DOCKER_USER}" --password-stdin docker.elastic.co
 
 # Create the manifest for the multiarch image
 echo "Creating manifest..."
-buildah manifest create $TAG_NAME \
-  $AMD64_TAG \
-  $ARM64_TAG
+docker manifest create $TAG_NAME $AMD64_TAG $ARM64_TAG
 
 # ... and push it
 echo "Pushing manifest..."
-buildah manifest push $TAG_NAME docker://$TAG_NAME
+docker manifest push $TAG_NAME
 
 # Write out the final manifest for debugging purposes
 echo "Built and pushed multiarch image... dumping final manifest..."
-buildah manifest inspect $TAG_NAME
+docker manifest inspect $TAG_NAME

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -105,9 +105,8 @@ steps:
           - ".buildkite/publish/push-docker.sh"
       - label: "Build and push multiarch Docker image"
         agents:
-          image: "docker.elastic.co/ci-agent-images/drivah:0.25.0"
-          ephemeralStorage: "20G"
-          memory: "4G"
+          provider: aws
+          instanceType: m6i.xlarge
         command: ".buildkite/publish/build-multiarch-docker.sh"
         depends_on:
           - "push_amd64_docker_image"
@@ -228,9 +227,8 @@ steps:
           - ".buildkite/publish/push-docker.sh"
       - label: "Build and push multiarch Docker image based on Wolfi"
         agents:
-          image: "docker.elastic.co/ci-agent-images/drivah:0.25.0"
-          ephemeralStorage: "20G"
-          memory: "4G"
+          provider: aws
+          instanceType: m6i.xlarge
         env:
           DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
         command: ".buildkite/publish/build-multiarch-docker.sh"


### PR DESCRIPTION
`buildah` is failing to build a multi-arch image when the image is Wolfi-based:

> ERRO[0010] While applying layer: ApplyLayer stdout:  stderr: operation not permitted exit status 1

We've seen in the past that switching to `docker` in these situations makes sense as a work-around.