### PR TITLE
Replace python setup.py develop with pip install --editable .

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ install: bin/python bin/elastic-ingest
 
 bin/elastic-ingest: bin/python
 	bin/pip install -r requirements/$(ARCH).txt
-	bin/python setup.py develop
+	bin/pip install --editable .
 
 bin/black: bin/python
 	bin/pip install -r requirements/$(ARCH).txt

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 asyncio_mode = auto
+pythonpath = "." "connectors" "tests"
 addopts =
   -v
 filterwarnings =


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/8096

The far-reaching goal of current work is to be able to have libraries separate from executables - for simplicity and maintenance, but also to be able to distribute executables separately. Unlikely that running connectors natively would need CLIs, or running connectors on agent would need a native connectors service.

This PR just starts the process by removing deprecated call to `python setup.py develop` and replacing it with `pip install --editable .`. This breaks tests as they do not know where to get the actual package code, so a change to `pytest.ini` was done.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)
