### PR TITLE
Update stack scripts README

### DIFF
--- a/scripts/stack/README.md
+++ b/scripts/stack/README.md
@@ -19,7 +19,8 @@ These scripts can also be used as a starting place for adding Connectors to your
 * Linux or macOS (Although Windows can run the Connectors service, it is not currently supported via these scripts)
 * Python 3.10
 * Docker with Docker Compose Installed
-* It is recommended to run Docker with at least 4GB of available RAM.
+    * It is recommended to run Docker with at least 4GB of available RAM.
+* cURL 8.7.1 or higher
 
 ## Running the Stack
 

--- a/scripts/stack/README.md
+++ b/scripts/stack/README.md
@@ -20,7 +20,8 @@ These scripts can also be used as a starting place for adding Connectors to your
 * Python 3.10
 * Docker with Docker Compose Installed
     * It is recommended to run Docker with at least 4GB of available RAM.
-* cURL 8.7.1 or higher
+* Curl 8.7.1 or higher
+    * Versions before 8.6.0 should also work. Just avoid 8.6 due to a [regression](https://curl.se/mail/lib-2024-02/0000.html) that will cause Kibana to not boot properly.
 
 ## Running the Stack
 

--- a/scripts/stack/README.md
+++ b/scripts/stack/README.md
@@ -21,7 +21,7 @@ These scripts can also be used as a starting place for adding Connectors to your
 * Docker with Docker Compose Installed
     * It is recommended to run Docker with at least 4GB of available RAM.
 * Curl 8.7.1 or higher
-    * Versions before 8.6.0 should also work. Just avoid 8.6 due to a [regression](https://curl.se/mail/lib-2024-02/0000.html) that will cause Kibana to not boot properly.
+    * Versions before 8.6.0 should also work. Just avoid 8.6 due to a [regression](https://www.github.com/curl/curl/issues/13170) that will cause Kibana to not boot properly.
 
 ## Running the Stack
 


### PR DESCRIPTION
There's a regression in curl prior to 8.7.1 (https://www.github.com/curl/curl/issues/13170) that can make stack scripts fail to launch Kibana.
This just adds a version requirement and an explanation about the existence of the regression.