### PR TITLE
Log error when sync ends

### DIFF
--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -366,6 +366,7 @@ class SyncJobRunner:
                 ] = await self.connector.document_count()
 
             if sync_status == JobStatus.ERROR:
+                self.sync_job.log_error(f"Terminated with error: {sync_error}")
                 await self.sync_job.fail(sync_error, ingestion_stats=persisted_stats)
             elif sync_status == JobStatus.SUSPENDED:
                 await self.sync_job.suspend(ingestion_stats=persisted_stats)


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2645

Once syncs end with an error we just say:

```
Sync ended with status error -- created: 0 | updated: 4000 | deleted: 0 (took 423 seconds)
```

Actual error is not logged anywhere - you need to go to UI or connectors index to figure out what's the error. This is problematic when doing support of connectors via reading logs.

This PR adds a log line for situation when connector terminates with status error, this line contains the error message that will be shown in UI.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)