### PR TITLE
Post-process deps-csv to meet DRA needs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,3 +96,4 @@ sdist: .venv/bin/python
 deps-csv: .venv/bin/pip-licenses
 	mkdir -p dist
 	.venv/bin/pip-licenses --format=csv --with-urls > dist/dependencies.csv
+	.venv/bin/python scripts/deps-csv.py dist/dependencies.csv

--- a/scripts/deps-csv.py
+++ b/scripts/deps-csv.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+import csv
+import sys
+
+# input csv column indices
+NAME = 0
+VERSION = 1
+LICENSE = 2
+URL = 3
+
+
+def main(dependencies_csv):
+    """
+    The input is what we get from `pip-licenses --format=csv --with-urls`
+    See: https://pypi.org/project/pip-licenses/#csv
+    Unfortunately, our DRA requires a few more columns that `pip-licenses` does not understand.
+    This function reorders each row.
+    :param dependencies_csv:
+    :return:
+    """
+    rows = []
+
+    # read the csv rows into memory
+    with open(dependencies_csv) as csv_file:
+        reader = csv.reader(csv_file)
+        for row in reader:
+            rows.append(row)
+
+    # overwrite the original file
+    with open(dependencies_csv, "w") as csv_file:
+        writer = csv.writer(csv_file, quoting=csv.QUOTE_MINIMAL)
+
+        # The expected column order (this row is the CSV header)
+        writer.writerow(["name", "url", "version", "revision", "license", "sourceURL"])
+
+        # reorder each row using the expected column order. (leaves 'revision' and 'sourceURL' empty)
+        for row in rows[1:]:  # skip the header row
+            writer.writerow([row[NAME], row[URL], row[VERSION], "", row[LICENSE], ""])
+
+
+if __name__ == "__main__":
+    depenencies_csv = sys.argv[1]
+    print(f"post-processing {depenencies_csv}")  # noqa
+    main(depenencies_csv)
+    print(f"wrote output to {depenencies_csv}")  # noqa


### PR DESCRIPTION
@alpar-t flagged that the current csv structure is causing downstream issues because it doesn't meet their format requirements. TIL!

This PR adds a post-processing script to parse the output of `pip-licenses` to reorder the columns to match requirements.
It also uses "minimal quoting" as apparently having quotes in the header row was causing issues too.

Old output:
```
"Name","Version","License","URL"
"PyJWT","2.9.0","MIT License","https://github.com/jpadilla/pyjwt"
...
```

New output:
```
name,url,version,revision,license,sourceURL
PyJWT,https://github.com/jpadilla/pyjwt,2.9.0,,MIT License,
...
```

This leaves `revision` and `sourceURL` empty, which Alpar says is ok.

## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests

CSV was added in: https://github.com/elastic/connectors/pull/2757

