### PR TITLE
Docker: make a symlink to maintain backwards-compatibility after venv change, update makefile to build with --no-cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11-slim-bookworm
-RUN apt update && apt upgrade && apt install make -y
+RUN apt update && apt upgrade && apt install make git -y
 COPY . /app
 WORKDIR /app
 RUN make clean install
+RUN ln -s .venv/bin /app/bin
 ENTRYPOINT []

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -3,4 +3,5 @@ USER root
 COPY . /app
 WORKDIR /app
 RUN make clean install
+RUN ln -s .venv/bin /app/bin
 ENTRYPOINT []

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ default-config: install
 	.venv/bin/elastic-ingest --action config --service-type $(SERVICE_TYPE)
 
 docker-build: $(DOCKERFILE_PATH)
-	docker build -f $(DOCKERFILE_PATH) -t $(DOCKER_IMAGE_NAME):$(VERSION)-SNAPSHOT .
+	docker build --no-cache -f $(DOCKERFILE_PATH) -t $(DOCKER_IMAGE_NAME):$(VERSION)-SNAPSHOT .
 
 docker-run:
 	docker run -v $(PWD):/config $(DOCKER_IMAGE_NAME):$(VERSION)-SNAPSHOT /app/.venv/bin/elastic-ingest -c /config/config.yml --log-level=DEBUG


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2886

This PR makes a symlink from `/app/.venv/bin` to `/app/bin` to preserve old logic of running the app from `/app/bin/elastic-ingest`. Otherwise they'd have to run it with `/app/.venv/bin/elastic-ingest` and it feels getting out of hand. Documentation still points to `/app/bin/elatic-ingest`, so let's just symlink it!

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
