### PR TITLE
Ensure orchestrator tasks are always canceled

### DIFF
--- a/connectors/connectors_cli.py
+++ b/connectors/connectors_cli.py
@@ -633,7 +633,7 @@ cli.add_command(job)
 
 
 def main(args=None):
-    cli()
+    cli()  # pyright: ignore
 
 
 if __name__ == "__main__":

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -817,6 +817,7 @@ class SyncOrchestrator:
 
     async def close(self):
         await self.es_management_client.close()
+        await self.cancel()
 
     async def has_active_license_enabled(self, license_):
         # TODO: think how to make it not a proxy method to the client
@@ -882,12 +883,31 @@ class SyncOrchestrator:
 
     async def cancel(self):
         if self._sink_task_running():
+            self._logger.info(
+                f"Cancling the Sink task: {self._sink_task.name}"  # pyright: ignore
+            )
             self._sink_task.cancel()
+        else:
+            self._logger.debug(
+                "Orchetrator cancel() called, but sink task is not running"
+            )
+
         if self._extractor_task_running():
+            self._logger.info(
+                f"Canceling the Extractor task: {self._extractor_task.name}"  # pyright: ignore
+            )
             self._extractor_task.cancel()
+        else:
+            self._logger.debug(
+                "Orchetrator cancel() called, but extractor task is not running"
+            )
+
         self.canceled = True
 
         cancelation_timeout = CANCELATION_TIMEOUT
+        self._logger.debug(
+            f"Allowing {cancelation_timeout} seconds for the orchestrator tasks to finish..."
+        )
         while cancelation_timeout > 0:
             await asyncio.sleep(1)
             cancelation_timeout -= 1
@@ -896,6 +916,10 @@ class SyncOrchestrator:
                     "Both Extractor and Sink tasks are successfully stopped."
                 )
                 return
+            self._logger.debug(f"Sink task running? {self._sink_task_running()}")
+            self._logger.debug(
+                f"Extractor task running? {self._extractor_task_running()}"
+            )
 
         self._logger.error(
             f"Sync job did not stop within {CANCELATION_TIMEOUT} seconds of canceling. Force-canceling."
@@ -990,7 +1014,8 @@ class SyncOrchestrator:
             skip_unchanged_documents=skip_unchanged_documents,
         )
         self._extractor_task = asyncio.create_task(
-            self._extractor.run(generator, job_type)
+            self._extractor.run(generator, job_type),
+            name=f"Extractor for {job_type} sync to {index}",
         )
         self._extractor_task.add_done_callback(
             functools.partial(self.extractor_task_callback)
@@ -1009,7 +1034,9 @@ class SyncOrchestrator:
             logger_=self._logger,
             enable_bulk_operations_logging=enable_bulk_operations_logging,
         )
-        self._sink_task = asyncio.create_task(self._sink.run())
+        self._sink_task = asyncio.create_task(
+            self._sink.run(), name=f"Sink for {job_type} sync to {index}"
+        )
         self._sink_task.add_done_callback(functools.partial(self.sink_task_callback))
 
     def sink_task_callback(self, task):

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -889,7 +889,7 @@ class SyncOrchestrator:
             self._sink_task.cancel()
         else:
             self._logger.debug(
-                "Orchetrator cancel() called, but sink task is not running"
+                "Orchestrator cancel() called, but sink task is not running"
             )
 
         if self._extractor_task_running():
@@ -899,7 +899,7 @@ class SyncOrchestrator:
             self._extractor_task.cancel()
         else:
             self._logger.debug(
-                "Orchetrator cancel() called, but extractor task is not running"
+                "Orchestrator cancel() called, but extractor task is not running"
             )
 
         self.canceled = True

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -345,12 +345,8 @@ class SyncJobRunner:
                 await self.job_reporting_task
             except asyncio.CancelledError:
                 self.sync_job.log_debug("Job reporting task is stopped.")
-        if (
-            self.sync_orchestrator is not None
-            and not self.sync_orchestrator.canceled
-            and sync_error is not None
-        ):
-            await self.sync_orchestrator.cancel()
+        if self.sync_orchestrator is not None:
+            await self.sync_orchestrator.cancel()  # in case the extractor/sink tasks are still running
 
         ingestion_stats = (
             {}

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -140,6 +140,8 @@ def sync_orchestrator_mock():
         sync_orchestrator_mock.has_active_license_enabled = AsyncMock(
             return_value=(True, License.PLATINUM)
         )
+        sync_orchestrator_mock._extractor_task = Mock()
+        sync_orchestrator_mock._sink_task = Mock()
         sync_orchestrator_klass_mock.return_value = sync_orchestrator_mock
 
         yield sync_orchestrator_mock
@@ -410,6 +412,7 @@ async def test_invalid_filtering(job_type, sync_orchestrator_mock):
     sync_job_runner.connector.sync_done.assert_awaited_with(
         sync_job_runner.sync_job, cursor=SYNC_CURSOR
     )
+    sync_job_runner.sync_orchestrator.cancel.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -438,6 +441,7 @@ async def test_invalid_filtering_access_control_sync_still_executed(
     sync_job_runner.connector.sync_done.assert_awaited_with(
         sync_job_runner.sync_job, cursor=None
     )
+    sync_job_runner.sync_orchestrator.cancel.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -475,6 +479,7 @@ async def test_async_bulk_error(job_type, sync_cursor, sync_orchestrator_mock):
     sync_job_runner.connector.sync_done.assert_awaited_with(
         sync_job_runner.sync_job, cursor=sync_cursor
     )
+    sync_job_runner.sync_orchestrator.cancel.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -509,6 +514,7 @@ async def test_access_control_sync_fails_with_insufficient_license(
     sync_job_runner.connector.sync_done.assert_awaited_with(
         sync_job_runner.sync_job, cursor=None
     )
+    sync_job_runner.sync_orchestrator.cancel.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -542,6 +548,7 @@ async def test_sync_job_runner(job_type, sync_cursor, sync_orchestrator_mock):
     sync_job_runner.connector.sync_done.assert_awaited_with(
         sync_job_runner.sync_job, cursor=sync_cursor
     )
+    sync_job_runner.sync_orchestrator.cancel.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -580,6 +587,7 @@ async def test_sync_job_runner_suspend(job_type, sync_cursor, sync_orchestrator_
     sync_job_runner.connector.sync_done.assert_awaited_with(
         sync_job_runner.sync_job, cursor=sync_cursor
     )
+    sync_job_runner.sync_orchestrator.cancel.assert_called_once()
 
 
 @patch("connectors.sync_job_runner.ES_ID_SIZE_LIMIT", 1)

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -140,8 +140,6 @@ def sync_orchestrator_mock():
         sync_orchestrator_mock.has_active_license_enabled = AsyncMock(
             return_value=(True, License.PLATINUM)
         )
-        sync_orchestrator_mock._extractor_task = Mock()
-        sync_orchestrator_mock._sink_task = Mock()
         sync_orchestrator_klass_mock.return_value = sync_orchestrator_mock
 
         yield sync_orchestrator_mock


### PR DESCRIPTION
## relates to https://github.com/elastic/connectors/issues/2638

We've been having an issue with the GCS ftest taking > 10 minutes. Digging with @artem-shelkovnikov today, we found that there was a sync that received a SIGINT, and acted like it was stopping/cleaning up (printed job counters and everything) but the extractor clearly kept going. Digging further, we found a logical error, where the SyncOrchestrator's tasks were only being canceled if there was an "error" in the job.

This change instead makes sure that `orchestrator.close()` always cancels the tasks if they are still running. It also makes sure that the SyncJobRunner's `_sync_done()` function always calls `orchestrator.cancel()`. There is no risk in calling `cancel()` multiple times.


## Checklists


#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Fixes a bug where the framework might receive an interrupt, but not terminate all running sync job tasks correctly.
