### PR TITLE
log in utc

### DIFF
--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -29,15 +29,23 @@ class ColorFormatter(logging.Formatter):
     RED = "\x1b[31;20m"
     BOLD_RED = "\x1b[31;1m"
     RESET = "\x1b[0m"
+    COLORS = {
+        logging.DEBUG: GREY,
+        logging.INFO: GREEN,
+        logging.WARNING: YELLOW,
+        logging.ERROR: RED,
+        logging.CRITICAL: BOLD_RED,
+    }
 
     DATE_FMT = "%H:%M:%S"
 
     def __init__(self, prefix):
         self.custom_format = "[" + prefix + "][%(asctime)s][%(levelname)s] %(message)s"
         super().__init__(datefmt=self.DATE_FMT)
+        self.local_tz = tzlocal()
 
     def converter(self, timestamp):
-        dt = datetime.fromtimestamp(timestamp, tzlocal())
+        dt = datetime.fromtimestamp(timestamp, self.local_tz)
         return dt.astimezone(timezone.utc)
 
     # override logging.Formatter to use an aware datetime object
@@ -53,16 +61,7 @@ class ColorFormatter(logging.Formatter):
         return s
 
     def format(self, record):  # noqa: A003
-        if record.levelno == logging.DEBUG:
-            self._style._fmt = self.GREY + self.custom_format + self.RESET
-        elif record.levelno == logging.INFO:
-            self._style._fmt = self.GREEN + self.custom_format + self.RESET
-        elif record.levelno == logging.WARNING:
-            self._style._fmt = self.YELLOW + self.custom_format + self.RESET
-        elif record.levelno == logging.ERROR:
-            self._style._fmt = self.RED + self.custom_format + self.RESET
-        elif record.levelno == logging.CRITICAL:
-            self._style._fmt = self.BOLD_RED + self.custom_format + self.RESET
+        self._style._fmt = self.COLORS[record.levelno] + self.custom_format + self.RESET
         return super().format(record)
 
 

--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -7,16 +7,15 @@
 Logger -- sets the logging and provides a `logger` global object.
 """
 import contextlib
-import datetime
 import inspect
 import logging
 import time
+from datetime import datetime, timezone
 from functools import wraps
 from typing import AsyncGenerator
 
 import ecs_logging
-import pytz
-import tzlocal
+from dateutil.tz import tzlocal
 
 from connectors import __version__
 
@@ -38,9 +37,8 @@ class ColorFormatter(logging.Formatter):
         super().__init__(datefmt=self.DATE_FMT)
 
     def converter(self, timestamp):
-        tzinfo = tzlocal.get_localzone()
-        dt = datetime.datetime.fromtimestamp(timestamp, tzinfo)
-        return dt.astimezone(pytz.UTC)
+        dt = datetime.fromtimestamp(timestamp, tzlocal())
+        return dt.astimezone(timezone.utc)
 
     # override logging.Formatter to use an aware datetime object
     def formatTime(self, record, datefmt=None):
@@ -55,7 +53,6 @@ class ColorFormatter(logging.Formatter):
         return s
 
     def format(self, record):  # noqa: A003
-        # record.asctime = self.formatTime(record, self.DATE_FMT)
         if record.levelno == logging.DEBUG:
             self._style._fmt = self.GREY + self.custom_format + self.RESET
         elif record.levelno == logging.INFO:

--- a/connectors/logger.py
+++ b/connectors/logger.py
@@ -11,7 +11,7 @@ import datetime
 import inspect
 import logging
 import time
-from functools import cached_property, wraps
+from functools import wraps
 from typing import AsyncGenerator
 
 import ecs_logging
@@ -49,7 +49,7 @@ class ColorFormatter(logging.Formatter):
             s = dt.strftime(datefmt)
         else:
             try:
-                s = dt.isoformat(timespec='milliseconds')
+                s = dt.isoformat(timespec="milliseconds")
             except TypeError:
                 s = dt.isoformat()
         return s


### PR DESCRIPTION

I noticed log lines like:
```
[FMWK][14:25:44][DEBUG] [job_scheduling_service] Scheduler woke up at 2024-07-09 19:25:44.085357+00:00.
```

notice that the logging framework timestamp is `14:25:44` (my local time) but the connectors logic understands that the time should be reasoned about in UTC (`19:25:44`). 

This discrepancy makes it hard to get scheduling right. If I just look at the _majority_ of timestamps that I see in the logs, I'd assume that the scheduling logic should use my local time, and not UTC time.

This PR fixes the issue by overwriting `logging.Formatter.format_time()` for our Formatter class.

It also simplifies the logic for changing the style depending on log level so that function overwrites work. 

## Checklists


#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)



## Release Note

Connector logs now use UTC timestamps, instead of machine-local timestamps. This only impacts logging output.