### PR TITLE
Fix flakey interrupt test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ steps:
 
   - label: ":pytest: Test"
     command: "make test"
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
 
   - label: ":shipit: Smoke test"
     command: "make ftest NAME=dir DATA_SIZE=small"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PYTHON=python3.10
 ARCH=$(shell uname -m)
 PERF8?=no
-SLOW_TEST_THRESHOLD=1 # seconds
+SLOW_TEST_THRESHOLD=2 # seconds
 VERSION=$(shell cat connectors/VERSION)
 
 DOCKER_IMAGE_NAME?=docker.elastic.co/enterprise-search/elastic-connectors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ def catch_stdout():
 @pytest.fixture
 def patch_logger(request):
     from connectors.logger import logger
+
     class PatchedLogger(Logger):
         def info(self, msg, *args, prefix=None, extra=None, exc_info=None):
             super(PatchedLogger, self).info(msg, *args)
@@ -91,7 +92,7 @@ def patch_logger(request):
         if request:
             silent = request.param
     except AttributeError:
-        pass # patch_logger may not be parametrized
+        pass  # patch_logger may not be parametrized
 
     new_logger = PatchedLogger(silent)
 

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -56,7 +56,11 @@ def test_version_action(option):
     assert __version__ in result.output
 
 
-@pytest.mark.parametrize(["sig", 'patch_logger'], [[signal.SIGINT, False], [signal.SIGTERM, False]], indirect=["patch_logger"])
+@pytest.mark.parametrize(
+    ["sig", "patch_logger"],
+    [[signal.SIGINT, False], [signal.SIGTERM, False]],
+    indirect=["patch_logger"],
+)
 @patch("connectors.service_cli.PreflightCheck")
 def test_shutdown_called_on_shutdown_signal(
     patch_preflight_check, sig, patch_logger, mock_responses, set_env


### PR DESCRIPTION
We've seen a few tests fail in buildkite with:
```
Exited with status 255 (after intercepting the agent's termination signal, sent because the job was canceled)
```

Looking deeper, those seem to have been coming because all the tests were taking > 5 min.
What's the long pole in this case? Looks like:

```
2024-06-27 14:29:01 UTC | tests/test_service_cli.py::test_main_exits_on_sigterm PASSED
2024-06-27 14:32:13 UTC | tests/test_service_cli.py::test_shutdown_called_on_shutdown_signal[Signals.SIGINT] # Received cancellation signal, interrupting
2024-06-27 14:32:13 UTC | FAILED
```

Notice the 3 minute gap.

Two problems here:
1. probably there is a race condition in the `test_shutdown_called_on_shutdown_signal` test, causing the CLI to not get the near-immediate interrupt signal, and instead waiting to shut down naturally when a connection to ES isn't established (takes a few minutes)
2. we have no logs to use for investigating. The test uses `patch_logger`, so we need to keep that capability, while also dumping the logs for debugging.

This PR attempts to fix both. It increases the `asyncio.sleep` to avoid the race condition (and increases the slow test threshold accordingly) and makes changes to PatchLogger to make `silent=False` actually work.

Finally, it also increases the buildkite timeout, so that we can get the full test output in these scenarios.

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

