### PR TITLE
Get 8.x branch set up

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,7 @@
 {
   "targetBranchChoices": [
     { "name": "main", "checked": true },
+    "8.x",
     "8.15",
     "8.14",
     "8.13",
@@ -12,7 +13,8 @@
   "fork": false,
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
-    "^v8.16.0(.0)?$": "main",
+    "^v9.0.0$": "main",
+    "^v8.16.0$": "8.x",
     "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
   },
   "upstream": "elastic/connectors"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -526,7 +526,7 @@ steps:
   # ----
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"8.x\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -51,7 +51,7 @@ export PRODUCT_NAME="connectors"
 export GIT_REPO="connectors"
 
 # set PUBLISH_SNAPSHOT and PUBLISH_STAGING based on the branch
-if [[ "${BUILDKITE_BRANCH:-}" =~ (main|[0-9]\.[0-9x]*$) ]]; then
+if [[ "${BUILDKITE_BRANCH:-}" =~ (main|8\.x|[0-9]\.[0-9x]*$) ]]; then
   export PUBLISH_SNAPSHOT="true"
 fi
 if [[ "${BUILDKITE_BRANCH:-}" =~ ([0-9]\.[0-9x]*$) ]]; then

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -53,6 +53,10 @@ spec:
           branch: main
           cronline: '@daily'
           message: "Builds, tests, and pushes daily `main` DRA artifacts"
+        Daily 8.x:
+          branch: 8.x
+          cronline: '@daily'
+          message: "Builds, tests, and pushes daily `8.x` DRA artifacts"
       provider_settings:
         skip_pull_request_builds_for_existing_commits: false
         build_pull_request_labels_changed: true
@@ -93,14 +97,14 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
-        Daily 8_14:
-          branch: '8.14'
-          cronline: '@daily'
-          message: "Runs daily `8.14` e2e test"
         Daily 8_15:
           branch: '8.15'
           cronline: '@daily'
           message: "Runs daily `8.15` e2e test"
+        Daily 8_x:
+          branch: '8.x'
+          cronline: '@daily'
+          message: "Runs daily `8.x` e2e test"
         Daily main:
           branch: main
           cronline: '@daily'
@@ -139,14 +143,14 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
-        Daily 8_14:
-          branch: '8.14'
-          cronline: '@daily'
-          message: "Runs daily `8.14` e2e aarch64 test"
         Daily 8_15:
           branch: '8.15'
           cronline: '@daily'
           message: "Runs daily `8.15` e2e aarch64 test"
+        Daily 8_x:
+          branch: '8.x'
+          cronline: '@daily'
+          message: "Runs daily `8.x` e2e aarch64 test"
         Daily main:
           branch: main
           cronline: '@daily'


### PR DESCRIPTION
Contains most of https://github.com/elastic/connectors/pull/2800, but doesn't actually bump main to 9.0

This will need to be backported manually.