### PR TITLE
Bump `aiohttp` version to 3.10.4

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,4 +1,4 @@
-aiohttp==3.10.3
+aiohttp==3.10.4
 aiofiles==23.2.1
 aiomysql==0.1.1
 httpx==0.27.0


### PR DESCRIPTION
## Bump `aiohttp` from `3.10.3` to `3.10.4`

This attempts to address some issues from: https://github.com/elastic/connectors/issues/2309

Bumping this lib was suggested in the thread of aiohttp issue:  https://github.com/aio-libs/aiohttp/issues/4581#issuecomment-2307177212


### Validation

make test 
triggered a sync locally