### PR TITLE
[Network Drive] fix duplicate ids in access control sync

### DIFF
--- a/connectors/sources/network_drive.py
+++ b/connectors/sources/network_drive.py
@@ -724,8 +724,7 @@ class NASDataSource(BaseDataSource):
         rid_groups = []
 
         for group_sid in groups_info or []:
-            rid = group_sid.split("-")[-1]
-            rid_groups.append(_prefix_rid(rid))
+            rid_groups.append(_prefix_rid(group_sid.split("-")[-1]))
 
         access_control = [rid_user, prefixed_username, *rid_groups]
 
@@ -744,13 +743,14 @@ class NASDataSource(BaseDataSource):
             try:
                 csv_reader = csv.reader(file, delimiter=";")
                 for row in csv_reader:
-                    user_info.append(
-                        {
-                            "name": row[0],
-                            "user_sid": row[1],
-                            "groups": row[2].split(",") if len(row[2]) > 0 else [],
-                        }
-                    )
+                    if row:
+                        user_info.append(
+                            {
+                                "name": row[0],
+                                "user_sid": row[1],
+                                "groups": row[2].split(",") if len(row[2]) > 0 else [],
+                            }
+                        )
             except csv.Error as e:
                 self._logger.exception(
                     f"Error while reading user mapping file at the location: {self.identity_mappings}. Error: {e}"
@@ -882,9 +882,11 @@ class NASDataSource(BaseDataSource):
             async for document in self.fetch_filtered_directory(advanced_rules):
                 yield (
                     document,
-                    partial(self.get_content, document)
-                    if document["type"] == "file"
-                    else None,
+                    (
+                        partial(self.get_content, document)
+                        if document["type"] == "file"
+                        else None
+                    ),
                 )
 
         else:
@@ -899,7 +901,9 @@ class NASDataSource(BaseDataSource):
                     await self._decorate_with_access_control(
                         document, document["path"], document["type"], groups_info
                     ),
-                    partial(self.get_content, document)
-                    if document["type"] == "file"
-                    else None,
+                    (
+                        partial(self.get_content, document)
+                        if document["type"] == "file"
+                        else None
+                    ),
                 )

--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -855,6 +855,28 @@ async def test_get_access_control_dls_enabled():
         assert expected_user_access_control == user_access_control
 
 
+@pytest.mark.asyncio
+async def test_get_access_control_without_duplicate_ids():
+    async with create_source(NASDataSource) as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        source.drive_type = LINUX
+        source.identity_mappings = "/a/b"
+
+        source.read_user_info_csv = MagicMock(
+            return_value=[
+                {"name": "user1", "user_sid": "S-1", "groups": ["S-11", "S-22"]},
+                {"name": "user2", "user_sid": "S-2", "groups": ["S-22"]},
+                {"name": "user3", "user_sid": "S-3", "groups": ["S-11"]},
+            ]
+        )
+
+        seen_users = set()
+        async for access_control in source.get_access_control():
+            seen_users.add(access_control["_id"])
+
+        assert len(seen_users) == 3
+
+
 @mock.patch.object(
     NASDataSource,
     "traverse_diretory",


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2821

Network Drive connector is currently indexing the access control docs (user docs) with group ids and causes duplicate ids for documents within that group. So, this PR now assigning the user id instead of group id.


## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

## Release Note

Fixing the overwriting issue for access control docs.