### PR TITLE
Build and publish Wolfi-based images only

### DIFF
--- a/.buildkite/nightly_docker.yml
+++ b/.buildkite/nightly_docker.yml
@@ -13,17 +13,6 @@ steps:
       - label: "Building and pushing Docker image"
         env:
           DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors"
-          DOCKERFILE_PATH: "Dockerfile"
-        command:
-          - ".buildkite/publish_docker.sh"
-  # ----
-  # Docker images - Chainguard
-  # ----
-  - group: "🏗️ Docker images - Chainguard"
-    steps:
-      - label: "Building and pushing Docker image based on Wolfi"
-        env:
-          DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
           DOCKERFILE_PATH: "Dockerfile.wolfi"
         command:
           - ".buildkite/publish_docker.sh"

--- a/.buildkite/publish/publish-common.sh
+++ b/.buildkite/publish/publish-common.sh
@@ -23,7 +23,7 @@ fi
 
 export BASE_TAG_NAME=${DOCKER_IMAGE_NAME:-docker.elastic.co/enterprise-search/elastic-connectors}
 export DOCKERFILE_PATH=${DOCKERFILE_PATH:-Dockerfile}
-export DOCKER_ARTIFACT_KEY=${DOCKER_ARTIFACT_KEY:-elastic-connectors-docker-debian}
+export DOCKER_ARTIFACT_KEY=${DOCKER_ARTIFACT_KEY:-elastic-connectors-docker}
 
 export VAULT_ADDR=${VAULT_ADDR:-https://vault-ci-prod.elastic.dev}
 export VAULT_USER="docker-swiftypeadmin"

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -16,7 +16,7 @@ steps:
           imagePrefix: ci-amazonlinux-2
         env:
           ARCHITECTURE: "amd64"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-debian"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
         command: ".buildkite/publish/build-docker.sh"
         key: "build_docker_image_amd64"
         artifact_paths: ".artifacts/*.tar.gz"
@@ -27,6 +27,7 @@ steps:
           imagePrefix: ci-amazonlinux-2
         env:
           ARCHITECTURE: "amd64"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
         depends_on: "build_docker_image_amd64"
         commands:
           - "mkdir -p .artifacts"
@@ -48,7 +49,7 @@ steps:
           diskName: '/dev/xvda'
         env:
           ARCHITECTURE: "arm64"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-debian"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
         command: ".buildkite/publish/build-docker.sh"
         key: "build_docker_image_arm64"
         artifact_paths: ".artifacts/*.tar.gz"
@@ -61,6 +62,7 @@ steps:
           diskName: '/dev/xvda'
         env:
           ARCHITECTURE: "arm64"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
         depends_on: "build_docker_image_arm64"
         commands:
           - "mkdir -p .artifacts"
@@ -79,7 +81,7 @@ steps:
         key: "push_amd64_docker_image"
         env:
           ARCHITECTURE: "amd64"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-debian"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
         agents:
           provider: aws
           instanceType: m6i.xlarge
@@ -92,7 +94,7 @@ steps:
         key: "push_arm64_docker_image"
         env:
           ARCHITECTURE: "arm64"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-debian"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
         agents:
           provider: aws
           instanceType: m6g.xlarge
@@ -112,128 +114,3 @@ steps:
         depends_on:
           - "push_amd64_docker_image"
           - "push_arm64_docker_image"
-
-  # ----
-  # Docker builds for amd64 - Chainguard
-  # ----
-  - group: ":package: amd64 Build and Test - Chainguard"
-    key: "build_and_test_amd64_wolfi"
-    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
-    steps:
-      - label: "Building amd64 Docker image based on Wolfi"
-        agents:
-          provider: aws
-          instanceType: m6i.xlarge
-          imagePrefix: ci-amazonlinux-2
-        env:
-          ARCHITECTURE: "amd64"
-          DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
-          DOCKERFILE_PATH: "Dockerfile.wolfi"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-wolfi"
-        command: ".buildkite/publish/build-docker.sh"
-        key: "build_docker_image_amd64_wolfi"
-        artifact_paths: ".artifacts/*.tar.gz"
-      - label: "Testing amd64 Docker image based on Wolfi"
-        agents:
-          provider: aws
-          instanceType: m6i.xlarge
-          imagePrefix: ci-amazonlinux-2
-        env:
-          ARCHITECTURE: "amd64"
-          DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
-          DOCKERFILE_PATH: "Dockerfile.wolfi"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-wolfi"
-        depends_on: "build_docker_image_amd64_wolfi"
-        commands:
-          - "mkdir -p .artifacts"
-          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_amd64_wolfi
-          - ".buildkite/publish/test-docker.sh"
-  # ----
-  # Docker builds for arm64 - Chainguard
-  # ----
-  - group: ":package: arm64 Build and Test - Chainguard"
-    key: "build_and_test_arm64_wolfi"
-    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
-    steps:
-      - label: "Building arm64 Docker image based on Wolfi"
-        agents:
-          provider: aws
-          instanceType: m6g.xlarge
-          imagePrefix: ci-amazonlinux-2-aarch64
-          diskSizeGb: 40
-          diskName: '/dev/xvda'
-        env:
-          ARCHITECTURE: "arm64"
-          DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
-          DOCKERFILE_PATH: "Dockerfile.wolfi"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-wolfi"
-        command: ".buildkite/publish/build-docker.sh"
-        key: "build_docker_image_arm64_wolfi"
-        artifact_paths: ".artifacts/*.tar.gz"
-      - label: "Testing arm64 Docker image based on Wolfi"
-        agents:
-          provider: aws
-          instanceType: m6g.xlarge
-          imagePrefix: ci-amazonlinux-2-aarch64
-          diskSizeGb: 40
-          diskName: '/dev/xvda'
-        env:
-          ARCHITECTURE: "arm64"
-          DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
-          DOCKERFILE_PATH: "Dockerfile.wolfi"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-wolfi"
-        depends_on: "build_docker_image_arm64_wolfi"
-        commands:
-          - "mkdir -p .artifacts"
-          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_arm64_wolfi
-          - ".buildkite/publish/test-docker.sh"
-  # ----
-  # Multiarch Docker image build and push - Chainguard
-  # ----
-  - group: ":truck: Publish images - Chainguard"
-    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
-    depends_on:
-      - "build_and_test_amd64_wolfi"
-      - "build_and_test_arm64_wolfi"
-    steps:
-      - label: "Push amd64 Docker image based on Wolfi"
-        key: "push_amd64_docker_image_wolfi"
-        env:
-          ARCHITECTURE: "amd64"
-          DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-wolfi"
-        agents:
-          provider: aws
-          instanceType: m6i.xlarge
-          imagePrefix: ci-amazonlinux-2
-        commands:
-          - "mkdir -p .artifacts"
-          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_amd64_wolfi
-          - ".buildkite/publish/push-docker.sh"
-      - label: "Push arm64 Docker image based on Wolfi"
-        key: "push_arm64_docker_image_wolfi"
-        env:
-          ARCHITECTURE: "arm64"
-          DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
-          DOCKER_ARTIFACT_KEY: "elastic-connectors-docker-wolfi"
-        agents:
-          provider: aws
-          instanceType: m6g.xlarge
-          imagePrefix: ci-amazonlinux-2-aarch64
-          diskSizeGb: 40
-          diskName: '/dev/xvda'
-        commands:
-          - "mkdir -p .artifacts"
-          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_arm64_wolfi
-          - ".buildkite/publish/push-docker.sh"
-      - label: "Build and push multiarch Docker image based on Wolfi"
-        agents:
-          image: "docker.elastic.co/ci-agent-images/drivah:0.25.0"
-          ephemeralStorage: "20G"
-          memory: "4G"
-        env:
-          DOCKER_IMAGE_NAME: "docker.elastic.co/enterprise-search/elastic-connectors-wolfi"
-        command: ".buildkite/publish/build-multiarch-docker.sh"
-        depends_on:
-          - "push_amd64_docker_image_wolfi"
-          - "push_arm64_docker_image_wolfi"


### PR DESCRIPTION
With 8.14 we published two image flavours:
* `docker.elastic.co/enterprise-search/elastic-connectors` (based on Debian)
* `docker.elastic.co/enterprise-search/elastic-connectors-wolfi` (based on Wolfi)

Only `docker.elastic.co/enterprise-search/elastic-connectors` (based on Wolfi) will be published from 8.15.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)