### PR TITLE
Bump aioboto

### DIFF
--- a/requirements/aarch64.txt
+++ b/requirements/aarch64.txt
@@ -1,7 +1,6 @@
 # Linux ARM
 -r framework.txt
 
-aioboto3==10.3.0
 pymongo==4.6.3
 motor==3.4.0
 smbprotocol==1.9.0

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -39,3 +39,4 @@ simple-term-menu==1.6.4
 graphql-core==3.2.3
 notion-client==2.2.1
 certifi==2023.7.22
+aioboto3==12.4.0

--- a/requirements/ftest.txt
+++ b/requirements/ftest.txt
@@ -5,7 +5,7 @@ mysql-connector-python==8.1.0
 google-auth==2.22.0
 google-cloud-storage==2.10.0
 asyncpg==0.28.0
-boto3==1.24.59
+boto3==1.34.69
 oracledb==1.2.2
 smbprotocol==1.10.1
 yattag==1.15.1

--- a/requirements/x86_64.txt
+++ b/requirements/x86_64.txt
@@ -3,5 +3,4 @@
 
 pymongo==4.6.3
 motor==3.4.0
-aioboto3==10.3.0
 smbprotocol==1.9.0

--- a/tests/sources/test_s3.py
+++ b/tests/sources/test_s3.py
@@ -480,7 +480,7 @@ async def test_close_with_client_session():
         await source.s3_client.client()
 
         await source.close()
-        with pytest.raises(HTTPClientError):
+        with pytest.raises(ClientError):
             await source.ping()
 
 

--- a/tests/sources/test_s3.py
+++ b/tests/sources/test_s3.py
@@ -11,7 +11,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 import aioboto3
 import aiofiles
 import pytest
-from botocore.exceptions import ClientError, HTTPClientError
+from botocore.exceptions import ClientError
 
 from connectors.filtering.validation import SyncRuleValidationResult
 from connectors.protocol import Filter


### PR DESCRIPTION
Snyk flagged a race condition:

```
Introduced through aioboto3@10.3.0
Fixed in aiobotocore@2.9.1
```

This PR bumps our `aioboto3` dep to give us:
```
Name: aiobotocore
Version: 2.12.3
``` 

I also took the opportunity to move this dep into `requirements/framework.txt` since we don't support any architecture that doesn't include this, so having it separate files felt redundant.

The upgrade caused one test failure, where an `aioboto.exceptions.ClientError` was raised instead of an `aioboto.exceptions.HTTPClientError`. I think that's likely ok, as the S3 connector doesn't have any reliance on `HTTPClientError`, so this only broke the test, but not the connector itself.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

