### PR TITLE
[Docker] Add git so that non-wolfi images are usable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11-slim-bookworm
-RUN apt update && apt upgrade && apt install make -y
+RUN apt update && apt upgrade && apt install make git -y
 COPY . /app
 WORKDIR /app
 RUN make clean install

--- a/Dockerfile.ftest
+++ b/Dockerfile.ftest
@@ -1,6 +1,6 @@
 FROM python:3.11-slim-bookworm
 # RUN apt update && apt install make
-RUN apt update && apt upgrade && apt install make -y
+RUN apt update && apt upgrade && apt install make git -y
 COPY . /app
 WORKDIR /app
 RUN make clean install


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2877

More details in the issue, but TLDR because we were missing git in non-Wolfi Dockerfiles building the local docker image and running ftests was failing

This PR fixed both scenarios, verified manually:
- building local image with non-wolfi image
- running ftest with non-wolfi image

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

