### PR TITLE
Use latest drivah image for building multiarch images

### DIFF
--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -105,7 +105,7 @@ steps:
           - ".buildkite/publish/push-docker.sh"
       - label: "Build and push multiarch Docker image"
         agents:
-          image: "docker.elastic.co/ci-agent-images/drivah:0.24.3"
+          image: "docker.elastic.co/ci-agent-images/drivah:0.25.2"
           ephemeralStorage: "20G"
           memory: "4G"
         command: ".buildkite/publish/build-multiarch-docker.sh"
@@ -228,7 +228,7 @@ steps:
           - ".buildkite/publish/push-docker.sh"
       - label: "Build and push multiarch Docker image based on Wolfi"
         agents:
-          image: "docker.elastic.co/ci-agent-images/drivah:0.24.3"
+          image: "docker.elastic.co/ci-agent-images/drivah:0.25.2"
           ephemeralStorage: "20G"
           memory: "4G"
         env:


### PR DESCRIPTION
`buildah` is failing to build a multi-arch image when the image is Wolfi-based:

> ERRO[0010] While applying layer: ApplyLayer stdout:  stderr: operation not permitted exit status 1

It's possible that a newer version of `buildah`, which we'll get via the newer `drivah` image, may fix the problem.

If this doesn't work, we can go back to the approach over here: https://github.com/elastic/connectors/pull/2622