### PR TITLE
Fix docker test, and add label hack for running packaging from PRs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -499,9 +499,9 @@ steps:
   # ----
   # DRA publishing
   # ----
-  - group: ":truck: DRA"
+  - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -143,6 +143,8 @@ if [[ "${PUBLISH_SNAPSHOT:-}" == "true" ]]; then
   source "${PROJECT_ROOT}/.buildkite/publish/dra/publish-daily-release-artifact.sh"
   unsetDraVaultCredentials
   rm -rf "${DEPENDENCIES_REPORTS_DIR}/*"
+else
+  echo "Not publishing SNAPSHOTs in this build"
 fi
 
 # generate the dependency report and publish STAGING artifacts
@@ -160,4 +162,6 @@ if [[ "${PUBLISH_STAGING:-}" == "true" ]]; then
   source "${PROJECT_ROOT}/.buildkite/publish/dra/publish-daily-release-artifact.sh"
   unsetDraVaultCredentials
   rm -rf "${DEPENDENCIES_REPORTS_DIR}/*"
+else
+  echo "Not publishing to staging in this build"
 fi

--- a/.buildkite/publish/test-docker.sh
+++ b/.buildkite/publish/test-docker.sh
@@ -75,7 +75,7 @@ commandTests:
     args: ["--version"]
     expectedOutput: ["Python\\s3\\.11\\.*"]
   - name: "Connectors Installation"
-    command: "/app/bin/elastic-ingest"
+    command: "/app/.venv/bin/elastic-ingest"
     args: ["--version"]
     expectedOutput: ["'"${ESCAPED_VERSION}"'*"]
 '

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -55,6 +55,7 @@ spec:
           message: "Builds, tests, and pushes daily `main` DRA artifacts"
       provider_settings:
         skip_pull_request_builds_for_existing_commits: false
+        build_pull_request_labels_changed: true
       teams:
         everyone:
           access_level: "READ_ONLY"


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/8047

https://github.com/elastic/connectors/pull/2765 merged but didn't pass on main, because the docker tests expected an older file structure that changed earlier this week.

This also adds the ability to add `ci:packaging` to run everything except for the DRA publishing from branches other than `main` and `x.y` maintenance branches 

## Checklists



#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

