### PR TITLE
try out pushed perf8 branch

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,7 +7,7 @@ pytest-cov==4.1.0
 pytest-asyncio==0.21.1
 pytest-mock==3.11.1
 pytest-randomly==3.13.0
-git+https://github.com/elastic/perf8/tree/seanstory/bump-matplotlib#egg=perf8
+git+https://github.com/elastic/perf8@seanstory/bump-matplotlib#egg=perf8
 freezegun==1.2.2
 pytest-fail-slow==0.3.0
 pyright==1.1.317

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -7,7 +7,7 @@ pytest-cov==4.1.0
 pytest-asyncio==0.21.1
 pytest-mock==3.11.1
 pytest-randomly==3.13.0
-git+https://github.com/elastic/perf8#egg=perf8
+git+https://github.com/elastic/perf8/tree/seanstory/bump-matplotlib#egg=perf8
 freezegun==1.2.2
 pytest-fail-slow==0.3.0
 pyright==1.1.317


### PR DESCRIPTION
Over the weekend, perf8 started causing issues as it was pinning a `matplotlib` version that was incompatible with a version of `numpy` that another dep was pulling in.

This PR aims to make use of the changes made here: https://github.com/elastic/perf8/pull/17

We won't actually merge this. Once this confirms that perf8 is working, we can close this PR, merge the perf8 PR, and CI should go back to working 🤞 