### PR TITLE
Add missing __init__.py files

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [report]
-omit = connectors/quartz.py,connectors/conftest.py,tests/*
+omit = connectors/quartz.py,connectors/conftest.py,tests/*,connectors/agent/*,connectors/cli/*

--- a/connectors/agent/__init__.py
+++ b/connectors/agent/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#

--- a/connectors/cli/__init__.py
+++ b/connectors/cli/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#


### PR DESCRIPTION
```
make clean install-agent
.venv/bin/elastic-agent-connectors
```

would work from source, but not from the sdist, because `setup.py` was only packaging source code that it could "discover".

I hate python