### PR TITLE
Clean was a mistake

### DIFF
--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -122,7 +122,7 @@ function unsetDraVaultCredentials() {
 
 # function to generate dependency report.
 function generateDependencyReport() {
-  make clean install deps-csv
+  make install deps-csv
   cp $RELEASE_DIR/dist/dependencies.csv $1
 }
 


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/8047

`clean` removes `dist/` which destroyed all the artifacts we'd staged 🤦 


