### PR TITLE
Check for task cancelation before fetching exception

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -1052,7 +1052,11 @@ class SyncOrchestrator:
         self._sink_task.add_done_callback(functools.partial(self.sink_task_callback))
 
     def sink_task_callback(self, task):
-        if task.exception():
+        if task.cancelled():
+            self._logger.warning(
+                f"{type(self._sink).__name__}: {task.get_name()} was cancelled before completion"
+            )
+        elif task.exception():
             self._logger.error(
                 f"Encountered an error in the sync's {type(self._sink).__name__}: {task.get_name()}",
                 exc_info=task.exception(),
@@ -1060,7 +1064,11 @@ class SyncOrchestrator:
             self.error = task.exception()
 
     def extractor_task_callback(self, task):
-        if task.exception():
+        if task.cancelled():
+            self._logger.warning(
+                f"{type(self._extractor).__name__}: {task.get_name()} was cancelled before completion"
+            )
+        elif task.exception():
             self._logger.error(
                 f"Encountered an error in the sync's {type(self._extractor).__name__}: {task.get_name()}",
                 exc_info=task.exception(),


### PR DESCRIPTION


I hit an error:

```
[FMWK][15:19:19][INFO] [Connector id: confluence, index name: search-confluence, Sync job id: LwAtoJIB52ZH8QDRudeD] Task is canceled, stop Extractor...
--
  | 2024-10-18 15:19:19 UTC | Exception in callback SyncOrchestrator.extractor_task_callback()(<Task cancell.../sink.py:486>>)
  | 2024-10-18 15:19:19 UTC | handle: <Handle SyncOrchestrator.extractor_task_callback()(<Task cancell.../sink.py:486>>)>
  | 2024-10-18 15:19:19 UTC | Traceback (most recent call last):
  | 2024-10-18 15:19:19 UTC | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1729263632898151260/elastic/connectors/connectors/es/sink.py", line 587, in get_docs
  | 2024-10-18 15:19:19 UTC | await lazy_downloads.put(
  | 2024-10-18 15:19:19 UTC | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1729263632898151260/elastic/connectors/connectors/utils.py", line 478, in put
  | 2024-10-18 15:19:19 UTC | await self._sem.acquire()
  | 2024-10-18 15:19:19 UTC | File "/opt/buildkite-agent/.pyenv/versions/3.11.10/lib/python3.11/asyncio/locks.py", line 387, in acquire
  | 2024-10-18 15:19:19 UTC | await fut
  | 2024-10-18 15:19:19 UTC | asyncio.exceptions.CancelledError
  | 2024-10-18 15:19:19 UTC |  
  | 2024-10-18 15:19:19 UTC | During handling of the above exception, another exception occurred:
  | 2024-10-18 15:19:19 UTC |  
  | 2024-10-18 15:19:19 UTC | Traceback (most recent call last):
  | 2024-10-18 15:19:19 UTC | File "/opt/buildkite-agent/.pyenv/versions/3.11.10/lib/python3.11/asyncio/events.py", line 84, in _run
  | 2024-10-18 15:19:19 UTC | self._context.run(self._callback, *self._args)
  | 2024-10-18 15:19:19 UTC | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1729263632898151260/elastic/connectors/connectors/es/sink.py", line 1063, in extractor_task_callback
  | 2024-10-18 15:19:19 UTC | if task.exception():
  | 2024-10-18 15:19:19 UTC | ^^^^^^^^^^^^^^^^
  | 2024-10-18 15:19:19 UTC | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1729263632898151260/elastic/connectors/connectors/es/sink.py", line 490, in run
  | 2024-10-18 15:19:19 UTC | await self.get_docs(generator)
  | 2024-10-18 15:19:19 UTC | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1729263632898151260/elastic/connectors/connectors/es/sink.py", line 618, in get_docs
  | 2024-10-18 15:19:19 UTC | await lazy_downloads.join()
  | 2024-10-18 15:19:19 UTC | File "/opt/buildkite-agent/builds/bk-agent-prod-gcp-1729263632898151260/elastic/connectors/connectors/utils.py", line 495, in join
  | 2024-10-18 15:19:19 UTC | await asyncio.gather(*self.tasks, return_exceptions=(not raise_on_error))
  | 2024-10-18 15:19:19 UTC | asyncio.exceptions.CancelledError
```

Which made me realize that we were not checking in the sink/extractor callbacks for if the task was cancelled before trying to fetch any exception. `task.exception()` raises a cancelledError if the task was canceled, so it's important to check first.



## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
