### PR TITLE
Bump python in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "matchPackageNames": [
         "docker.elastic.co/wolfi/python"
       ],
-      "matchCurrentValue": "/3\\.10(-dev)?/",
+      "matchCurrentValue": "/3\\.11(-dev)?/",
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     }


### PR DESCRIPTION
We've got a PR from renovate bot to bump [python docker image to 3.12](https://github.com/elastic/connectors/pull/2750) which is not good cause we don't support 3.12 yet.

This PR should scope these updates to 3.11 version of images