### PR TITLE
Claim sync jobs with Connector APIs

### DIFF
--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -110,7 +110,7 @@ class ESApi(ESClient):
                 sync_cursor,
             )
         )
-    
+
     async def connector_sync_job_create(self, connector_id, job_type, trigger_method):
         return await self._retrier.execute_with_retry(
             partial(

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -325,14 +325,21 @@ class SyncJob(ESDocument):
 
     async def claim(self, sync_cursor=None):
         try:
-            doc = {
-                "status": JobStatus.IN_PROGRESS.value,
-                "started_at": iso_utc(),
-                "last_seen": iso_utc(),
-                "worker_hostname": socket.gethostname(),
-                "connector.sync_cursor": sync_cursor,
-            }
-            await self.index.update(doc_id=self.id, doc=doc)
+            if self.index.feature_use_connectors_api:
+                await self.index.api.connector_sync_job_claim(
+                    sync_job_id=self.id,
+                    worker_hostname=socket.gethostname(),
+                    sync_cursor=sync_cursor,
+                )
+            else:
+                doc = {
+                    "status": JobStatus.IN_PROGRESS.value,
+                    "started_at": iso_utc(),
+                    "last_seen": iso_utc(),
+                    "worker_hostname": socket.gethostname(),
+                    "connector.sync_cursor": sync_cursor,
+                }
+                await self.index.update(doc_id=self.id, doc=doc)
         except Exception as e:
             self._wrap_errors("claim job", e)
 

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -790,9 +790,25 @@ async def test_sync_job_claim():
     }
 
     sync_job = SyncJob(elastic_index=index, doc_source=source)
+    sync_job.index.feature_use_connectors_api = False
     await sync_job.claim(sync_cursor=SYNC_CURSOR)
 
     index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_claim_with_connector_api():
+    source = {"_id": "1"}
+    index = Mock()
+    index.api.connector_sync_job_claim = AsyncMock(return_value={"result": "updated"})
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+    sync_job.index.feature_use_connectors_api = True
+    await sync_job.claim(sync_cursor=SYNC_CURSOR)
+
+    index.api.connector_sync_job_claim.assert_called_with(
+        sync_job_id=sync_job.id, worker_hostname=ANY, sync_cursor=SYNC_CURSOR
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/7475

Use [claim sync job API](https://github.com/elastic/elasticsearch/pull/109480) to claim a sync job at the beginning of the sync.

This feature is behind a feature flag that is disabled by default.

### Validation
- added unit tests
- tested e2e on all sync types

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)