### PR TITLE
Bump elasticsearch and elastic-transport packages to 8.15

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -3,8 +3,8 @@ aiofiles==23.2.1
 aiomysql==0.1.1
 httpx==0.27.0
 httpx-ntlm==1.4.0
-elasticsearch[async]==8.14.0
-elastic-transport==8.13.1
+elasticsearch[async]==8.15.0
+elastic-transport==8.15.0
 pyyaml==6.0
 envyaml==1.10.211231
 ecs-logging==2.0.0

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -2,11 +2,11 @@ aiohttp==3.9.5
 aiofiles==23.2.1
 aiomysql==0.1.1
 httpx==0.27.0
-httpx-ntlm==1.4.0=
+httpx-ntlm==1.4.0
 elasticsearch[async]==8.15.0
 elastic-transport==8.15.0
 pyyaml==6.0.1
-cffi==1.16.0=
+cffi==1.16.0
 envyaml==1.10.211231
 ecs-logging==2.0.0
 pympler==1.0.1


### PR DESCRIPTION
Part of https://github.com/elastic/search-team/issues/7689

This PR bumps the elasticsearch version to 8.15.0, and elastic-transport version to 8.15.0