### PR TITLE
[Connector API] Validate and activate filtering with API call

### DIFF
--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -34,6 +34,23 @@ class TemporaryConnectorApiWrapper(ESClient):
             headers={"accept": "application/json"},
         )
 
+    async def connector_update_filtering_draft_validation(
+        self, connector_id, validation_info
+    ):
+        await self.client.perform_request(
+            "PUT",
+            f"/_connector/{connector_id}/_filtering/_validation",
+            headers={"accept": "application/json", "Content-Type": "application/json"},
+            body={"validation": validation_info},
+        )
+
+    async def connector_activate_filtering_draft(self, connector_id):
+        await self.client.perform_request(
+            "PUT",
+            f"/_connector/{connector_id}/_filtering/_activate",
+            headers={"accept": "application/json"},
+        )
+
 
 class ESApi(ESClient):
     def __init__(self, elastic_config):
@@ -43,6 +60,22 @@ class ESApi(ESClient):
     async def connector_check_in(self, connector_id):
         await self._retrier.execute_with_retry(
             partial(self._api_wrapper.connector_check_in, connector_id)
+        )
+
+    async def connector_update_filtering_draft_validation(
+        self, connector_id, validation_info
+    ):
+        await self._retrier.execute_with_retry(
+            partial(
+                self._api_wrapper.connector_update_filtering_draft_validation,
+                connector_id,
+                validation_info,
+            )
+        )
+
+    async def connector_activate_filtering_draft(self, connector_id):
+        await self._retrier.execute_with_retry(
+            partial(self._api_wrapper.connector_activate_filtering_draft, connector_id)
         )
 
 

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -35,13 +35,13 @@ class TemporaryConnectorApiWrapper(ESClient):
         )
 
     async def connector_update_filtering_draft_validation(
-        self, connector_id, validation_info
+        self, connector_id, validation_result
     ):
         await self.client.perform_request(
             "PUT",
             f"/_connector/{connector_id}/_filtering/_validation",
             headers={"accept": "application/json", "Content-Type": "application/json"},
-            body={"validation": validation_info},
+            body={"validation": validation_result},
         )
 
     async def connector_activate_filtering_draft(self, connector_id):
@@ -63,13 +63,13 @@ class ESApi(ESClient):
         )
 
     async def connector_update_filtering_draft_validation(
-        self, connector_id, validation_info
+        self, connector_id, validation_result
     ):
         await self._retrier.execute_with_retry(
             partial(
                 self._api_wrapper.connector_update_filtering_draft_validation,
                 connector_id,
-                validation_info,
+                validation_result,
             )
         )
 

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -972,10 +972,12 @@ class Connector(ESDocument):
 
         if self.index.feature_use_connectors_api:
             await self.index.api.connector_update_filtering_draft_validation(
-                self.id, validation_result.to_dict()
+                connector_id=self.id, validation_result=validation_result.to_dict()
             )
             if validation_result.state == FilteringValidationState.VALID:
-                await self.index.api.connector_activate_filtering_draft(self.id)
+                await self.index.api.connector_activate_filtering_draft(
+                    connector_id=self.id
+                )
         else:
             filtering = self.filtering.to_list()
             for filter_ in filtering:

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -970,21 +970,28 @@ class Connector(ESDocument):
         validation_result = await validator.validate_filtering(draft_filter)
         self.log_info(f"Filtering validation result: {validation_result.state.value}")
 
-        filtering = self.filtering.to_list()
-        for filter_ in filtering:
-            if filter_.get("domain", "") == Filtering.DEFAULT_DOMAIN:
-                filter_.get("draft", {"validation": {}})[
-                    "validation"
-                ] = validation_result.to_dict()
-                if validation_result.state == FilteringValidationState.VALID:
-                    filter_["active"] = filter_.get("draft")
+        if self.index.feature_use_connectors_api:
+            await self.index.api.connector_update_filtering_draft_validation(
+                self.id, validation_result.to_dict()
+            )
+            if validation_result.state == FilteringValidationState.VALID:
+                await self.index.api.connector_activate_filtering_draft(self.id)
+        else:
+            filtering = self.filtering.to_list()
+            for filter_ in filtering:
+                if filter_.get("domain", "") == Filtering.DEFAULT_DOMAIN:
+                    filter_.get("draft", {"validation": {}})[
+                        "validation"
+                    ] = validation_result.to_dict()
+                    if validation_result.state == FilteringValidationState.VALID:
+                        filter_["active"] = filter_.get("draft")
 
-        await self.index.update(
-            doc_id=self.id,
-            doc={"filtering": filtering},
-            if_seq_no=self._seq_no,
-            if_primary_term=self._primary_term,
-        )
+            await self.index.update(
+                doc_id=self.id,
+                doc={"filtering": filtering},
+                if_seq_no=self._seq_no,
+                if_primary_term=self._primary_term,
+            )
         await self.reload()
 
     async def document_count(self):


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/7701

Next step after #2561

If the feature flag `feature_use_connectors_api` we call Connector APIs to update the filtering validation info and activate the filtering if valid.

- `PUT _connector/{connector_id}/_filtering/_validation` updates the draft validation info
- `PUT _connector/{connector_id}/_filtering/_activate` activates the draft