### PR TITLE
[8.15][Network Drive] fix duplicate ids in access control sync #2832

### DIFF
--- a/tests/sources/test_network_drive.py
+++ b/tests/sources/test_network_drive.py
@@ -855,6 +855,28 @@ async def test_get_access_control_dls_enabled():
         assert expected_user_access_control == user_access_control
 
 
+@pytest.mark.asyncio
+async def test_get_access_control_without_duplicate_ids():
+    async with create_source(NASDataSource) as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        source.drive_type = LINUX
+        source.identity_mappings = "/a/b"
+
+        source.read_user_info_csv = MagicMock(
+            return_value=[
+                {"name": "user1", "user_sid": "S-1", "groups": ["S-11", "S-22"]},
+                {"name": "user2", "user_sid": "S-2", "groups": ["S-22"]},
+                {"name": "user3", "user_sid": "S-3", "groups": ["S-11"]},
+            ]
+        )
+
+        seen_users = set()
+        async for access_control in source.get_access_control():
+            seen_users.add(access_control["_id"])
+
+        assert len(seen_users) == 3
+
+
 @mock.patch.object(
     NASDataSource,
     "traverse_diretory",


### PR DESCRIPTION
## Backport
This will backport the following commits from main to 8.15:

- https://github.com/elastic/connectors/pull/2832