### PR TITLE
[Amazon S3] Remove security concerned logs

### DIFF
--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -45,8 +45,6 @@ class S3Client:
             aws_access_key_id=self.configuration["aws_access_key_id"],
             aws_secret_access_key=self.configuration["aws_secret_access_key"],
         )
-        set_extra_logger(aws_logger, log_level=logging.DEBUG, prefix="S3")
-        set_extra_logger("aioboto3.resources", log_level=logging.INFO, prefix="S3")
         self.config = AioConfig(
             read_timeout=self.configuration["read_timeout"],
             connect_timeout=self.configuration["connect_timeout"],

--- a/connectors/sources/s3.py
+++ b/connectors/sources/s3.py
@@ -4,7 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 import asyncio
-import logging
 import os
 from contextlib import AsyncExitStack
 from functools import partial
@@ -12,7 +11,6 @@ from functools import partial
 import aioboto3
 import fastjsonschema
 from aiobotocore.config import AioConfig
-from aiobotocore.utils import logger as aws_logger
 from botocore.exceptions import ClientError
 from fastjsonschema import JsonSchemaValueException
 
@@ -20,7 +18,7 @@ from connectors.filtering.validation import (
     AdvancedRulesValidator,
     SyncRuleValidationResult,
 )
-from connectors.logger import logger, set_extra_logger
+from connectors.logger import logger
 from connectors.source import BaseDataSource
 from connectors.utils import hash_id
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2655

There is a security concern with the AWS library `aiobotocore` which is being called via the logs in S3 connector. This PR aims to remove those logs.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
~- [ ] Considered corresponding documentation changes~
~- [ ] Contributed any configuration settings changes to the configuration reference~
~- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)~

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
