### PR TITLE
Bump elasticsearch and elastic-transport versions

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,8 +1,8 @@
 aiohttp==3.9.5
 aiofiles==23.2.1
 aiomysql==0.1.1
-elasticsearch[async]==8.13.0
-elastic-transport==8.13.0
+elasticsearch[async]==8.14.0
+elastic-transport==8.13.1
 pyyaml==6.0
 envyaml==1.10.211231
 ecs-logging==2.0.0


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/7218

This PR bumps the `elasticsearch` version to `8.14.0`, and `elastic-transport` version to `8.13.1` (There's no plan to release `8.14.0`)