### PR TITLE
Attempt to fix the flaky test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,16 @@ class Logger:
                 if isinstance(log, str) and msg in log:
                     raise AssertionError(f"'{msg}' found in {self.logs}")
 
+    def assert_regex(self, regex):
+        found = False
+        compiled_regex = re.compile(regex)
+        for log in self.logs:
+            if isinstance(log, str) and compiled_regex.match(log):
+                found = True
+                break
+        if not found:
+            raise AssertionError(f"'{msg}' not found in {self.logs}")
+
     def assert_present(self, lines):
         if isinstance(lines, str):
             lines = [lines]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ class Logger:
                 found = True
                 break
         if not found:
-            raise AssertionError(f"'{msg}' not found in {self.logs}")
+            raise AssertionError(f"r'{regex}' not found in {self.logs}")
 
     def assert_present(self, lines):
         if isinstance(lines, str):

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -65,13 +65,16 @@ def test_shutdown_called_on_shutdown_signal(
 
     async def emit_shutdown_signal():
         pid = os.getpid()
-        while True:
+        retries = 10
+        while retries > 0:
             try:
                 patch_logger.assert_regex("Job Scheduling Service started.*")
                 os.kill(pid, sig)
                 break
             except AssertionError:
+                retries -=1
                 await asyncio.sleep(0.1)
+        os.kill(pid, sig)
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -70,7 +70,7 @@ def test_shutdown_called_on_shutdown_signal(
                 patch_logger.assert_regex("Job Scheduling Service started.*")
                 os.kill(pid, sig)
                 break
-            except Exception:
+            except AssertionError:
                 await asyncio.sleep(0.1)
 
     loop = asyncio.new_event_loop()

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -71,7 +71,7 @@ def test_shutdown_called_on_shutdown_signal(
                 os.kill(pid, sig)
                 break
             except Exception:
-                await asyncio.sleep(0.2)
+                await asyncio.sleep(0.1)
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -64,8 +64,14 @@ def test_shutdown_called_on_shutdown_signal(
     patch_preflight_check.return_value.run = AsyncMock()
 
     async def emit_shutdown_signal():
-        await asyncio.sleep(0.2)
-        os.kill(os.getpid(), sig)
+        pid = os.getpid()
+        while True:
+            try:
+                patch_logger.assert_regex("Job Scheduling Service started.*")
+                os.kill(pid, sig)
+                break
+            except Exception:
+                await asyncio.sleep(0.2)
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2517

Problem seems to happen because the test is running interrupt in the wrong moment - not when the service has started. Therefore when SIGINT/SIGTERM is issued, service is not there yet and cannot start the shutdown procedure.

This PR attempts to fix it by changing the code that issues SIGTERM/SIGINT: now it reads the logger and issues the signal only after a log line saying that service has started is present in the logs.

## Checklists

#### Pre-Review Checklist
- [ ] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [ ] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [ ] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
