### PR TITLE
[Confluence] Add Fields Author and Created Date

### DIFF
--- a/tests/sources/fixtures/confluence/fixture.py
+++ b/tests/sources/fixtures/confluence/fixture.py
@@ -160,7 +160,11 @@ class ConfluenceAPI:
                     "id": f"{document_type}_{content_count}",
                     "title": f"ES-scrum_{content_count}",
                     "type": document_type,
-                    "history": {"lastUpdated": {"when": "2023-01-24T04:07:19.672Z"}},
+                    "history": {
+                        "lastUpdated": {"when": "2023-01-24T04:07:19.672Z"},
+                        "createdDate": "2023-01-03T09:24:50.633Z",
+                        "createdBy": {"publicName": "user1", "username": "user1"},
+                    },
                     "children": {"attachment": {"size": ATTACHMENT_COUNT}},
                     "body": {"storage": {"value": f"This is a test {document_type}"}},
                     "space": {"name": "Demo Space 0"},

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -76,6 +76,11 @@ SPACE = {
             "operation": {"operation": "read", "targetType": "space"},
         }
     ],
+    "history": {
+        "lastUpdated": {"when": "2023-01-24T04:07:19.672Z"},
+        "createdDate": "2023-01-03T09:24:50.633Z",
+        "createdBy": {"publicName": "user1"},
+    },
 }
 
 RESPONSE_PAGE = {
@@ -84,7 +89,11 @@ RESPONSE_PAGE = {
             "id": 4779,
             "title": "ES-scrum",
             "type": "page",
-            "history": {"lastUpdated": {"when": "2023-01-24T04:07:19.672Z"}},
+            "history": {
+                "lastUpdated": {"when": "2023-01-24T04:07:19.672Z"},
+                "createdDate": "2023-01-03T09:24:50.633Z",
+                "createdBy": {"publicName": "user1"},
+            },
             "children": {"attachment": {"size": 2}},
             "body": {"storage": {"value": "This is a test page"}},
             "space": {"name": "DEMO"},
@@ -110,6 +119,8 @@ EXPECTED_PAGE = {
     "space": "DEMO",
     "url": f"{HOST_URL}/spaces/~1234abc/pages/4779/ES-scrum",
     "labels": [None],
+    "author": "user1",
+    "createdDate": "2023-01-03T09:24:50.633Z",
 }
 
 EXPECTED_SPACE = {
@@ -118,6 +129,8 @@ EXPECTED_SPACE = {
     "title": "DEMO",
     "_timestamp": "2024-04-02T09:53:15.818621+00:00",
     "url": "http://127.0.0.1:9696/spaces/DM",
+    "createdDate": "2023-01-03T09:24:50.633Z",
+    "author": "user1",
 }
 
 RESPONSE_ATTACHMENT = {
@@ -127,6 +140,7 @@ RESPONSE_ATTACHMENT = {
             "title": "demo.py",
             "type": "attachment",
             "version": {"when": "2023-01-03T09:24:50.633Z"},
+            "history": {"createdDate": "2023-01-03T09:24:50.633Z"},
             "extensions": {"fileSize": 230},
             "_links": {
                 "download": "/download/attachments/1113/demo.py?version=1&modificationDate=1672737890633&cacheVersion=1&api=v2",
@@ -149,6 +163,7 @@ EXPECTED_ATTACHMENT = {
     "space": "DEMO",
     "page": "ES-scrum",
     "url": f"{HOST_URL}/pages/viewpageattachments.action?pageId=1113&preview=demo.py",
+    "createdDate": "2023-01-03T09:24:50.633Z",
 }
 
 RESPONSE_CONTENT = "# This is the dummy file"
@@ -190,6 +205,8 @@ EXPECTED_BLOG = {
     "body": "This is a test blog",
     "space": "DEMO",
     "url": f"{HOST_URL}/spaces/~1234abc/blogposts/4779/demo-blog",
+    "createdDate": "2023-01-03T09:24:50.633Z",
+    "author": "user1",
 }
 
 EXPECTED_BLOG_ATTACHMENT = {
@@ -201,6 +218,8 @@ EXPECTED_BLOG_ATTACHMENT = {
     "space": "DEMO",
     "blog": "demo-blog",
     "url": f"{HOST_URL}/pages/viewpageattachments.action?pageId=1113&preview=demo.py",
+    "createdDate": "2023-01-03T09:24:50.633Z",
+    "author": "user1",
 }
 
 RESPONSE_SEARCH_RESULT = {
@@ -217,6 +236,11 @@ RESPONSE_SEARCH_RESULT = {
                         "embeddedContent": [],
                         "_expandable": {"content": "/rest/api/content/6455384"},
                     },
+                },
+                "history": {
+                    "lastUpdated": {"when": "2023-01-24T04:07:19.672Z"},
+                    "createdDate": "2023-01-03T09:24:50.633Z",
+                    "createdBy": {"publicName": "user1", "username": "user1"},
                 },
             },
             "title": "Product Details",
@@ -245,6 +269,11 @@ RESPONSE_SEARCH_RESULT = {
                 },
                 "container": {"type": "page", "title": "Product Details"},
                 "_links": {"download": "/download/attachments/196717/Potential.pdf"},
+                "history": {
+                    "lastUpdated": {"when": "2023-01-24T04:07:19.672Z"},
+                    "createdDate": "2023-01-03T09:24:50.633Z",
+                    "createdBy": {"publicName": "user1", "username": "user1"},
+                },
             },
             "title": "Potential.pdf",
             "excerpt": "Evaluation Overview",
@@ -258,6 +287,11 @@ RESPONSE_SEARCH_RESULT = {
                 "id": "196612",
                 "key": "SD",
                 "type": "global",
+                "history": {
+                    "lastUpdated": {"when": "2023-01-24T04:07:19.672Z"},
+                    "createdDate": "2023-01-03T09:24:50.633Z",
+                    "createdBy": {"publicName": "user1", "username": "user1"},
+                },
             },
             "title": "Software Development",
             "excerpt": "",
@@ -270,7 +304,7 @@ RESPONSE_SEARCH_RESULT = {
 }
 
 
-EXPECTED_SEARCH_RESULT_FOR_FILTERING = [
+EXPECTED_SEARCH_RESULT_FOR_FILTERING_CLOUD = [
     {
         "_id": "983046",
         "title": "Product Details",
@@ -279,6 +313,8 @@ EXPECTED_SEARCH_RESULT_FOR_FILTERING = [
         "type": "page",
         "space": "Software Development",
         "url": f"{HOST_URL}/spaces/SD/pages/983046/Product+Details",
+        "createdDate": "2023-01-03T09:24:50.633Z",
+        "author": "user1",
     },
     {
         "_id": "att4587521",
@@ -289,6 +325,45 @@ EXPECTED_SEARCH_RESULT_FOR_FILTERING = [
         "space": "Software Development",
         "size": 1119256,
         "page": "Product Details",
+        "createdDate": "2023-01-03T09:24:50.633Z",
+        "author": "user1",
+    },
+    {
+        "_id": "196612",
+        "title": "Software Development",
+        "_timestamp": "2022-12-13T09:49:01.000Z",
+        "body": None,
+        "type": "space",
+        "url": f"{HOST_URL}/spaces/SD",
+        "createdDate": "2023-01-03T09:24:50.633Z",
+        "author": "user1",
+    },
+]
+
+
+EXPECTED_SEARCH_RESULT_FOR_FILTERING_DATA_CENTER = [
+    {
+        "_id": "983046",
+        "title": "Product Details",
+        "_timestamp": "2022-12-19T13:06:18.000Z",
+        "body": "Confluence Connector currently supports below objects for ingestion of data in ElasticSearch.\nBlogs\nAttachments\nPages\nSpaces",
+        "type": "page",
+        "url": f"{HOST_URL}/spaces/SD/pages/983046/Product+Details",
+        "space": "Software Development",
+        "createdDate": "2023-01-03T09:24:50.633Z",
+        "author": "user1",
+    },
+    {
+        "_id": "att4587521",
+        "title": "Potential.pdf",
+        "_timestamp": "2023-01-24T03:34:38.000Z",
+        "type": "attachment",
+        "url": f"{HOST_URL}/pages/viewpageattachments.action?pageId=196717&preview=%2F196717%2F4587521%2FPotential.pdf",
+        "space": "Software Development",
+        "size": 1119256,
+        "page": "Product Details",
+        "createdDate": "2023-01-03T09:24:50.633Z",
+        "author": "user1",
     },
     {
         "_id": "196612",
@@ -299,6 +374,7 @@ EXPECTED_SEARCH_RESULT_FOR_FILTERING = [
         "url": f"{HOST_URL}/spaces/SD",
     },
 ]
+
 
 SPACE_PERMISSION_RESPONSE = [
     {
@@ -813,6 +889,7 @@ async def test_fetch_documents():
         async_response = AsyncMock()
         async_response.__aenter__ = AsyncMock(return_value=JSONAsyncMock(RESPONSE_PAGE))
         source.confluence_client.index_labels = True
+        source.confluence_client.data_source_type = "confluence_cloud"
         # Execute
         with mock.patch("aiohttp.ClientSession.get", return_value=async_response):
             async for response, _, _, _, _ in source.fetch_documents(api_query=""):
@@ -846,13 +923,14 @@ async def test_search_by_query():
         async_response.__aenter__ = AsyncMock(
             return_value=JSONAsyncMock(RESPONSE_SEARCH_RESULT)
         )
+        source.confluence_client.data_source_type = "confluence_cloud"
         documents = []
         with mock.patch("aiohttp.ClientSession.get", return_value=async_response):
             async for response, _ in source.search_by_query(
                 query="type in ('space', 'page', 'attachment') AND space.key ='SD'"
             ):
                 documents.append(response)
-        assert documents == EXPECTED_SEARCH_RESULT_FOR_FILTERING
+        assert documents == EXPECTED_SEARCH_RESULT_FOR_FILTERING_CLOUD
 
 
 @pytest.mark.asyncio
@@ -869,7 +947,7 @@ async def test_search_by_query_for_datacenter():
                 query="type in ('space', 'page', 'attachment') AND space.key ='SD'"
             ):
                 documents.append(response)
-        assert documents == EXPECTED_SEARCH_RESULT_FOR_FILTERING
+        assert documents == EXPECTED_SEARCH_RESULT_FOR_FILTERING_DATA_CENTER
 
 
 @pytest.mark.asyncio
@@ -1534,7 +1612,11 @@ async def test_fetch_page_blog_documents_with_labels():
                     "id": 4779,
                     "title": "ES-scrum",
                     "type": "page",
-                    "history": {"lastUpdated": {"when": "2023-01-24T04:07:19.672Z"}},
+                    "history": {
+                        "lastUpdated": {"when": "2023-01-24T04:07:19.672Z"},
+                        "createdDate": "2023-01-03T09:24:50.633Z",
+                        "createdBy": {"publicName": "user1"},
+                    },
                     "children": {"attachment": {"size": 2}},
                     "body": {"storage": {"value": "This is a test page"}},
                     "space": {"name": "DEMO"},


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2573


- Added missing fields for Creator/attribution, and Created date. 
- Last modified date is already available via the timestamp field. 

Note: There's a limitation for data center space objects, Author and Created date are not available in the API response.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
