### PR TITLE
Add _id to failed bulk logs

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -197,7 +197,9 @@ class Sink:
             for item in res["items"]:
                 for op, data in item.items():
                     if "error" in data:
-                        self._logger.error(f"operation {op} failed for doc {data['_id']}, {data['error']}")
+                        self._logger.error(
+                            f"operation {op} failed for doc {data['_id']}, {data['error']}"
+                        )
 
         self._populate_stats(stats, res)
 

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -197,7 +197,7 @@ class Sink:
             for item in res["items"]:
                 for op, data in item.items():
                     if "error" in data:
-                        self._logger.error(f"operation {op} failed, {data['error']}")
+                        self._logger.error(f"operation {op} failed for doc {data['_id']}, {data['error']}")
 
         self._populate_stats(stats, res)
 

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -1228,7 +1228,7 @@ async def test_batch_bulk_with_errors(patch_logger):
         }
         client.client.bulk = AsyncMock(return_value=mock_result)
         await sink._batch_bulk([], {OP_INDEX: {"1": 20}, OP_UPDATE: {}, OP_DELETE: {}})
-        patch_logger.assert_present(f"operation index failed, {error}")
+        patch_logger.assert_present(f"operation index failed for doc 1, {error}")
 
 
 @patch("connectors.es.sink.CANCELATION_TIMEOUT", -1)


### PR DESCRIPTION
The output log for a failed bulk operation item doesn't include the ID of the document, so there's no actions a user can take to remedy the problem.
This adds the `_id` to the error log when an item in the bulk indexing fails.