### PR TITLE
add back release pipeline

### DIFF
--- a/.buildkite/publish/build-docker.sh
+++ b/.buildkite/publish/build-docker.sh
@@ -20,12 +20,12 @@ source $CURDIR/publish-common.sh
 pushd $PROJECT_ROOT
 
 # set our complete tag name and build the image
-TAG_NAME="$BASE_TAG_NAME:${VERSION}-${ARCHITECTURE}"
+TAG_NAME="$BASE_TAG_NAME:${DOCKER_TAG_VERSION}-${ARCHITECTURE}"
 docker build -f $DOCKERFILE_PATH -t $TAG_NAME .
 
 # save the image to an archive file
 OUTPUT_PATH="$PROJECT_ROOT/.artifacts"
-OUTPUT_FILE="$OUTPUT_PATH/${DOCKER_ARTIFACT_KEY}-${VERSION}-${ARCHITECTURE}.tar.gz"
+OUTPUT_FILE="$OUTPUT_PATH/${DOCKER_ARTIFACT_KEY}-${DOCKER_TAG_VERSION}-${ARCHITECTURE}.tar.gz"
 mkdir -p $OUTPUT_PATH
 docker save $TAG_NAME | gzip > $OUTPUT_FILE
 

--- a/.buildkite/publish/build-multiarch-docker.sh
+++ b/.buildkite/publish/build-multiarch-docker.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+########
+# Builds the multiarch docker image and pushes it to the docker registry
+########
+
+set -exu
+set -o pipefail
+
+# Load our common environment variables for publishing
+export CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $CURDIR/publish-common.sh
+
+# Set our tag name as well as the tag names of the indiividual platform images
+TAG_NAME="${BASE_TAG_NAME}:${VERSION}"
+AMD64_TAG="${BASE_TAG_NAME}:${VERSION}-amd64"
+ARM64_TAG="${BASE_TAG_NAME}:${VERSION}-arm64"
+
+# Pull the images from the registry
+buildah pull $AMD64_TAG
+buildah pull $ARM64_TAG
+
+# ensure +x is set to avoid writing any sensitive information to the console
+set +x
+
+DOCKER_PASSWORD=$(vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-connectors/${VAULT_USER})
+
+# Log into Docker
+echo "Logging into docker..."
+DOCKER_USER=$(vault read -address "${VAULT_ADDR}" -field user_20230609 secret/ci/elastic-connectors/${VAULT_USER})
+vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-connectors/${VAULT_USER} | \
+  buildah login --username="${DOCKER_USER}" --password-stdin docker.elastic.co
+
+# Create the manifest for the multiarch image
+echo "Creating manifest..."
+buildah manifest create $TAG_NAME \
+  $AMD64_TAG \
+  $ARM64_TAG
+
+# ... and push it
+echo "Pushing manifest..."
+buildah manifest push $TAG_NAME docker://$TAG_NAME
+
+# Write out the final manifest for debugging purposes
+echo "Built and pushed multiarch image... dumping final manifest..."
+buildah manifest inspect $TAG_NAME

--- a/.buildkite/publish/build-multiarch-docker.sh
+++ b/.buildkite/publish/build-multiarch-docker.sh
@@ -12,9 +12,9 @@ export CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )
 source $CURDIR/publish-common.sh
 
 # Set our tag name as well as the tag names of the indiividual platform images
-TAG_NAME="${BASE_TAG_NAME}:${VERSION}"
-AMD64_TAG="${BASE_TAG_NAME}:${VERSION}-amd64"
-ARM64_TAG="${BASE_TAG_NAME}:${VERSION}-arm64"
+TAG_NAME="${BASE_TAG_NAME}:${DOCKER_TAG_VERSION}"
+AMD64_TAG="${BASE_TAG_NAME}:${DOCKER_TAG_VERSION}-amd64"
+ARM64_TAG="${BASE_TAG_NAME}:${DOCKER_TAG_VERSION}-arm64"
 
 # Pull the images from the registry
 buildah pull $AMD64_TAG

--- a/.buildkite/publish/git-setup.sh
+++ b/.buildkite/publish/git-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+export GIT_BRANCH=${BUILDKITE_BRANCH}
+
+git switch -
+git checkout $GIT_BRANCH
+git pull origin $GIT_BRANCH
+git config --local user.email 'elasticmachine@users.noreply.github.com'
+git config --local user.name 'Elastic Machine'

--- a/.buildkite/publish/manual-release/restore-stack-version.sh
+++ b/.buildkite/publish/manual-release/restore-stack-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+# Load our common environment variables for publishing
+export REL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CURDIR="$(dirname "$REL_DIR")"
+
+source $CURDIR/publish-common.sh
+
+echo $ORIG_VERSION > $PROJECT_ROOT/connectors/VERSION # removes the timestamp suffix
+UPDATED_VERSION=`cat $PROJECT_ROOT/connectors/VERSION`
+
+git add $PROJECT_ROOT/connectors/VERSION
+git commit -m "Restoring version from ${VERSION} to ${UPDATED_VERSION}"
+git push origin ${GIT_BRANCH}

--- a/.buildkite/publish/manual-release/update-release-version.sh
+++ b/.buildkite/publish/manual-release/update-release-version.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ex
+
+# Load our common environment variables for publishing
+export REL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CURDIR="$(dirname "$REL_DIR")"
+
+source $CURDIR/publish-common.sh
+
+echo $VERSION > $PROJECT_ROOT/connectors/VERSION # adds the timestamp suffix
+UPDATED_VERSION=`cat $PROJECT_ROOT/connectors/VERSION`
+
+git add $PROJECT_ROOT/connectors/VERSION
+git commit -m "Bumping version from ${ORIG_VERSION} to ${UPDATED_VERSION}"
+git push origin ${GIT_BRANCH}
+
+echo "Tagging the release"
+git tag "v${UPDATED_VERSION}"
+git push origin --tags

--- a/.buildkite/publish/publish-common.sh
+++ b/.buildkite/publish/publish-common.sh
@@ -24,6 +24,9 @@ if [[ "${USE_SNAPSHOT:-}" == "true" ]]; then
 fi
 
 if [[ "${MANUAL_RELEASE:-}" == "true" ]]; then
+  # This block is for out-of-band releases, triggered by the release-pipeline
+  # See discussion in https://github.com/elastic/connectors/pull/2804/commits/d27e4c18650bc2dfd099018080fe16ad307eb18b#r1758850508
+  # See also RELEASING.md
   export ORIG_VERSION=$(buildkite-agent meta-data get orig_version)
   IFS='.' read -ra VERSION_PARTS <<< "$ORIG_VERSION"
   PATCH_PART=${VERSION_PARTS[2]}

--- a/.buildkite/publish/publish-common.sh
+++ b/.buildkite/publish/publish-common.sh
@@ -25,3 +25,5 @@ export BASE_TAG_NAME=${DOCKER_IMAGE_NAME:-docker.elastic.co/enterprise-search/el
 export DOCKERFILE_PATH=${DOCKERFILE_PATH:-Dockerfile}
 export PROJECT_NAME=${PROJECT_NAME:-elastic-connectors}
 export DOCKER_ARTIFACT_KEY=${DOCKER_ARTIFACT_KEY:-${PROJECT_NAME}-docker}
+export VAULT_ADDR=${VAULT_ADDR:-https://vault-ci-prod.elastic.dev}
+export VAULT_USER="docker-swiftypeadmin"

--- a/.buildkite/publish/publish-common.sh
+++ b/.buildkite/publish/publish-common.sh
@@ -13,12 +13,29 @@ export SCRIPT_DIR="$CURDIR"
 export BUILDKITE_DIR=$(realpath "$(dirname "$SCRIPT_DIR")")
 export PROJECT_ROOT=$(realpath "$(dirname "$BUILDKITE_DIR")")
 
+source $SCRIPT_DIR/git-setup.sh
+
 VERSION_PATH="$PROJECT_ROOT/connectors/VERSION"
 export VERSION=$(cat $VERSION_PATH)
 
 if [[ "${USE_SNAPSHOT:-}" == "true" ]]; then
   echo "Adding SNAPSHOT labeling"
   export VERSION="${VERSION}-SNAPSHOT"
+fi
+
+if [[ "${MANUAL_RELEASE:-}" == "true" ]]; then
+  export ORIG_VERSION=$(buildkite-agent meta-data get orig_version)
+  IFS='.' read -ra VERSION_PARTS <<< "$ORIG_VERSION"
+  PATCH_PART=${VERSION_PARTS[2]}
+  LAST_PATCH="$((PATCH_PART - 1))"
+  LAST_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${LAST_PATCH}"
+  echo "last version was ${LAST_VERSION}"
+  echo "Adding timestamp version suffix"
+  VERSION_SUFFIX=$(buildkite-agent meta-data get timestamp)
+  export DOCKER_TAG_VERSION="${LAST_VERSION}.build$VERSION_SUFFIX"
+  export VERSION="${LAST_VERSION}+build$VERSION_SUFFIX"
+else
+  export DOCKER_TAG_VERSION=${VERSION}
 fi
 
 export BASE_TAG_NAME=${DOCKER_IMAGE_NAME:-docker.elastic.co/enterprise-search/elastic-connectors}

--- a/.buildkite/publish/push-docker.sh
+++ b/.buildkite/publish/push-docker.sh
@@ -18,7 +18,7 @@ source $CURDIR/publish-common.sh
 
 # Load the image from the artifact created in build-docker.sh
 echo "Loading image from archive file..."
-docker load < "$PROJECT_ROOT/.artifacts/${DOCKER_ARTIFACT_KEY}-${VERSION}-${ARCHITECTURE}.tar.gz"
+docker load < "$PROJECT_ROOT/.artifacts/${DOCKER_ARTIFACT_KEY}-${DOCKER_TAG_VERSION}-${ARCHITECTURE}.tar.gz"
 
 # ensure +x is set to avoid writing any sensitive information to the console
 set +x
@@ -30,6 +30,6 @@ vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-con
   docker login -u $DOCKER_USER --password-stdin docker.elastic.co
 
 # Set our tag name and push the image
-TAG_NAME="$BASE_TAG_NAME:${VERSION}-${ARCHITECTURE}"
+TAG_NAME="$BASE_TAG_NAME:${DOCKER_TAG_VERSION}-${ARCHITECTURE}"
 echo "Pushing image to docker with tag: $TAG_NAME"
 docker push $TAG_NAME

--- a/.buildkite/publish/push-docker.sh
+++ b/.buildkite/publish/push-docker.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+########
+# Pushes the docker image to the docker registry
+########
+
+set -exu
+set -o pipefail
+
+if [[ "${ARCHITECTURE:-}" == "" ]]; then
+  echo "!! ARCHITECTURE is not set. Exiting."
+  exit 2
+fi
+
+# Load our common environment variables for publishing
+export CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source $CURDIR/publish-common.sh
+
+# Load the image from the artifact created in build-docker.sh
+echo "Loading image from archive file..."
+docker load < "$PROJECT_ROOT/.artifacts/${DOCKER_ARTIFACT_KEY}-${VERSION}-${ARCHITECTURE}.tar.gz"
+
+# ensure +x is set to avoid writing any sensitive information to the console
+set +x
+
+# Log into Docker
+echo "Logging into docker..."
+DOCKER_USER=$(vault read -address "${VAULT_ADDR}" -field user_20230609 secret/ci/elastic-connectors/${VAULT_USER})
+vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-connectors/${VAULT_USER} | \
+  docker login -u $DOCKER_USER --password-stdin docker.elastic.co
+
+# Set our tag name and push the image
+TAG_NAME="$BASE_TAG_NAME:${VERSION}-${ARCHITECTURE}"
+echo "Pushing image to docker with tag: $TAG_NAME"
+docker push $TAG_NAME

--- a/.buildkite/publish/test-docker.sh
+++ b/.buildkite/publish/test-docker.sh
@@ -35,7 +35,7 @@ esac
 
 # Load the image from the artifact created in build-docker.sh
 echo "Loading image from archive file..."
-docker load < "$PROJECT_ROOT/.artifacts/${DOCKER_ARTIFACT_KEY}-${VERSION}-${ARCHITECTURE}.tar.gz"
+docker load < "$PROJECT_ROOT/.artifacts/${DOCKER_ARTIFACT_KEY}-${DOCKER_TAG_VERSION}-${ARCHITECTURE}.tar.gz"
 
 # Ensure we have container-structure-test installed
 echo "Ensuring test environment is set up"
@@ -61,8 +61,9 @@ fi
 # Generate our config file
 TEST_CONFIG_FILE="$PROJECT_ROOT/.buildkite/publish/container-structure-test.yaml"
 
-# The config file needs escaped dots - we'll do that here
+# The config file needs escaped dots and pluses - we'll do that here
 ESCAPED_VERSION=${VERSION//./\\\\.}
+ESCAPED_VERSION=${ESCAPED_VERSION//+/\\\\+}
 
 # Generate the config file text
 TEST_CONFIG_TEXT='
@@ -84,5 +85,5 @@ printf '%s\n' "$TEST_CONFIG_TEXT" > "$TEST_CONFIG_FILE"
 
 # Finally, run the tests
 echo "Running container-structure-test"
-TAG_NAME="$BASE_TAG_NAME:${VERSION}-${ARCHITECTURE}"
+TAG_NAME="$BASE_TAG_NAME:${DOCKER_TAG_VERSION}-${ARCHITECTURE}"
 "$TEST_EXEC" test --image "$TAG_NAME" --config "$TEST_CONFIG_FILE"

--- a/.buildkite/publish_docker.sh
+++ b/.buildkite/publish_docker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# !!! WARNING DO NOT add -x to avoid leaking vault passwords
+set -euo pipefail
+
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install ca-certificates curl gnupg lsb-release -y
+
+BASEDIR=$(realpath $(dirname $0))
+ROOT=$(realpath $BASEDIR/../)
+
+cd $ROOT
+
+# docker snapshot publication
+echo "Building the image"
+make docker-build
+
+# !!! WARNING be cautious about the following lines, to avoid leaking the secrets in the CI logs
+
+set +x   # Do not remove so we don't leak passwords
+VAULT_ADDR=${VAULT_ADDR:-https://vault-ci-prod.elastic.dev}
+VAULT_USER="docker-swiftypeadmin"
+echo "Fetching Docker credentials for '$VAULT_USER' from Vault..."
+DOCKER_USER=$(vault read -address "${VAULT_ADDR}" -field user_20230609 secret/ci/elastic-connectors/${VAULT_USER})
+DOCKER_PASSWORD=$(vault read -address "${VAULT_ADDR}" -field secret_20230609 secret/ci/elastic-connectors/${VAULT_USER})
+echo "Done!"
+echo
+
+echo "Logging into Docker as '$DOCKER_USER'..."
+docker login -u "${DOCKER_USER}" -p ${DOCKER_PASSWORD} docker.elastic.co
+echo "Done!"
+echo
+echo "Pushing the image to docker.elastic.co"
+make docker-push

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -1,13 +1,36 @@
 ## 🏠/.buildkite/pipeline-release.yml
 # Manual triggered pipeline to build and publish Docker images
 
+env:
+  MANUAL_RELEASE: true # unlike DRA, this pipeline should suffix its artifacts with a timestamp
+
 steps:
+  - group: "Release setup"
+    key: "release_setup"
+    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
+    steps:
+    # ----
+    # Set the build timestamp (for the verion suffix)
+    # ---
+    - label: "Set build metadata"
+      commands:
+        - buildkite-agent meta-data set timestamp "$(date -u +'%Y%m%d%H%M')"
+        - buildkite-agent meta-data set orig_version "$(cat connectors/VERSION)"
+      key: set_timestamp
+    - wait
+    - label: ":github: update version and tag"
+      key: update_version
+      command: ".buildkite/publish/manual-release/update-release-version.sh"
+
+
   # ----
   # Docker builds for amd64
   # ----
   - group: ":package: amd64 Build and Test"
     key: "build_and_test_amd64"
     if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
+    depends_on:
+      - release_setup
     steps:
       - label: "Building amd64 Docker image"
         agents:
@@ -39,6 +62,8 @@ steps:
   - group: ":package: arm64 Build and Test"
     key: "build_and_test_arm64"
     if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
+    depends_on:
+      - release_setup
     steps:
       - label: "Building arm64 Docker image"
         agents:
@@ -68,6 +93,20 @@ steps:
           - "mkdir -p .artifacts"
           - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_arm64
           - ".buildkite/publish/test-docker.sh"
+
+  - group: "Release repo cleanup"
+    key: "repo_cleanup"
+    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
+    depends_on:
+      - step: "build_and_test_amd64"
+        allow_failure: true
+      - step: "build_and_test_arm64"
+        allow_failure: true
+      - step: "update_version"
+    steps:
+      - label: "restore VERSION file"
+        command: ".buildkite/publish/manual-release/restore-stack-version.sh"
+
   # ----
   # Multiarch Docker image build and push
   # ----

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -94,8 +94,8 @@ steps:
           - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_arm64
           - ".buildkite/publish/test-docker.sh"
 
-  - group: "Release repo cleanup"
-    key: "repo_cleanup"
+  - group: "Release cleanup"
+    key: "release_cleanup"
     if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
     depends_on:
       - step: "build_and_test_amd64"

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -1,0 +1,116 @@
+## 🏠/.buildkite/pipeline-release.yml
+# Manual triggered pipeline to build and publish Docker images
+
+steps:
+  # ----
+  # Docker builds for amd64
+  # ----
+  - group: ":package: amd64 Build and Test"
+    key: "build_and_test_amd64"
+    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
+    steps:
+      - label: "Building amd64 Docker image"
+        agents:
+          provider: aws
+          instanceType: m6i.xlarge
+          imagePrefix: ci-amazonlinux-2
+        env:
+          ARCHITECTURE: "amd64"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
+        command: ".buildkite/publish/build-docker.sh"
+        key: "build_docker_image_amd64"
+        artifact_paths: ".artifacts/*.tar.gz"
+      - label: "Testing amd64 Docker image"
+        agents:
+          provider: aws
+          instanceType: m6i.xlarge
+          imagePrefix: ci-amazonlinux-2
+        env:
+          ARCHITECTURE: "amd64"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
+        depends_on: "build_docker_image_amd64"
+        commands:
+          - "mkdir -p .artifacts"
+          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_amd64
+          - ".buildkite/publish/test-docker.sh"
+  # ----
+  # Docker builds for arm64
+  # ----
+  - group: ":package: arm64 Build and Test"
+    key: "build_and_test_arm64"
+    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
+    steps:
+      - label: "Building arm64 Docker image"
+        agents:
+          provider: aws
+          instanceType: m6g.xlarge
+          imagePrefix: ci-amazonlinux-2-aarch64
+          diskSizeGb: 40
+          diskName: '/dev/xvda'
+        env:
+          ARCHITECTURE: "arm64"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
+        command: ".buildkite/publish/build-docker.sh"
+        key: "build_docker_image_arm64"
+        artifact_paths: ".artifacts/*.tar.gz"
+      - label: "Testing arm64 Docker image"
+        agents:
+          provider: aws
+          instanceType: m6g.xlarge
+          imagePrefix: ci-amazonlinux-2-aarch64
+          diskSizeGb: 40
+          diskName: '/dev/xvda'
+        env:
+          ARCHITECTURE: "arm64"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
+        depends_on: "build_docker_image_arm64"
+        commands:
+          - "mkdir -p .artifacts"
+          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_arm64
+          - ".buildkite/publish/test-docker.sh"
+  # ----
+  # Multiarch Docker image build and push
+  # ----
+  - group: ":truck: Publish images"
+    if: "build.branch =~ /^[0-9]+\\.[0-9x]+.*/"
+    depends_on:
+      - "build_and_test_amd64"
+      - "build_and_test_arm64"
+    steps:
+      - label: "Push amd64 Docker image"
+        key: "push_amd64_docker_image"
+        env:
+          ARCHITECTURE: "amd64"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
+        agents:
+          provider: aws
+          instanceType: m6i.xlarge
+          imagePrefix: ci-amazonlinux-2
+        commands:
+          - "mkdir -p .artifacts"
+          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_amd64
+          - ".buildkite/publish/push-docker.sh"
+      - label: "Push arm64 Docker image"
+        key: "push_arm64_docker_image"
+        env:
+          ARCHITECTURE: "arm64"
+          DOCKERFILE_PATH: "Dockerfile.wolfi"
+        agents:
+          provider: aws
+          instanceType: m6g.xlarge
+          imagePrefix: ci-amazonlinux-2-aarch64
+          diskSizeGb: 40
+          diskName: '/dev/xvda'
+        commands:
+          - "mkdir -p .artifacts"
+          - buildkite-agent artifact download '.artifacts/*.tar.gz*' .artifacts/ --step build_docker_image_arm64
+          - ".buildkite/publish/push-docker.sh"
+      - label: "Build and push multiarch Docker image"
+        agents:
+          image: "docker.elastic.co/ci-agent-images/drivah:0.25.0"
+          ephemeralStorage: "20G"
+          memory: "4G"
+        command: ".buildkite/publish/build-multiarch-docker.sh"
+        depends_on:
+          - "push_amd64_docker_image"
+          - "push_arm64_docker_image"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [report]
-omit = connectors/quartz.py,connectors/conftest.py,tests/*
+omit = connectors/quartz.py,connectors/conftest.py,tests/*,connectors/agent/*,connectors/cli/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bin
 lib
 lib64
 dist

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -206,8 +206,6 @@ spec:
 
 ########
 # Docker image build and publish - manual release
-#  This is in place to release versions < 8.16
-#  Once we are no longer maintaining versions that old, this can be removed
 ########
 ---
 apiVersion: "backstage.io/v1alpha1"

--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -91,7 +91,7 @@ class PreflightCheck:
         es_version_parts = list(
             map(int, es_version.replace("-SNAPSHOT", "").split("."))
         )
-        connector_version_parts = list(map(int, self.version.split(".")))
+        connector_version_parts = list(map(int, self.version.split("+")[0].split(".")))
 
         # major
         if es_version_parts[0] != connector_version_parts[0]:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -29,13 +29,26 @@ The Unified Release build will take care of producing git tags and official arti
 Sometimes, we need to release Connectors independently from the Elastic unified-release.
 For instance, if a user reports a critical bug in Connectors, and we want to ship a fix as soon as possible.
 
-In this case, we can work with `#early-agent-releases` to trigger the Independent Agent Release Pipeline ([staging](https://buildkite.com/elastic/independent-agent-release-staging), [releasing](https://buildkite.com/elastic/independent-agent-release-releasing)) once the bugfix has been merged and a staging DRA artifact produced.
-This pipeline is used for integrations that need to release more frequently than the stack cadence, but still need to stay associated with the stack versioning scheme.
-This will produce Connectors (and Agent) artifacts like **MAJOR.MINOR.PATCH+build<TIMESTAMP>**.
-These versions are compatible with SEMVER (Semantic Versioning).
-While the pipeline was built by-and-for Agent, it will release all our connector artifacts - not just the agent docker image.
+In this case, we can trigger a manual release buildkite job.
+1. Go to https://buildkite.com/elastic, find "connectors-docker-build-publish" pipeline and trigger a Build:
+   - Choose the maintenance branch you want to release from. For example, `8.16` if you want to release between 8.16.0 and 8.16.1
+   - Click on "New Build"
+   - Enter a descriptive message, and leave HEAD as the commit
+   - Press "Create Build" and wait for the build to finish
 
-No changes to the VERSION file are necessary for these "in-between" releases.
+This will produce Connectors artifacts like **MAJOR.MINOR.PATCH+build<TIMESTAMP>**.
+These versions are compatible with SEMVER (Semantic Versioning).
+This will automatically create the necessary git tag.
+
+Note that `PATCH` will be 1 less than the current contents of the VERSION file.
+This is because the VERSION file is usually bumped right after a stack release.
+So right after 8.16.0, the VERSION file is bumped to 8.16.1.
+If we want to release again the next day, the in-between artifacts should be associated with 8.16.0 stack versions, not with 8.16.1.
+
+No manual changes to the VERSION file are necessary for these "in-between" releases.
+During the pipeline, it will bump the VERSION file in the branch, build the artifacts, then restore the VERSION file.
+If the release build fails for some reason, check to make sure the VERSION file was properly restored.
+
 
 ## For versions <= 8.15
 

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -224,6 +224,16 @@ async def test_warn_mismatched_version(
             "1.2.3.0",
             "Elasticsearch 1.2.3 and Connectors 1.2.3.0 are compatible",
         ),
+        (
+            "1.2.3",
+            "1.2.3+abc",
+            "Elasticsearch 1.2.3 and Connectors 1.2.3+abc are compatible",
+        ),
+        (
+            "1.2.3",
+            "1.2.3",
+            "Elasticsearch 1.2.3 and Connectors 1.2.3 are compatible",
+        ),
     ],
 )
 async def test_pass_mismatched_version(


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/8226

This PR does a few things.
1. Adds back the scripts that used to exist for triggering a manual release
2. Introduces a `MANUAL_RELEASE` env var (through the pipeline) that gates some special versioning logic
3. That logic (in `publish-common.sh`) will re-compute the VERSION by going to the most recent patch version, and adding a `+build<timestamp>` suffix (this matches the pattern that Agent is establishing)
4. The pipeline adds a setup and a cleanup group, which actually commit the VERSION file change and create a git tag on that commit. This ensures that the docker tag, git tag, and `bin/elastic-ingest --version` all are in agreement.
5. every part of this pipeline is gated, and can only be run off of `X.Y` branches (not `main`, not other dev branches)

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes

#### Changes Requiring Extra Attention

- [ ] added automated committing and tagging to a buildkite pipeline

## Related Pull Requests

* https://github.com/elastic/ci/pull/3327 gave the elastic CI bot push access


