### PR TITLE
Replace task.name with task.get_name()

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -884,7 +884,7 @@ class SyncOrchestrator:
     async def cancel(self):
         if self._sink_task_running():
             self._logger.info(
-                f"Cancling the Sink task: {self._sink_task.name}"  # pyright: ignore
+                f"Canceling the Sink task: {self._sink_task.get_name()}"  # pyright: ignore
             )
             self._sink_task.cancel()
         else:
@@ -894,7 +894,7 @@ class SyncOrchestrator:
 
         if self._extractor_task_running():
             self._logger.info(
-                f"Canceling the Extractor task: {self._extractor_task.name}"  # pyright: ignore
+                f"Canceling the Extractor task: {self._extractor_task.get_name()}"  # pyright: ignore
             )
             self._extractor_task.cancel()
         else:

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -883,9 +883,7 @@ class SyncOrchestrator:
 
     async def cancel(self):
         if self._sink_task_running():
-            self._logger.info(
-                f"Canceling the Sink task: {self._sink_task.get_name()}"  # pyright: ignore
-            )
+            self._logger.info(f"Canceling the Sink task: {self._sink_task.get_name()}")
             self._sink_task.cancel()
         else:
             self._logger.debug(
@@ -894,7 +892,7 @@ class SyncOrchestrator:
 
         if self._extractor_task_running():
             self._logger.info(
-                f"Canceling the Extractor task: {self._extractor_task.get_name()}"  # pyright: ignore
+                f"Canceling the Extractor task: {self._extractor_task.get_name()}"
             )
             self._extractor_task.cancel()
         else:

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -1419,11 +1419,11 @@ async def test_cancel_sync(extractor_task_done, sink_task_done, force_cancel):
     es._sink = Mock()
     es._sink.force_cancel = Mock()
 
-    es._extractor_task = Mock()
+    es._extractor_task = mock.create_autospec(asyncio.Task)
     es._extractor_task.cancel = Mock()
     es._extractor_task.done = Mock(side_effect=extractor_task_done)
 
-    es._sink_task = Mock()
+    es._sink_task = mock.create_autospec(asyncio.Task)
     es._sink_task.cancel = Mock()
     es._sink_task.done = Mock(side_effect=sink_task_done)
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2689


Fixes a bug where `task.name` is not a thing, but my previous usage of mocks in the spec covered up the AttributeError

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)



## Related Pull Requests

* first fixed in https://github.com/elastic/connectors/pull/2671/files#diff-68c31d9379d91378705cf6d47c447185e8c6ad952876c7a5fb979e3c89646148R914, but that might be a minute before merged, so putting this up separately.


