### PR TITLE
Minor fixes for agent component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ docker-push:
 
 ## Agent Docker Zone
 # Only use it for local testing, that's it
-AGENT_ES_HOSTS?=http://127.0.0.1:9200
+AGENT_ES_HOSTS?=[http://127.0.0.1:9200]
 AGENT_ES_USERNAME?=elastic
 AGENT_ES_PASSWORD?=changeme
 AGENT_DOCKERFILE_NAME?=Dockerfile.agent

--- a/connectors/agent/config.py
+++ b/connectors/agent/config.py
@@ -3,6 +3,8 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import base64
+
 from connectors.config import add_defaults
 
 
@@ -24,6 +26,9 @@ class ConnectorsAgentConfigurationWrapper:
         """
         self._default_config = {
             "_force_allow_native": True,
+            "service": {
+                "_use_native_connector_api_keys": False,
+            },
             "native_service_types": [
                 "azure_blob_storage",
                 "box",
@@ -74,7 +79,12 @@ class ConnectorsAgentConfigurationWrapper:
             }
 
             if source.fields.get("api_key"):
-                es_creds["api_key"] = source["api_key"]
+                api_key = source["api_key"]
+                # if beats_logstash_format we need to base64 the key
+                if ":" in api_key:
+                    api_key = base64.b64encode(api_key.encode()).decode()
+
+                es_creds["api_key"] = api_key
             elif source.fields.get("username") and source.fields.get("password"):
                 es_creds["username"] = source["username"]
                 es_creds["password"] = source["password"]

--- a/tests/agent/test_agent_config.py
+++ b/tests/agent/test_agent_config.py
@@ -37,6 +37,24 @@ async def test_try_update_with_api_key_auth_data():
 
 
 @pytest.mark.asyncio
+async def test_try_update_with_non_encoded_api_key_auth_data():
+    hosts = ["https://localhost:9200"]
+    api_key = "something:else"
+    encoded = "c29tZXRoaW5nOmVsc2U="
+
+    config_wrapper = ConnectorsAgentConfigurationWrapper()
+    source_mock = MagicMock()
+    fields_container = {"hosts": hosts, "api_key": api_key}
+
+    source_mock.fields = fields_container
+    source_mock.__getitem__.side_effect = fields_container.__getitem__
+
+    assert config_wrapper.try_update(source_mock) is True
+    assert config_wrapper.get()["elasticsearch"]["host"] == hosts[0]
+    assert config_wrapper.get()["elasticsearch"]["api_key"] == encoded
+
+
+@pytest.mark.asyncio
 async def test_try_update_with_basic_auth_auth_data():
     hosts = ["https://localhost:9200"]
     username = "elastic"


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/7982
## Closes https://github.com/elastic/search-team/issues/8211

Bundles two changes:

- Makes it possible to run the component with fleet. This is achieved by base64 encoding the api key if it's received in a format "a:b"
- Set `service._use_native_connector_api_keys` to `False` to make the service run without using native api keys and use agent/fleet api key instead

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
