### PR TITLE
rename VENV_DIR->VIRTUAL_ENV

### DIFF
--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -10,7 +10,7 @@ INDEX_NAME=search-${NAME%"_serverless"}
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR="$SCRIPT_DIR/.."
-VENV_DIR="$ROOT_DIR/.venv"
+VIRTUAL_ENV="$ROOT_DIR/.venv"
 PLATFORM='unknown'
 MAX_RSS="200M"
 MAX_DURATION=600
@@ -29,9 +29,9 @@ else
     PLUGINS='--asyncstats --psutil'
 fi
 
-PERF8_BIN=${PERF8_BIN:-$VENV_DIR/bin/perf8}
-PYTHON=${PYTHON:-$VENV_DIR/bin/python}
-ELASTIC_INGEST=${ELASTIC_INGEST:-$VENV_DIR/bin/elastic-ingest}
+PERF8_BIN=${PERF8_BIN:-$VIRTUAL_ENV/bin/perf8}
+PYTHON=${PYTHON:-$VIRTUAL_ENV/bin/python}
+ELASTIC_INGEST=${ELASTIC_INGEST:-$VIRTUAL_ENV/bin/elastic-ingest}
 
 unamestr=$(uname)
 if [[ "$unamestr" == 'Linux' ]]; then
@@ -55,7 +55,7 @@ fi
 $PYTHON fixture.py --name $NAME --action setup
 $PYTHON fixture.py --name $NAME --action start_stack
 $PYTHON fixture.py --name $NAME --action check_stack
-$VENV_DIR/bin/fake-kibana --index-name $INDEX_NAME --service-type $SERVICE_TYPE --config-file $NAME/config.yml --connector-definition $NAME/connector.json --debug
+$VIRTUAL_ENV/bin/fake-kibana --index-name $INDEX_NAME --service-type $SERVICE_TYPE --config-file $NAME/config.yml --connector-definition $NAME/connector.json --debug
 $PYTHON fixture.py --name $NAME --action load
 
 if [[ $PERF8 == "yes" ]]


### PR DESCRIPTION
Addressing comment in https://github.com/elastic/connectors/pull/2768#discussion_r1732145623:

renaming `$VENV_DIR` to `$VIRTUAL_ENV`