### PR TITLE
include full stack trace in concurrent exception

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -457,7 +457,7 @@ class ConcurrentTasks:
             )
         elif task.exception():
             logger.error(
-                f"Exception found for task {task.get_name()}: {task.exception()}",
+                f"Exception found for task {task.get_name()}", exc_info=task.exception()
             )
 
     def _add_task(self, coroutine, name=None):


### PR DESCRIPTION
error messages like:

```
Exception found for task Extractor download #946:
```

Are not particularly helpful. When we log exceptions, we should include the full stack trace, if we're not re-raising the error. 

## Checklists



#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

