### PR TITLE
Use Connector APIs to update sync job stats

### DIFF
--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -74,6 +74,19 @@ class TemporaryConnectorApiWrapper(ESClient):
             },
         )
 
+    async def connector_sync_job_update_stats(
+        self, sync_job_id, ingestion_stats, metadata
+    ):
+        await self.client.perform_request(
+            "PUT",
+            f"/_connector/_sync_job/{sync_job_id}/_stats",
+            headers={"accept": "application/json", "Content-Type": "application/json"},
+            body={
+                **ingestion_stats,
+                **({"metadata": metadata} if metadata else {}),
+            },
+        )
+
 
 class ESApi(ESClient):
     def __init__(self, elastic_config):
@@ -118,6 +131,18 @@ class ESApi(ESClient):
                 connector_id,
                 job_type,
                 trigger_method,
+            )
+        )
+
+    async def connector_sync_job_update_stats(
+        self, sync_job_id, ingestion_stats, metadata
+    ):
+        return await self._retrier.execute_with_retry(
+            partial(
+                self._api_wrapper.connector_sync_job_update_stats,
+                sync_job_id,
+                ingestion_stats,
+                metadata,
             )
         )
 

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -837,6 +837,7 @@ async def test_sync_job_claim_fails():
 async def test_sync_job_update_metadata():
     source = {"_id": "1"}
     index = Mock()
+    index.feature_use_connectors_api = False
     index.update = AsyncMock(return_value=1)
     ingestion_stats = {
         "indexed_document_count": 1,
@@ -859,6 +860,33 @@ async def test_sync_job_update_metadata():
     )
 
     index.update.assert_called_with(doc_id=sync_job.id, doc=expected_doc_source_update)
+
+
+@pytest.mark.asyncio
+async def test_sync_job_update_metadata_with_connector_api():
+    source = {"_id": "1"}
+    index = Mock()
+    index.feature_use_connectors_api = True
+    index.api.connector_sync_job_update_stats = AsyncMock()
+    ingestion_stats = {
+        "indexed_document_count": 1,
+        "indexed_document_volume": 13,
+        "deleted_document_count": 0,
+    }
+    connector_metadata = {"foo": "bar"}
+
+    sync_job = SyncJob(elastic_index=index, doc_source=source)
+
+    await sync_job.update_metadata(
+        ingestion_stats=ingestion_stats | {"blah": 0},
+        connector_metadata=connector_metadata,
+    )
+
+    index.api.connector_sync_job_update_stats.assert_called_with(
+        sync_job_id=sync_job.id,
+        ingestion_stats=ingestion_stats,
+        metadata=connector_metadata,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/7474

Use [update stats api](https://www.elastic.co/guide/en/elasticsearch/reference/master/set-connector-sync-job-stats-api.html) to update connector sync job ingestion stats.

Note we don't need to provide `last_seen` as server will update it automatically to current UTC timestamp. 

This feature is behind a feature flag that is disabled by default.

### Validation
- added unit tests
- tested e2e on all sync types

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)