### PR TITLE
Add retry for on-commit and nightly pipelines

### DIFF
--- a/.buildkite/nightly_steps.yml
+++ b/.buildkite/nightly_steps.yml
@@ -1,3 +1,14 @@
+retry:
+  automatic:
+    - exit_status: -1  # Connection to the Agent was lost
+      signal_reason: none
+      limit: 2
+    - exit_status: 255  # Timeout
+      signal_reason: none
+      limit: 2
+    - signal_reason: 2  # Flaky test
+      limit: 2
+
 env:
   DOCKERFILE_FTEST_PATH: "Dockerfile.ftest.wolfi"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,14 @@
+retry:
+  automatic:
+    - exit_status: -1  # Connection to the Agent was lost
+      signal_reason: none
+      limit: 2
+    - exit_status: 255  # Timeout
+      signal_reason: none
+      limit: 2
+    - signal_reason: 2  # Flaky test
+      limit: 2
+
 definitions:
   steps:
     - step: &test-agents


### PR DESCRIPTION
Adding retries to our buildkite pipelines:
- commit/main
- Nightly

For now we'll retry 2 times for signals -1, 255 and 2.

See https://buildkite.com/blog/retrying-ci-cd-steps-when-spot-instances-terminate for docs