### PR TITLE
Create scheduled jobs with Connector APIs

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -154,9 +154,6 @@ class ConnectorIndex(ESIndex):
         logger.debug(f"ConnectorIndex connecting to {elastic_config['host']}")
         # initialize ESIndex instance
         super().__init__(index_name=CONNECTORS_INDEX, elastic_config=elastic_config)
-        self.feature_use_connectors_api = elastic_config.get(
-            "feature_use_connectors_api"
-        )
 
     async def heartbeat(self, doc_id):
         if self.feature_use_connectors_api:
@@ -1044,34 +1041,42 @@ class SyncJobIndex(ESIndex):
         )
 
     async def create(self, connector, trigger_method, job_type):
-        filtering = connector.filtering.get_active_filter().transform_filtering()
-        index_name = connector.index_name
+        if self.feature_use_connectors_api:
+            response = await self.api.connector_sync_job_create(
+                connector_id=connector.id,
+                trigger_method=trigger_method.value,
+                job_type=job_type.value,
+            )
+            return response["id"]
+        else:
+            filtering = connector.filtering.get_active_filter().transform_filtering()
+            index_name = connector.index_name
 
-        if job_type == JobType.ACCESS_CONTROL:
-            index_name = f"{ACCESS_CONTROL_INDEX_PREFIX}{index_name}"
+            if job_type == JobType.ACCESS_CONTROL:
+                index_name = f"{ACCESS_CONTROL_INDEX_PREFIX}{index_name}"
 
-        job_def = {
-            "connector": {
-                "id": connector.id,
-                "filtering": filtering,
-                "index_name": index_name,
-                "language": connector.language,
-                "pipeline": connector.pipeline.data,
-                "service_type": connector.service_type,
-                "configuration": connector.configuration.to_dict(),
-            },
-            "trigger_method": trigger_method.value,
-            "job_type": job_type.value,
-            "status": JobStatus.PENDING.value,
-            INDEXED_DOCUMENT_COUNT: 0,
-            INDEXED_DOCUMENT_VOLUME: 0,
-            DELETED_DOCUMENT_COUNT: 0,
-            "created_at": iso_utc(),
-            "last_seen": iso_utc(),
-        }
-        api_response = await self.index(job_def)
+            job_def = {
+                "connector": {
+                    "id": connector.id,
+                    "filtering": filtering,
+                    "index_name": index_name,
+                    "language": connector.language,
+                    "pipeline": connector.pipeline.data,
+                    "service_type": connector.service_type,
+                    "configuration": connector.configuration.to_dict(),
+                },
+                "trigger_method": trigger_method.value,
+                "job_type": job_type.value,
+                "status": JobStatus.PENDING.value,
+                INDEXED_DOCUMENT_COUNT: 0,
+                INDEXED_DOCUMENT_VOLUME: 0,
+                DELETED_DOCUMENT_COUNT: 0,
+                "created_at": iso_utc(),
+                "last_seen": iso_utc(),
+            }
+            api_response = await self.index(job_def)
 
-        return api_response["_id"]
+            return api_response["_id"]
 
     async def pending_jobs(self, connector_ids, job_types):
         if not job_types:

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1961,11 +1961,40 @@ async def test_create_job(index_method, trigger_method, set_env):
     }
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    sync_job_index.feature_use_connectors_api = False
     await sync_job_index.create(
         connector=connector, trigger_method=trigger_method, job_type=JobType.INCREMENTAL
     )
 
     index_method.assert_called_with(expected_index_doc)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "trigger_method, job_type",
+    [
+        (JobTriggerMethod.ON_DEMAND, JobType.FULL),
+        (JobTriggerMethod.ON_DEMAND, JobType.INCREMENTAL),
+        (JobTriggerMethod.ON_DEMAND, JobType.ACCESS_CONTROL),
+        (JobTriggerMethod.SCHEDULED, JobType.FULL),
+        (JobTriggerMethod.SCHEDULED, JobType.INCREMENTAL),
+        (JobTriggerMethod.SCHEDULED, JobType.ACCESS_CONTROL),
+    ],
+)
+async def test_create_job_with_connector_api(trigger_method, job_type):
+    connector = Mock()
+    connector.id = "id"
+    config = load_config(CONFIG)
+    sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    sync_job_index.feature_use_connectors_api = True
+    sync_job_index.api.connector_sync_job_create = AsyncMock()
+    await sync_job_index.create(
+        connector=connector, trigger_method=trigger_method, job_type=job_type
+    )
+
+    sync_job_index.api.connector_sync_job_create.assert_awaited_once_with(
+        connector_id=connector.id, trigger_method=trigger_method, job_type=job_type
+    )
 
 
 @pytest.mark.asyncio
@@ -2010,6 +2039,7 @@ async def test_create_jobs_with_correct_target_index(
     }
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
+    sync_job_index.feature_use_connectors_api = False
     await sync_job_index.create(
         connector=connector,
         trigger_method=JobTriggerMethod.SCHEDULED,

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -1993,7 +1993,9 @@ async def test_create_job_with_connector_api(trigger_method, job_type):
     )
 
     sync_job_index.api.connector_sync_job_create.assert_awaited_once_with(
-        connector_id=connector.id, trigger_method=trigger_method, job_type=job_type
+        connector_id=connector.id,
+        trigger_method=trigger_method.value,
+        job_type=job_type.value,
     )
 
 


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/7472

Use [create sync job API ](https://www.elastic.co/guide/en/elasticsearch/reference/current/create-connector-sync-job-api.html) to create a scheduled sync job with a given type. 

This feature is behind a feature flag that is disabled by default.


### Validation
- added unit tests
- tested e2e on all sync types


#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)