### PR TITLE
Include `manage_connector` privilege in generated api keys

### DIFF
--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -240,7 +240,7 @@ class Connector:
         metadata = {"created_by": "Connectors CLI"}
         role_descriptors = {
             f"{name}-connector-role": {
-                "cluster": ["monitor"],
+                "cluster": ["monitor", "manage_connector"],
                 "index": [
                     {
                         "names": [


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/7837

We introduced `manage_connector` privilege in ES: https://github.com/elastic/elasticsearch/pull/110128

Let's use it for new generated API keys for connectors.

See Kibana PR for reference with similar change: https://github.com/elastic/kibana/pull/187361

This is not backward compatible, since the new privilege is introduced in 8.15. Hence CLI won't work with <8.15 ES versions

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
