### PR TITLE
Forcefully downgrade pyasn1 to 0.6.0

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -43,3 +43,4 @@ graphql-core==3.2.3
 notion-client==2.2.1
 certifi==2024.7.4
 aioboto3==12.4.0
+pyasn1<0.6.1


### PR DESCRIPTION
CI started failing overnight.

This happened because of release of `pyasn1` `0.6.1` version: https://github.com/pyasn1/pyasn1/pull/75/files. Runtime deprecation happened that affected other libraries that use this package - we only use `pyasn1` as a transitive dependency.

This PR enforces usage of previous version for now until the libraries that we use ever support new version.

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
