### PR TITLE
[Jira] Add tooltip for service account id

### DIFF
--- a/connectors/sources/jira.py
+++ b/connectors/sources/jira.py
@@ -516,6 +516,7 @@ class JiraDataSource(BaseDataSource):
                 "label": "Jira Cloud service account id",
                 "order": 6,
                 "type": "str",
+                "tooltip": "Email address associated with Jira Cloud account. E.g. alex.wilber@gmail.com",
             },
             "api_token": {
                 "depends_on": [{"field": "data_source", "value": JIRA_CLOUD}],


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/2614

Added a tooltip to avoid the confusion for the `Jira Cloud service account id` configuration.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)
