### PR TITLE
Switch to API access, over direct index access, by default

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -157,7 +157,8 @@
 #
 #
 ##  Enable usage of Connectors API instead of calling connectors indices directly
-#elasticsearch.feature_use_connectors_api: false
+##    Using direct index access is deprecated, and will be disallowed entirely in a future version
+#elasticsearch.feature_use_connectors_api: true
 ## ------------------------------- Service ----------------------------------
 #
 ##  Connector service/framework related configurations

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -86,7 +86,7 @@ def _default_config():
             "initial_backoff_duration": 1,
             "backoff_multiplier": 2,
             "log_level": "info",
-            "feature_use_connectors_api": False,
+            "feature_use_connectors_api": True,
         },
         "service": {
             "idling": 30,


### PR DESCRIPTION
For 8.16.0, we want to keep moving forward with deprecating direct index access for `.elastic-connectors*`, and a good way to dogfood that is to toggle this feature flag by default. We can still leave the feature flag as an escape hatch for now, in case any bugs surface.

## Checklists



#### Pre-Review Checklist
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)


## Release Note

Directly accessing connector and sync job state through `.elastic-connectors*` indices is deprecated, and will be disallowed entirely in a future release. Instead, the Elasticsearch Connector APIs should be used.
