### PR TITLE
Change docker-compose network in stack scripts to `elastic`

### DIFF
--- a/scripts/stack/docker/docker-compose.yml
+++ b/scripts/stack/docker/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3"
 
 networks:
-  connectors_stack_net:
+  elastic:
+    name: 'elastic'
+    external: true
 
 services:
   elasticsearch:
@@ -19,7 +21,7 @@ services:
         soft: -1
         hard: -1
     networks:
-      - connectors_stack_net
+      - elastic
     ports:
       - 9200:9200
     volumes:
@@ -32,7 +34,7 @@ services:
     depends_on:
       - elasticsearch
     networks:
-      - connectors_stack_net
+      - elastic
     environment:
       ELASTICSEARCH_URL: http://elasticsearch:9200
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
@@ -48,7 +50,7 @@ services:
     volumes:
       - ${CURDIR}/connectors-config:/config
     command: /app/bin/elastic-ingest -c /config/config.yml
-    network_mode: "host"
+    network_mode: "elastic"
 
 volumes:
   conn-es-data:

--- a/scripts/stack/run-stack.sh
+++ b/scripts/stack/run-stack.sh
@@ -19,6 +19,14 @@ eval set -- "$parsed_params"
 
 source $CURDIR/set-env.sh $CURDIR/.env
 
+# Check if the network exists
+if ! docker network ls --format '{{.Name}}' | grep -w 'elastic' > /dev/null; then
+  echo "Network 'elastic' does not exist. Creating..."
+  docker network create elastic
+else
+  echo "Network 'elastic' already exists."
+fi
+
 # for now, always update the images, make this an arg later
 if [ "${update_images:-}" = true ]
 then


### PR DESCRIPTION
## Summary

The stack scripts `script/stack/run-stack.sh` was using a generated network called `connectors_stack_net` (which would finalize as `docker_connectors_stack_net`) whenever the script was run.
In [Elasticsearch](https://github.com/elastic/elasticsearch) and [Connectors](https://github.com/elastic/connectors/blob/34efbe579e65eba89f70b3e3f1228e6ade0cb26f/docs/DOCKER.md#5-run-the-docker-image) documentation, we always specify to use the docker network `elastic`. This change updates the stack scripts docker compose to use the `elastic` network.

Because users may be following manual steps from other documentation, we can't rely on creating the network in the docker-compose file. Instead, we must assume the network was already created (the flag `external: true`). Without this flag, the docker compose file will crash if the network was already manually created.
To stop users from _needing_ to manually create the `elastic` network if they're using the stack scripts exclusively, I added a step that checks if the network exists and creates it if it's missing. This network can then be handled as "external" in the docker compose file.

## Changes

1. Manually create `elastic` network when running stack scripts (if it doesn't exist)
2. Use the "externally" created `elastic` network in the docker-compose file

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
