### PR TITLE
Make job cleanup service not sleep if it's not running any more

### DIFF
--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -34,6 +34,8 @@ class JobCleanUpService(BaseService):
             while self.running:
                 await self._process_orphaned_idle_jobs()
                 await self._process_idle_jobs()
+                if not self.running:
+                    break
                 await self._sleeps.sleep(self.idling)
         finally:
             if self.connector_index is not None:


### PR DESCRIPTION
All other services do this.

Rationale:
If the service is interrupted it should stop doing whatever it's doing and quit.

It can happen due to asynchronous nature that the service is stopped right before the `await self._sleeps.sleep(self.idling)` is called. What happens is:

1. `self.running` is set to false
2. `self._sleeps.cancel` is called

But CancellableSleeps class allows adding new sleeps after cancellation happens, so service is not running but it will still sleep one last time before exiting. For job cleanup service this sleep will be 5 minutes by default, thus graceful cancellation will just hang for 5 minutes cause of it.

This change is just to "make it work" - we need to think about making CancellableSleeps not accept any more sleeps if cancelled.