### PR TITLE
Ensure required python libs are installed before generating csv

### DIFF
--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -122,7 +122,7 @@ function unsetDraVaultCredentials() {
 
 # function to generate dependency report.
 function generateDependencyReport() {
-  make deps-csv
+  make clean install deps-csv
   cp $RELEASE_DIR/dist/dependencies.csv $1
 }
 


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/8047

I noticed that our artifact CSV was just:
```
"Name","Version","License","URL"

```

Because this job doesn't run `make install` first. So this ensures that it does, and also adds `clean` in case we ever add anything else earlier in this job (we don't want to ship with test deps in the CSV)

Related PR: https://github.com/elastic/connectors/pull/2757/files
