### PR TITLE
Improve test coverage for content_extraction.py

### DIFF
--- a/tests/test_content_extraction.py
+++ b/tests/test_content_extraction.py
@@ -6,8 +6,19 @@
 from unittest.mock import mock_open, patch
 
 import pytest
+from aiohttp.client_exceptions import ClientConnectionError
 
 from connectors.content_extraction import ContentExtraction
+
+
+def test_set_and_get_configuration():
+    config = {
+        "extraction_service": {
+            "host": "http://localhost:8090",
+        }
+    }
+    ContentExtraction.set_extraction_config(config)
+    assert ContentExtraction.get_extraction_config() == config
 
 
 @pytest.mark.parametrize(
@@ -49,6 +60,8 @@ async def test_extract_text(mock_responses, patch_logger):
         extraction_service = ContentExtraction()
         extraction_service._begin_session()
 
+        assert extraction_service.get_volume_dir() is None
+
         response = await extraction_service.extract_text(filepath, "notreal.txt")
         await extraction_service._end_session()
 
@@ -75,11 +88,38 @@ async def test_extract_text_with_file_pointer(mock_responses, patch_logger):
         extraction_service = ContentExtraction()
         extraction_service._begin_session()
 
+        assert extraction_service.get_volume_dir() == "/tmp"
+
         response = await extraction_service.extract_text(filepath, "notreal.txt")
         await extraction_service._end_session()
 
         assert response == "I've been extracted from a local file!"
         patch_logger.assert_present("Text extraction is successful for 'notreal.txt'.")
+
+
+@pytest.mark.asyncio
+async def test_extract_text_when_host_is_none(mock_responses, patch_logger):
+    filepath = "/tmp/notreal.txt"
+
+    with patch("builtins.open", mock_open(read_data=b"data")), patch(
+        "connectors.content_extraction.ContentExtraction.get_extraction_config",
+        return_value={
+            "host": None,
+            "use_file_pointers": True,
+            "shared_volume_dir": "/tmp",
+        },
+    ):
+        extraction_service = ContentExtraction()
+
+        assert extraction_service.get_volume_dir() is None
+
+        response = await extraction_service.extract_text(filepath, "notreal.txt")
+        await extraction_service._end_session()
+
+        assert response == ""
+        patch_logger.assert_present(
+            "Extraction service has been initialised but no extraction service configuration was found. No text will be extracted for this sync."
+        )
 
 
 @pytest.mark.asyncio
@@ -111,6 +151,29 @@ async def test_extract_text_when_response_isnt_200_logs_warning(
 
         patch_logger.assert_present(
             "Extraction service could not parse `notreal.txt'. Status: [422]; Unprocessable Entity: Could not process file."
+        )
+
+
+@pytest.mark.asyncio
+async def test_extract_text_when_response_is_error(mock_responses, patch_logger):
+    filepath = "tmp/notreal.txt"
+
+    with patch("builtins.open", mock_open(read_data=b"data")), patch(
+        "connectors.content_extraction.ContentExtraction.get_extraction_config",
+        return_value={"host": "http://localhost:8090"},
+    ), patch(
+        "connectors.content_extraction.ContentExtraction.send_file",
+        side_effect=ClientConnectionError("oops!"),
+    ):
+        extraction_service = ContentExtraction()
+        extraction_service._begin_session()
+
+        response = await extraction_service.extract_text(filepath, "notreal.txt")
+        await extraction_service._end_session()
+        assert response == ""
+
+        patch_logger.assert_present(
+            "Connection to http://localhost:8090 failed while extracting data from notreal.txt. Error: oops!"
         )
 
 


### PR DESCRIPTION
Improve test coverage so we can get the baseline a bit above 92%.

This should improve content_extraction.py coverage from 84% to 98%.