### PR TITLE
Config option to disable connector secrets for native connectors

### DIFF
--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -10,9 +10,7 @@ import elasticsearch
 from elasticsearch import (
     AuthorizationException as ElasticAuthorizationException,
 )
-from elasticsearch import (
-    NotFoundError as ElasticNotFoundError,
-)
+from elasticsearch import NotFoundError as ElasticNotFoundError
 
 from connectors.config import DataSourceFrameworkConfig
 from connectors.es.client import License, with_concurrency_control
@@ -178,6 +176,7 @@ class SyncJobRunner:
             if (
                 self.connector.native
                 and self.connector.features.native_connector_api_keys_enabled()
+                and self.service_config.get("_use_native_connector_api_keys", True)
             ):
                 # Update the config so native connectors can use API key authentication during sync
                 await self._update_native_connector_authentication()
@@ -380,9 +379,11 @@ class SyncJobRunner:
             sync_cursor = (
                 None
                 if not self.data_provider  # If we failed before initializing the data provider, we don't need to change the cursor
-                else self.data_provider.sync_cursor()
-                if self.sync_job.is_content_sync()
-                else None
+                else (
+                    self.data_provider.sync_cursor()
+                    if self.sync_job.is_content_sync()
+                    else None
+                )
             )
             await self.connector.sync_done(
                 self.sync_job if await self.reload_sync_job() else None,

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -88,6 +88,7 @@ def create_runner(
     index_name=SEARCH_INDEX_NAME,
     sync_cursor=SYNC_CURSOR,
     connector=None,
+    service_config=None,
 ):
     source_klass = Mock()
     data_provider = Mock()
@@ -113,7 +114,7 @@ def create_runner(
         connector = mock_connector()
 
     es_config = {}
-    service_config = {}
+    service_config = service_config if service_config is not None else {}
 
     return SyncJobRunner(
         source_klass=source_klass,
@@ -988,6 +989,94 @@ async def test_native_connector_sync_fails_when_api_key_secret_missing(
     sync_job_runner.sync_job.suspend.assert_not_awaited()
 
     assert sync_job_runner.sync_orchestrator is None
+
+    sync_job_runner.connector.sync_starts.assert_awaited_with(job_type)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=sync_cursor
+    )
+
+
+@pytest.mark.parametrize(
+    "job_type, sync_cursor",
+    [
+        (JobType.FULL, SYNC_CURSOR),
+        (JobType.INCREMENTAL, SYNC_CURSOR),
+        (JobType.ACCESS_CONTROL, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_native_sync_runs_with_secrets_disabled(
+    job_type, sync_cursor, sync_orchestrator_mock, es_management_client_mock
+):
+    ingestion_stats = {
+        "indexed_document_count": 25,
+        "indexed_document_volume": 30,
+        "deleted_document_count": 20,
+    }
+    sync_orchestrator_mock.ingestion_stats.return_value = ingestion_stats
+    es_management_client_mock.get_connector_secret.side_effect = ElasticNotFoundError(
+        message="not found", meta=None, body={}
+    )
+    sync_job_runner = create_runner(
+        job_type=job_type,
+        sync_cursor=sync_cursor,
+        service_config={"_use_native_connector_api_keys": False},
+    )
+    await sync_job_runner.execute()
+
+    ingestion_stats["total_document_count"] = TOTAL_DOCUMENT_COUNT
+
+    sync_job_runner.connector.sync_starts.assert_awaited_with(job_type)
+    sync_job_runner.sync_job.claim.assert_awaited()
+    sync_job_runner.sync_orchestrator.async_bulk.assert_awaited()
+    sync_job_runner.sync_job.done.assert_awaited_with(ingestion_stats=ingestion_stats)
+    sync_job_runner.sync_job.fail.assert_not_awaited()
+    sync_job_runner.sync_job.cancel.assert_not_awaited()
+    sync_job_runner.sync_job.suspend.assert_not_awaited()
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=sync_cursor
+    )
+    sync_job_runner.sync_orchestrator.cancel.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "job_type, sync_cursor",
+    [
+        (JobType.FULL, SYNC_CURSOR),
+        (JobType.INCREMENTAL, SYNC_CURSOR),
+        (JobType.ACCESS_CONTROL, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_native_sync_fails_with_secrets_enabled_and_no_permissions(
+    job_type, sync_cursor, sync_orchestrator_mock, es_management_client_mock
+):
+    expected_error = f"Connector is not authorized to access index [{SEARCH_INDEX_NAME}]. API key may need to be regenerated. Status code: [403]."
+    ingestion_stats = {
+        "indexed_document_count": 0,
+        "indexed_document_volume": 0,
+        "deleted_document_count": 0,
+        "total_document_count": TOTAL_DOCUMENT_COUNT,
+    }
+    sync_orchestrator_mock.ingestion_stats.return_value = ingestion_stats
+    error_meta = Mock()
+    error_meta.status = 403
+    es_management_client_mock.get_connector_secret.side_effect = (
+        ElasticAuthorizationException(message=None, meta=error_meta, body={})
+    )
+    sync_job_runner = create_runner(
+        job_type=job_type,
+        sync_cursor=sync_cursor,
+    )
+    await sync_job_runner.execute()
+
+    sync_job_runner.sync_job.claim.assert_awaited()
+    sync_job_runner.sync_job.fail.assert_awaited_with(
+        expected_error, ingestion_stats=ingestion_stats
+    )
+    sync_job_runner.sync_job.done.assert_not_awaited()
+    sync_job_runner.sync_job.cancel.assert_not_awaited()
+    sync_job_runner.sync_job.suspend.assert_not_awaited()
 
     sync_job_runner.connector.sync_starts.assert_awaited_with(job_type)
     sync_job_runner.connector.sync_done.assert_awaited_with(


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/8229

For Elastic-managed connectors in agentless we need to disable connector secrets on a service-level. 

I added new "internal" option `_use_native_connector_api_keys` that **is not documented** in `config.py` , similar to how we handle the `_force_allow_native` flag in: https://github.com/elastic/connectors/blob/4e97330803087151952debbdfa35408ff240666d/connectors/preflight_check.py#L192

Let me know if this approach work for you!

### Verification

I ran the setup e2e and verified that this allows native connectors to run without connector secrets. If flag is not provided to service config the logic defaults it to `True` which is backward compatible option.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
