### PR TITLE
Revert default python to python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test lint autoformat run ftest install release docker-build docker-run docker-push
 
-PYTHON?=python
+PYTHON?=python3
 ARCH=$(shell uname -m)
 PERF8?=no
 SLOW_TEST_THRESHOLD=1 # seconds


### PR DESCRIPTION
Follow up for https://github.com/elastic/connectors/pull/2734#pullrequestreview-2238470095:

This was not a backwards-compatible change, and it did not work well for me when I was testing - `python` alias always led to system Python.

But it looks, like it just _should_. If CI is green, then I was wrong and we can safely keep the old `python3` command work - `python3` should be correctly handled by `pyenv`

Some context on `python` vs `python3`: https://stackoverflow.com/questions/67550189/i-dont-have-python-but-i-have-python3

> Recent Ubuntu versions do not install python 2 by default, as python 2 is now "dead". However, the command `python` is not (yet) linked to Python 3, to avoid some confusion; traditionally, `python` was for python 2 while `python3` was for python 3.