### PR TITLE
Mass backport into 8.x branch

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [report]
-omit = connectors/quartz.py,connectors/conftest.py,tests/*
+omit = connectors/quartz.py,connectors/conftest.py,tests/*,connectors/agent/*,connectors/cli/*

--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:6772998d0891abdf57cdd2d90f99fed76d1657208f618e3158f5b6516b549fb3
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:4543741cb065fca8bd0a3ba245f7b81a6ad8cf651db511cb078a404cd72d67fc
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:4543741cb065fca8bd0a3ba245f7b81a6ad8cf651db511cb078a404cd72d67fc
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:7f67246b4646373e777d1e91d22cc0acb27b74969adcd2992e20c1e61c8759a4
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:6d21dd09efd41b21f4abeab6291bc93af86d1a438225eeac98bdea85f6617b22
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:1087eb8ae370d98fbc631694009dd2c39c9848055a68e44ef5a804e772df94cf
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:1087eb8ae370d98fbc631694009dd2c39c9848055a68e44ef5a804e772df94cf
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:6772998d0891abdf57cdd2d90f99fed76d1657208f618e3158f5b6516b549fb3
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:4543741cb065fca8bd0a3ba245f7b81a6ad8cf651db511cb078a404cd72d67fc
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:7f67246b4646373e777d1e91d22cc0acb27b74969adcd2992e20c1e61c8759a4
 USER root
 COPY . /app
 WORKDIR /app

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:6d21dd09efd41b21f4abeab6291bc93af86d1a438225eeac98bdea85f6617b22
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:1087eb8ae370d98fbc631694009dd2c39c9848055a68e44ef5a804e772df94cf
 USER root
 COPY . /app
 WORKDIR /app

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:6772998d0891abdf57cdd2d90f99fed76d1657208f618e3158f5b6516b549fb3
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:4543741cb065fca8bd0a3ba245f7b81a6ad8cf651db511cb078a404cd72d67fc
 USER root
 COPY . /app
 WORKDIR /app

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:1087eb8ae370d98fbc631694009dd2c39c9848055a68e44ef5a804e772df94cf
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:6772998d0891abdf57cdd2d90f99fed76d1657208f618e3158f5b6516b549fb3
 USER root
 COPY . /app
 WORKDIR /app

--- a/connectors/agent/__init__.py
+++ b/connectors/agent/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#

--- a/connectors/cli/__init__.py
+++ b/connectors/cli/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -836,15 +836,16 @@ class SyncOrchestrator:
         # TODO: think how to make it not a proxy method to the client
         return await self.es_management_client.has_active_license_enabled(license_)
 
+    def extract_index_or_alias(self, get_index_response, expected_index_name):
+        return None
+
     async def prepare_content_index(self, index_name, language_code=None):
         """Creates the index, given a mapping/settings if it does not exist."""
         self._logger.debug(f"Checking index {index_name}")
 
-        result = await self.es_management_client.get_index(
+        index = await self.es_management_client.get_index_or_alias(
             index_name, ignore_unavailable=True
         )
-
-        index = result.get(index_name, None)
 
         mappings = Mappings.default_text_fields_mappings(is_connectors_index=True)
 
@@ -859,7 +860,7 @@ class SyncOrchestrator:
             )
 
             await self.es_management_client.ensure_content_index_mappings(
-                index_name, mappings
+                index_name=index_name, index=index, desired_mappings=mappings
             )
         else:
             # Create a new index

--- a/connectors/sources/__init__.py
+++ b/connectors/sources/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+#

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -10,9 +10,7 @@ import elasticsearch
 from elasticsearch import (
     AuthorizationException as ElasticAuthorizationException,
 )
-from elasticsearch import (
-    NotFoundError as ElasticNotFoundError,
-)
+from elasticsearch import NotFoundError as ElasticNotFoundError
 
 from connectors.config import DataSourceFrameworkConfig
 from connectors.es.client import License, with_concurrency_control
@@ -178,6 +176,7 @@ class SyncJobRunner:
             if (
                 self.connector.native
                 and self.connector.features.native_connector_api_keys_enabled()
+                and self.service_config.get("_use_native_connector_api_keys", True)
             ):
                 # Update the config so native connectors can use API key authentication during sync
                 await self._update_native_connector_authentication()
@@ -380,9 +379,11 @@ class SyncJobRunner:
             sync_cursor = (
                 None
                 if not self.data_provider  # If we failed before initializing the data provider, we don't need to change the cursor
-                else self.data_provider.sync_cursor()
-                if self.sync_job.is_content_sync()
-                else None
+                else (
+                    self.data_provider.sync_cursor()
+                    if self.sync_job.is_content_sync()
+                    else None
+                )
             )
             await self.connector.sync_done(
                 self.sync_job if await self.reload_sync_job() else None,

--- a/tests/agent/test_cli.py
+++ b/tests/agent/test_cli.py
@@ -12,7 +12,7 @@ from connectors.agent.cli import main
 
 
 @patch("connectors.agent.cli.ConnectorsAgentComponent", return_value=AsyncMock())
-def test_main(patch_component):
+def test_main_responds_to_sigterm(patch_component):
     async def kill():
         await asyncio.sleep(0.2)
         os.kill(os.getpid(), signal.SIGTERM)
@@ -20,6 +20,9 @@ def test_main(patch_component):
     loop = asyncio.new_event_loop()
     loop.create_task(kill())
 
+    # No asserts here.
+    # main() will block forever unless it's killed with a signal
+    # This test succeeds if it exits, if it hangs it'll be killed by a timeout
     main()
 
     loop.close()

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -230,7 +230,9 @@ async def test_prepare_content_index(mock_responses):
 
         await es.close()
 
-        put_mapping_mock.assert_called_with(index_name, mappings)
+        put_mapping_mock.assert_called_with(
+            index_name=index_name, index=response[index_name], desired_mappings=mappings
+        )
 
 
 def set_responses(mock_responses, ts=None):
@@ -1481,6 +1483,7 @@ async def test_cancel_sync(extractor_task_done, sink_task_done, force_cancel):
             es._sink.force_cancel.assert_not_called()
 
 
+@pytest.mark.asyncio
 async def test_extractor_run_when_mem_full_is_raised():
     docs_from_source = [
         {"_id": 1},

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -88,6 +88,8 @@ def create_runner(
     index_name=SEARCH_INDEX_NAME,
     sync_cursor=SYNC_CURSOR,
     connector=None,
+    service_config=None,
+    es_config=None,
 ):
     source_klass = Mock()
     data_provider = Mock()
@@ -112,8 +114,8 @@ def create_runner(
     if not connector:
         connector = mock_connector()
 
-    es_config = {}
-    service_config = {}
+    es_config = es_config if es_config is not None else {}
+    service_config = service_config if service_config is not None else {}
 
     return SyncJobRunner(
         source_klass=source_klass,
@@ -988,6 +990,112 @@ async def test_native_connector_sync_fails_when_api_key_secret_missing(
     sync_job_runner.sync_job.suspend.assert_not_awaited()
 
     assert sync_job_runner.sync_orchestrator is None
+
+    sync_job_runner.connector.sync_starts.assert_awaited_with(job_type)
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=sync_cursor
+    )
+
+
+@patch(
+    "connectors.sync_job_runner.SyncJobRunner._update_native_connector_authentication",
+    AsyncMock(),
+)
+@pytest.mark.parametrize(
+    "job_type, sync_cursor",
+    [
+        (JobType.FULL, SYNC_CURSOR),
+        (JobType.INCREMENTAL, SYNC_CURSOR),
+        (JobType.ACCESS_CONTROL, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_native_sync_runs_with_secrets_disabled_when_no_permissions(
+    job_type, sync_cursor, sync_orchestrator_mock
+):
+    ingestion_stats = {
+        "indexed_document_count": 25,
+        "indexed_document_volume": 30,
+        "deleted_document_count": 20,
+    }
+    sync_orchestrator_mock.ingestion_stats.return_value = ingestion_stats
+
+    sync_job_runner = create_runner(
+        job_type=job_type,
+        sync_cursor=sync_cursor,
+        service_config={"_use_native_connector_api_keys": False},
+    )
+
+    error_meta = Mock()
+    error_meta.status = 403
+    sync_job_runner._update_native_connector_authentication.side_effect = (
+        ElasticAuthorizationException(message=None, meta=error_meta, body={})
+    )
+
+    await sync_job_runner.execute()
+
+    ingestion_stats["total_document_count"] = TOTAL_DOCUMENT_COUNT
+
+    sync_job_runner.connector.sync_starts.assert_awaited_with(job_type)
+    sync_job_runner.sync_job.claim.assert_awaited()
+    sync_job_runner._update_native_connector_authentication.assert_not_awaited()
+    sync_job_runner.sync_orchestrator.async_bulk.assert_awaited()
+    sync_job_runner.sync_job.done.assert_awaited_with(ingestion_stats=ingestion_stats)
+    sync_job_runner.sync_job.fail.assert_not_awaited()
+    sync_job_runner.sync_job.cancel.assert_not_awaited()
+    sync_job_runner.sync_job.suspend.assert_not_awaited()
+    sync_job_runner.connector.sync_done.assert_awaited_with(
+        sync_job_runner.sync_job, cursor=sync_cursor
+    )
+    sync_job_runner.sync_orchestrator.cancel.assert_called_once()
+
+
+@patch(
+    "connectors.sync_job_runner.SyncJobRunner._update_native_connector_authentication",
+    AsyncMock(),
+)
+@pytest.mark.parametrize(
+    "job_type, sync_cursor",
+    [
+        (JobType.FULL, SYNC_CURSOR),
+        (JobType.INCREMENTAL, SYNC_CURSOR),
+        (JobType.ACCESS_CONTROL, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_native_sync_fails_with_secrets_enabled_when_no_permissions(
+    job_type, sync_cursor, sync_orchestrator_mock, es_management_client_mock
+):
+    expected_error = f"Connector is not authorized to access index [{SEARCH_INDEX_NAME}]. API key may need to be regenerated. Status code: [403]."
+    ingestion_stats = {
+        "indexed_document_count": 0,
+        "indexed_document_volume": 0,
+        "deleted_document_count": 0,
+        "total_document_count": TOTAL_DOCUMENT_COUNT,
+    }
+    sync_orchestrator_mock.ingestion_stats.return_value = ingestion_stats
+
+    sync_job_runner = create_runner(
+        job_type=job_type,
+        sync_cursor=sync_cursor,
+    )
+
+    error_meta = Mock()
+    error_meta.status = 403
+    sync_job_runner._update_native_connector_authentication.side_effect = (
+        ElasticAuthorizationException(message=None, meta=error_meta, body={})
+    )
+
+    await sync_job_runner.execute()
+
+    sync_job_runner.sync_job.claim.assert_awaited()
+    sync_job_runner._update_native_connector_authentication.assert_awaited()
+    sync_job_runner.sync_job.fail.assert_awaited_with(
+        expected_error, ingestion_stats=ingestion_stats
+    )
+    sync_job_runner.sync_job.done.assert_not_awaited()
+    sync_job_runner.sync_job.cancel.assert_not_awaited()
+    sync_job_runner.sync_job.suspend.assert_not_awaited()
 
     sync_job_runner.connector.sync_starts.assert_awaited_with(job_type)
     sync_job_runner.connector.sync_done.assert_awaited_with(


### PR DESCRIPTION
Main is still on 8.16, as https://github.com/elastic/connectors/pull/2800 has not yet been able to build. But DRAs for 8.16 are being built now from 8.x branches, not main branches. We need to backport everything. 

I'm going to mass-backport this, then set up main to auto-backport to 8.x until we can merge the 9.0 version bump PR. 


