### PR TITLE
Change back to amd64 instead of x86_64

### DIFF
--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -26,9 +26,9 @@ buildkite-agent artifact download '.artifacts/*.tar.gz*' $RELEASE_DIR/dist/ --st
 buildkite-agent artifact download '.artifacts/*.tar.gz*' $RELEASE_DIR/dist/ --step build_docker_image_arm64
 cp $RELEASE_DIR/dist/.artifacts/* $DRA_ARTIFACTS_DIR
 
-# Rename to match DRA expectations (<name>-<version>-<classifier>-<os>-<arch>) (also, x86_64 instead of amd64)
+# Rename to match DRA expectations (<name>-<version>-<classifier>-<os>-<arch>)
 cd $DRA_ARTIFACTS_DIR
-mv $DOCKER_ARTIFACT_KEY-$VERSION-amd64.tar.gz $PROJECT_NAME-$VERSION-docker-image-linux-x86_64.tar.gz
+mv $DOCKER_ARTIFACT_KEY-$VERSION-amd64.tar.gz $PROJECT_NAME-$VERSION-docker-image-linux-amd64.tar.gz
 mv $DOCKER_ARTIFACT_KEY-$VERSION-arm64.tar.gz $PROJECT_NAME-$VERSION-docker-image-linux-arm64.tar.gz
 cd -
 
@@ -135,7 +135,7 @@ if [[ "${PUBLISH_SNAPSHOT:-}" == "true" ]]; then
 
   echo "-------- Publishing SNAPSHOT DRA Artifacts"
   cp $RELEASE_DIR/dist/elasticsearch_connectors-${VERSION}.zip $DRA_ARTIFACTS_DIR/connectors-${VERSION}-SNAPSHOT.zip
-  cp $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-docker-image-linux-x86_64.tar.gz $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-SNAPSHOT-docker-image-linux-x86_64.tar.gz
+  cp $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-docker-image-linux-amd64.tar.gz $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-SNAPSHOT-docker-image-linux-amd64.tar.gz
   cp $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-docker-image-linux-arm64.tar.gz $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-SNAPSHOT-docker-image-linux-arm64.tar.gz
   setDraVaultCredentials
   export WORKFLOW="snapshot"


### PR DESCRIPTION
## part of https://github.com/elastic/search-team/issues/8047

related to https://github.com/elastic/infra/pull/41445

Alpar let me know that the convention for docker is `amd64` not `x86_64`. I'd copied from a project that needs to be updated. Better for us to just do things the right way to start with.

## Checklists


#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
