### PR TITLE
[Docs] Add tip about self-signed certificate

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -103,3 +103,11 @@ You might need to adjust some details here:
   - For Elasticsearch of version `<VERSION>` you can use `elastic-connectors:<VERSION>`for a stable revision of the connectors, or `elastic-connectors:<VERSION>-SNAPSHOT` if you want the latest nightly build of the connectors (not recommended).
   - If you are using nightly builds, you will need to run `docker pull docker.elastic.co/enterprise-search/elastic-connectors:<VERSION>-SNAPSHOT` before starting the service. This ensures you're using the latest version of the Docker image.
 - `-c /config/config.yml` - replace `config.yml` with the name of the config file you've put in the directory you've created in step 2.
+
+> [!TIP]
+> When starting a Docker container with the connector service against a local Elasticsearch cluster that has security and SSL enabled (like the [docker compose example](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-compose-file) from the Elasticsearch docs), it's crucial to handle the self-signed certificate correctly:
+> 1. Ensure the Docker container running the connector service has the volume attached that contains the generated certificate. When using Docker Compose, Docker automatically adds a project-specific prefix to volume names based on the directory where your `docker-compose.yml` is located. When starting the connector service with `docker run`, use `-v <your_project>_certs:/usr/share/connectors/config/certs` to reference it. Replace `<your_project>` with the actual prefix, such as `elastic_docker_certs` if your `docker-compose.yml` that starts the Elasticsearch stack is in a directory named `elastic_docker`.
+> 2. Make sure the connector service's `config.yml` correctly references the certificate with:
+> ```
+> elasticsearch.ca_certs: /usr/share/connectors/config/certs/ca/ca.crt
+> ```


### PR DESCRIPTION
I’ve been checking Discuss forums and noticed a recurring issue: the lack of documentation around running connectors with Docker against a local Elastic Stack (started with [docker-compose.yml](https://github.com/elastic/elasticsearch/blob/8.15/docs/reference/setup/install/docker/docker-compose.yml)). This starts ES with security enabled and uses a self-signed certificate stored in a docker volume. Getting the connector docker command and service config to work with this setup requires some effort. See discuss threads: [ES PostgreSQL connector](https://discuss.elastic.co/t/es-postgresql-connector/365853/3), [Azure Blob Storage connector](https://discuss.elastic.co/t/azure-blob-storage-connector/360400/3), [PostgreSQL Connector unable to connect to elasticsearch server](https://discuss.elastic.co/t/postgresql-connector-unable-to-connect-to-elasticsearch-server/365029/4).

Add a tip explaining how to handle self-signed certs