### PR TITLE
[8.x] [Connector APIs] Enable Connector APIs framework-wide + update functional tests (#2902)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,7 @@ definitions:
     - step: &test-agents
         agents:
           provider: "gcp"
-          machineType: "n1-standard-2"
+          machineType: "n1-standard-8"
           useVault: true
           image: family/enterprise-search-ubuntu-2204-connectors-py
 

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -86,7 +86,7 @@ def _default_config():
             "initial_backoff_duration": 1,
             "backoff_multiplier": 2,
             "log_level": "info",
-            "feature_use_connectors_api": False,
+            "feature_use_connectors_api": True,
         },
         "service": {
             "idling": 30,

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -98,6 +98,38 @@ class ESApi(ESClient):
             partial(self._api_wrapper.connector_check_in, connector_id)
         )
 
+    async def connector_put(
+        self, connector_id, service_type, connector_name, index_name
+    ):
+        return await self._retrier.execute_with_retry(
+            partial(
+                self.client.connector.put,
+                connector_id=connector_id,
+                service_type=service_type,
+                name=connector_name,
+                index_name=index_name,
+            )
+        )
+
+    async def connector_update_scheduling(self, connector_id, scheduling):
+        return await self._retrier.execute_with_retry(
+            partial(
+                self.client.connector.update_scheduling,
+                connector_id=connector_id,
+                scheduling=scheduling,
+            )
+        )
+
+    async def connector_update_configuration(self, connector_id, configuration, values):
+        return await self._retrier.execute_with_retry(
+            partial(
+                self.client.connector.update_configuration,
+                connector_id=connector_id,
+                configuration=configuration,
+                values=values,
+            )
+        )
+
     async def connector_update_filtering_draft_validation(
         self, connector_id, validation_result
     ):

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -14,6 +14,7 @@ from connectors.config import load_config
 from connectors.es.management_client import ESManagementClient
 from connectors.es.settings import DEFAULT_LANGUAGE
 from connectors.logger import set_extra_logger
+from connectors.protocol import ConnectorIndex
 from connectors.source import get_source_klass
 from connectors.utils import validate_index_name
 
@@ -49,6 +50,7 @@ set_extra_logger(logger, log_level=logging.DEBUG, prefix="KBN-FAKE")
 async def prepare(service_type, index_name, config, connector_definition=None):
     klass = get_source_klass(config["sources"][service_type])
     es = ESManagementClient(config["elasticsearch"])
+    connector_index = ConnectorIndex(config["elasticsearch"])
 
     await es.ensure_ingest_pipeline_exists(
         "ent-search-generic-ingestion",
@@ -58,103 +60,37 @@ async def prepare(service_type, index_name, config, connector_definition=None):
     )
 
     try:
-        # https:#github.com/elastic/enterprise-search-team/discussions/2153#discussioncomment-2999765
-        doc = connector_definition or {
-            # Used by the frontend to manage the api key
-            # associated with the connector
-            "api_key_id": "",
-            # Configurations, e.g. API key
-            "configuration": klass.get_default_configuration(),
-            # Name of the index the documents will be written to.
-            # Set by Kibana, *not* the connector.
-            "index_name": index_name,
-            # used to surface copy and icons in the front end
-            "service_type": service_type,
-            # Current status of the connector, and the value can be
-            "status": "configured",
-            "language": "en",
-            # Last sync
-            "last_access_control_sync_error": None,
-            "last_access_control_sync_scheduled_at": None,
-            "last_access_control_sync_status": None,
-            "last_sync_status": None,
-            "last_sync_error": None,
-            "last_sync_scheduled_at": None,
-            "last_synced": None,
-            # Written by connector on each operation,
-            # used by Kibana to hint to user about status of connector
-            "last_seen": None,
-            # Date the connector was created
-            "created_at": None,
-            # Date the connector was updated
-            "updated_at": None,
-            "filtering": [
-                {
-                    "domain": "DEFAULT",
-                    "draft": {
-                        "advanced_snippet": {
-                            "updated_at": "2023-01-31T16:41:27.341Z",
-                            "created_at": "2023-01-31T16:38:49.244Z",
-                            "value": {},
-                        },
-                        "rules": [
-                            {
-                                "field": "_",
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "rule": "regex",
-                                "id": "DEFAULT",
-                                "value": ".*",
-                                "order": 1,
-                                "policy": "include",
-                            }
-                        ],
-                        "validation": {"state": "valid", "errors": []},
-                    },
-                    "active": {
-                        "advanced_snippet": {
-                            "updated_at": "2023-01-31T16:41:27.341Z",
-                            "created_at": "2023-01-31T16:38:49.244Z",
-                            "value": {},
-                        },
-                        "rules": [
-                            {
-                                "field": "_",
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "rule": "regex",
-                                "id": "DEFAULT",
-                                "value": ".*",
-                                "order": 1,
-                                "policy": "include",
-                            }
-                        ],
-                        "validation": {"state": "valid", "errors": []},
-                    },
-                }
-            ],
-            # Scheduling intervals
-            "scheduling": {
-                "full": {
-                    "enabled": True,
-                    "interval": "1 * * * * *",
-                },
-            },  # quartz syntax
-            "pipeline": {
-                "extract_binary_content": True,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": True,
-                "run_ml_inference": True,
-            },
-            "sync_cursor": None,
-            "is_native": False,
-        }
+        if connector_definition is not None:
+            connector_configuration = connector_definition["configuration"]
+        else:
+            connector_configuration = klass.get_default_configuration()
 
-        logger.info(f"Prepare {CONNECTORS_INDEX} document")
-        await es.upsert(
-            index_name=CONNECTORS_INDEX,
-            _id=config["connectors"][0]["connector_id"],
-            doc=doc,
+        connector_name = f"{service_type}-functional-test"
+
+        logger.info(f"Creating '{connector_name}' connector")
+
+        await connector_index.connector_put(
+            connector_id=config["connectors"][0]["connector_id"],
+            service_type=service_type,
+            connector_name=connector_name,
+            index_name=index_name,
+        )
+
+        logger.info(f"Updating scheduling for '{connector_name}' connector")
+
+        await connector_index.connector_update_scheduling(
+            connector_id=config["connectors"][0]["connector_id"],
+            full={
+                "enabled": True,
+                "interval": "1 * * * * ?",  # every minute
+            },
+        )
+
+        logger.info(f"Updating configuration for '{connector_name}' connector")
+
+        await connector_index.connector_update_configuration(
+            connector_id=config["connectors"][0]["connector_id"],
+            schema=connector_configuration,
         )
 
         logger.info(f"Prepare {index_name}")

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -162,6 +162,41 @@ class ConnectorIndex(ESIndex):
         else:
             await self.update(doc_id=doc_id, doc={"last_seen": iso_utc()})
 
+    async def connector_put(
+        self, connector_id, service_type, connector_name=None, index_name=None
+    ):
+        await self.api.connector_put(
+            connector_id=connector_id,
+            service_type=service_type,
+            connector_name=connector_name,
+            index_name=index_name,
+        )
+
+    async def connector_update_scheduling(
+        self, connector_id, full=None, incremental=None, access_control=None
+    ):
+        scheduling = {}
+
+        if full is not None:
+            scheduling["full"] = full
+
+        if incremental is not None:
+            scheduling["incremental"] = incremental
+
+        if access_control is not None:
+            scheduling["access_control"] = access_control
+
+        await self.api.connector_update_scheduling(
+            connector_id=connector_id, scheduling=scheduling
+        )
+
+    async def connector_update_configuration(
+        self, connector_id, schema=None, values=None
+    ):
+        await self.api.connector_update_configuration(
+            connector_id=connector_id, configuration=schema, values=values
+        )
+
     async def supported_connectors(self, native_service_types=None, connector_ids=None):
         if native_service_types is None:
             native_service_types = []

--- a/connectors/sources/notion.py
+++ b/connectors/sources/notion.py
@@ -451,7 +451,7 @@ class NotionDataSource(BaseDataSource):
         """
         return {
             "notion_secret_key": {
-                "display": "string",
+                "display": "text",
                 "label": "Notion Secret Key",
                 "order": 1,
                 "required": True,
@@ -460,14 +460,14 @@ class NotionDataSource(BaseDataSource):
             },
             "databases": {
                 "label": "List of Databases",
-                "display": "string",
+                "display": "text",
                 "order": 2,
                 "required": True,
                 "type": "list",
             },
             "pages": {
                 "label": "List of Pages",
-                "display": "string",
+                "display": "text",
                 "order": 3,
                 "required": True,
                 "type": "list",

--- a/tests/sources/fixtures/README.md
+++ b/tests/sources/fixtures/README.md
@@ -47,4 +47,4 @@ A Docker compose file that needs to run the whole stack:
 connector.json
 ==========
 
-This file should be a JSON representation of the connector document as it would exist in Elastic.
+This file should be a JSON representation of the connector’s `configuration`, with the schema populated as it would appear in an Elastic document See the [example connector.json file](../fixtures/sharepoint_online/connector.json) for reference.

--- a/tests/sources/fixtures/azure_blob_storage/connector.json
+++ b/tests/sources/fixtures/azure_blob_storage/connector.json
@@ -1,142 +1,74 @@
 {
-        "name": "azure_blob_storage",
-        "index_name": "search-azure_blob_storage",
-        "service_type": "azure_blob_storage",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "account_name": {
-                        "label": "Azure Blob Storage account name",
-                        "order": 1,
-                        "type": "str",
-                        "value": "devstoreaccount1"
-                },
-                "account_key": {
-                        "label": "Azure Blob Storage account key",
-                        "order": 2,
-                        "type": "str",
-                        "value": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
-                },
-                "blob_endpoint": {
-                        "label": "Azure Blob Storage blob endpoint",
-                        "order": 3,
-                        "type": "str",
-                        "value": "http://127.0.0.1:10000/devstoreaccount1"
-                },
-                "containers": {
-                        "display": "textarea",
-                        "label": "Azure Blob Storage containers",
-                        "order": 4,
-                        "type": "list",
-                        "value": "*"
-                },
-                "retry_count": {
-                        "default_value": 3,
-                        "display": "numeric",
-                        "label": "Retries per request",
-                        "order": 5,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": null
-                },
-                "concurrent_downloads": {
-                        "default_value": 100,
-                        "display": "numeric",
-                        "label": "Maximum concurrent downloads",
-                        "order": 6,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "validations": [
-                                {"type": "less_than", "constraint": 101}
-                        ],
-                        "value": null
-                },
-                "use_text_extraction_service": {
-                        "default_value": null,
-                        "depends_on": [],
-                        "display": "toggle",
-                        "label": "Use text extraction service",
-                        "options": [],
-                        "order": 7,
-                        "required": true,
-                        "sensitive": false,
-                        "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-                        "type": "bool",
-                        "ui_restrictions": [],
-                        "validations": [],
-                        "value": false
-                }
+    "configuration": {
+        "account_name": {
+            "label": "Azure Blob Storage account name",
+            "order": 1,
+            "type": "str",
+            "value": "devstoreaccount1"
         },
-        "filtering": [
+        "account_key": {
+            "label": "Azure Blob Storage account key",
+            "order": 2,
+            "type": "str",
+            "value": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+        },
+        "blob_endpoint": {
+            "label": "Azure Blob Storage blob endpoint",
+            "order": 3,
+            "type": "str",
+            "value": "http://127.0.0.1:10000/devstoreaccount1"
+        },
+        "containers": {
+            "display": "textarea",
+            "label": "Azure Blob Storage containers",
+            "order": 4,
+            "type": "list",
+            "value": "*"
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries per request",
+            "order": 5,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": null
+        },
+        "concurrent_downloads": {
+            "default_value": 100,
+            "display": "numeric",
+            "label": "Maximum concurrent downloads",
+            "order": 6,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "validations": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        },
-                        "active": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        }
+                    "type": "less_than",
+                    "constraint": 101
                 }
-
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "value": null
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 7,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
+    }
 }

--- a/tests/sources/fixtures/box/connector.json
+++ b/tests/sources/fixtures/box/connector.json
@@ -1,130 +1,76 @@
 {
-  "name": "box",
-  "index_name": "search-box",
-  "service_type": "box",
-  "sync_cursor": null,
-  "is_native": false,
-  "api_key_id": null,
-  "status": "configured",
-  "language": "en",
-  "last_access_control_sync_error": null,
-  "last_access_control_sync_status": null,
-  "last_sync_status": "canceled",
-  "last_sync_error": null,
-  "last_synced": null,
-  "last_seen": null,
-  "created_at": null,
-  "updated_at": null,
-  "configuration": {
-    "is_enterprise": {
-        "display": "dropdown",
-        "label": "Box data source",
-        "options": [
-            {"label": "Box Free", "value": "box_free"},
-            {"label": "Box Enterprise", "value": "box_enterprise"}
-        ],
-        "order": 1,
-        "type": "str",
-        "value": "box_free"
-    },
-    "client_id": {
-        "label": "Client ID",
-        "order": 2,
-        "type": "str",
-        "value": "0000000000000000000000000000"
-    },
-    "client_secret": {
-        "label": "Client Secret",
-        "order": 3,
-        "sensitive": true,
-        "type": "str",
-        "value": "0000000000000000000000000"
-    },
-    "refresh_token": {
-        "depends_on": [{"field": "is_enterprise", "value": "box_free"}],
-        "label": "Refresh Token",
-        "order": 4,
-        "sensitive": true,
-        "type": "str",
-        "value": "xxxxxxxxxxxxxxxxxxxx"
-    },
-    "enterprise_id": {
-        "depends_on": [{"field": "is_enterprise", "value": "box_enterprise"}],
-        "label": "Enterprise ID",
-        "order": 5,
-        "type": "int",
-        "value": 999999
-    },
-    "concurrent_downloads": {
-        "default_value": 15,
-        "display": "numeric",
-        "label": "Maximum concurrent downloads",
-        "order": 6,
-        "required": false,
-        "type": "int",
-        "ui_restrictions": ["advanced"],
-        "validations": [
-            {"type": "less_than", "constraint": 16}
-        ]
+    "configuration": {
+        "is_enterprise": {
+            "display": "dropdown",
+            "label": "Box data source",
+            "options": [
+                {
+                    "label": "Box Free",
+                    "value": "box_free"
+                },
+                {
+                    "label": "Box Enterprise",
+                    "value": "box_enterprise"
+                }
+            ],
+            "order": 1,
+            "type": "str",
+            "value": "box_free"
+        },
+        "client_id": {
+            "label": "Client ID",
+            "order": 2,
+            "type": "str",
+            "value": "0000000000000000000000000000"
+        },
+        "client_secret": {
+            "label": "Client Secret",
+            "order": 3,
+            "sensitive": true,
+            "type": "str",
+            "value": "0000000000000000000000000"
+        },
+        "refresh_token": {
+            "depends_on": [
+                {
+                    "field": "is_enterprise",
+                    "value": "box_free"
+                }
+            ],
+            "label": "Refresh Token",
+            "order": 4,
+            "sensitive": true,
+            "type": "str",
+            "value": "xxxxxxxxxxxxxxxxxxxx"
+        },
+        "enterprise_id": {
+            "depends_on": [
+                {
+                    "field": "is_enterprise",
+                    "value": "box_enterprise"
+                }
+            ],
+            "label": "Enterprise ID",
+            "order": 5,
+            "type": "int",
+            "value": 999999
+        },
+        "concurrent_downloads": {
+            "default_value": 15,
+            "display": "numeric",
+            "label": "Maximum concurrent downloads",
+            "order": 6,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "validations": [
+                {
+                    "type": "less_than",
+                    "constraint": 16
+                }
+            ]
+        }
     }
-  },
-  "filtering": [
-          {
-                  "domain": "DEFAULT",
-                  "draft": {
-                      "advanced_snippet": {
-                          "updated_at": "2023-01-31T16:41:27.341Z",
-                          "created_at": "2023-01-31T16:38:49.244Z",
-                          "value": {}
-                      },
-                      "rules": [
-                          {
-                              "field": "_",
-                              "updated_at": "2023-01-31T16:41:27.341Z",
-                              "created_at": "2023-01-31T16:38:49.244Z",
-                              "rule": "regex",
-                              "id": "DEFAULT",
-                              "value": ".*",
-                              "order": 1,
-                              "policy": "include"
-                          }
-                      ],
-                      "validation": {
-                          "state": "valid",
-                          "errors": []
-                      }
-                  },
-                  "active": {
-                      "advanced_snippet": {
-                          "updated_at": "2023-01-31T16:41:27.341Z",
-                          "created_at": "2023-01-31T16:38:49.244Z",
-                          "value": {}
-                      },
-                      "rules": [
-                          {
-                              "field": "_",
-                              "updated_at": "2023-01-31T16:41:27.341Z",
-                              "created_at": "2023-01-31T16:38:49.244Z",
-                              "rule": "regex",
-                              "id": "DEFAULT",
-                              "value": ".*",
-                              "order": 1,
-                              "policy": "include"
-                          }
-                      ],
-                      "validation": {
-                          "state": "valid",
-                          "errors": []
-                      }
-                  }
-          }
-
-  ],
-  "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-  "pipeline": {
-          "extract_binary_content": true,
-          "name": "ent-search-generic-ingestion",
-          "reduce_whitespace": true,
-          "run_ml_inference": true
-  }
 }

--- a/tests/sources/fixtures/confluence/connector.json
+++ b/tests/sources/fixtures/confluence/connector.json
@@ -1,220 +1,192 @@
 {
-        "name": "confluence",
-        "index_name": "search-confluence",
-        "service_type": "confluence",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "data_source": {
-                        "display": "dropdown",
-                        "label": "Confluence data source",
-                        "options": [
-                                {"label": "Confluence Cloud", "value": "confluence_cloud"},
-                                {"label": "Confluence Server", "value": "confluence_server"},
-                                {"label": "Confluence Data Center", "value": "confluence_data_center"}
-                        ],
-                        "order": 1,
-                        "type": "str",
-                        "value": "confluence_server"
-                },
-                "username": {
-                        "depends_on": [{"field": "data_source", "value": "confluence_server"}],
-                        "label": "Confluence Server username",
-                        "order": 2,
-                        "type": "str",
-                        "value": "admin"
-                },
-                "password": {
-                        "depends_on": [{"field": "data_source", "value": "confluence_server"}],
-                        "label": "Confluence Server password",
-                        "sensitive": true,
-                        "order": 3,
-                        "type": "str",
-                        "value": "abc@123"
-                },
-                "data_center_username": {
-                        "depends_on": [
-                                {"field": "data_source", "value": "confluence_data_center"}
-                        ],
-                        "label": "Confluence Data Center username",
-                        "order": 4,
-                        "type": "str"
-                },
-                "data_center_password": {
-                        "depends_on": [
-                                {"field": "data_source", "value": "confluence_data_center"}
-                        ],
-                        "label": "Confluence Data Center password",
-                        "sensitive": true,
-                        "order": 5,
-                        "type": "str"
-                },
-                "account_email": {
-                        "depends_on": [{"field": "data_source", "value": "confluence_cloud"}],
-                        "label": "Confluence Cloud account email",
-                        "order": 6,
-                        "type": "str",
-                        "value": "me@example.com"
-                },
-                "api_token": {
-                        "depends_on": [{"field": "data_source", "value": "confluence_cloud"}],
-                        "label": "Confluence Cloud API token",
-                        "sensitive": true,
-                        "order": 7,
-                        "type": "str",
-                        "value": "abc#123"
-                },
-                "confluence_url": {
-                        "label": "Confluence URL",
-                        "order": 8,
-                        "type": "str",
-                        "value": "http://127.0.0.1:9696"
-                },
-                "spaces": {
-                        "display": "textarea",
-                        "label": "Confluence space keys",
-                        "order": 9,
-                        "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
-                        "type": "list",
-                        "value": "*"
-                },
-                "index_labels": {
-                        "display": "toggle",
-                        "label": "Enable indexing labels",
-                        "order": 10,
-                        "tooltip": "Enabling this will increase the amount of network calls to the source, and may decrease performance",
-                        "type": "bool",
-                        "value": true
-                },
-                "ssl_enabled": {
-                        "display": "toggle",
-                        "label": "Enable SSL",
-                        "order": 11,
-                        "type": "bool",
-                        "value": false
-                },
-                "ssl_ca": {
-                        "depends_on": [{"field": "ssl_enabled", "value": true}],
-                        "label": "SSL certificate",
-                        "order": 12,
-                        "type": "str",
-                        "value": ""
-                },
-                "retry_count": {
-                        "default_value": 3,
-                        "display": "numeric",
-                        "label": "Retries per request",
-                        "order": 13,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": 3
-                },
-                "concurrent_downloads": {
-                        "default_value": 50,
-                        "display": "numeric",
-                        "label": "Maximum concurrent downloads",
-                        "order": 14,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "validations": [
-                                {"type": "less_than", "constraint": 51}
-                        ],
-                        "value": 50
-                },
-                "use_document_level_security": {
-                        "display": "toggle",
-                        "label": "Enable document level security",
-                        "order": 15,
-                        "tooltip": "Document level security ensures identities and permissions set in confluence are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
-                        "type": "bool",
-                        "value": false
-                },
-                "use_text_extraction_service": {
-                        "default_value": null,
-                        "depends_on": [],
-                        "display": "toggle",
-                        "label": "Use text extraction service",
-                        "options": [],
-                        "order": 16,
-                        "required": true,
-                        "sensitive": false,
-                        "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-                        "type": "bool",
-                        "ui_restrictions": [],
-                        "validations": [],
-                        "value": false
-                }
-        },
-        "filtering": [
+    "configuration": {
+        "data_source": {
+            "display": "dropdown",
+            "label": "Confluence data source",
+            "options": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        },
-                        "active": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        }
+                    "label": "Confluence Cloud",
+                    "value": "confluence_cloud"
+                },
+                {
+                    "label": "Confluence Server",
+                    "value": "confluence_server"
+                },
+                {
+                    "label": "Confluence Data Center",
+                    "value": "confluence_data_center"
                 }
-
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "order": 1,
+            "type": "str",
+            "value": "confluence_server"
+        },
+        "username": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "confluence_server"
+                }
+            ],
+            "label": "Confluence Server username",
+            "order": 2,
+            "type": "str",
+            "value": "admin"
+        },
+        "password": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "confluence_server"
+                }
+            ],
+            "label": "Confluence Server password",
+            "sensitive": true,
+            "order": 3,
+            "type": "str",
+            "value": "abc@123"
+        },
+        "data_center_username": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "confluence_data_center"
+                }
+            ],
+            "label": "Confluence Data Center username",
+            "order": 4,
+            "type": "str"
+        },
+        "data_center_password": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "confluence_data_center"
+                }
+            ],
+            "label": "Confluence Data Center password",
+            "sensitive": true,
+            "order": 5,
+            "type": "str"
+        },
+        "account_email": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "confluence_cloud"
+                }
+            ],
+            "label": "Confluence Cloud account email",
+            "order": 6,
+            "type": "str",
+            "value": "me@example.com"
+        },
+        "api_token": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "confluence_cloud"
+                }
+            ],
+            "label": "Confluence Cloud API token",
+            "sensitive": true,
+            "order": 7,
+            "type": "str",
+            "value": "abc#123"
+        },
+        "confluence_url": {
+            "label": "Confluence URL",
+            "order": 8,
+            "type": "str",
+            "value": "http://127.0.0.1:9696"
+        },
+        "spaces": {
+            "display": "textarea",
+            "label": "Confluence space keys",
+            "order": 9,
+            "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
+            "type": "list",
+            "value": "*"
+        },
+        "index_labels": {
+            "display": "toggle",
+            "label": "Enable indexing labels",
+            "order": 10,
+            "tooltip": "Enabling this will increase the amount of network calls to the source, and may decrease performance",
+            "type": "bool",
+            "value": true
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "Enable SSL",
+            "order": 11,
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
+                {
+                    "field": "ssl_enabled",
+                    "value": true
+                }
+            ],
+            "label": "SSL certificate",
+            "order": 12,
+            "type": "str",
+            "value": ""
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries per request",
+            "order": 13,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 3
+        },
+        "concurrent_downloads": {
+            "default_value": 50,
+            "display": "numeric",
+            "label": "Maximum concurrent downloads",
+            "order": 14,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "validations": [
+                {
+                    "type": "less_than",
+                    "constraint": 51
+                }
+            ],
+            "value": 50
+        },
+        "use_document_level_security": {
+            "display": "toggle",
+            "label": "Enable document level security",
+            "order": 15,
+            "tooltip": "Document level security ensures identities and permissions set in confluence are maintained in Elasticsearch. This enables you to restrict and personalize read-access users have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+            "type": "bool",
+            "value": false
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 16,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
+    }
 }

--- a/tests/sources/fixtures/dropbox/connector.json
+++ b/tests/sources/fixtures/dropbox/connector.json
@@ -1,20 +1,4 @@
 {
-    "name": "dropbox",
-    "service_type": "dropbox",
-    "index_name": "search-dropbox",
-    "sync_cursor": null,
-    "is_native": false,
-    "api_key_id": null,
-    "status": "configured",
-    "language": "en",
-    "last_access_control_sync_error": null,
-    "last_access_control_sync_status": null,
-    "last_sync_status": null,
-    "last_sync_error": null,
-    "last_synced": null,
-    "last_seen": null,
-    "created_at": null,
-    "updated_at": null,
     "configuration": {
         "path": {
             "label": "Path to fetch files/folders",
@@ -51,7 +35,9 @@
             "order": 5,
             "required": false,
             "type": "int",
-            "ui_restrictions": ["advanced"],
+            "ui_restrictions": [
+                "advanced"
+            ],
             "value": 3
         },
         "concurrent_downloads": {
@@ -61,7 +47,9 @@
             "order": 6,
             "required": false,
             "type": "int",
-            "ui_restrictions": ["advanced"],
+            "ui_restrictions": [
+                "advanced"
+            ],
             "value": 100
         },
         "use_text_extraction_service": {
@@ -93,7 +81,7 @@
             "value": false,
             "order": 8,
             "ui_restrictions": []
-          },
+        },
         "include_inherited_users_and_groups": {
             "default_value": null,
             "depends_on": [],
@@ -109,12 +97,5 @@
             "validations": [],
             "value": false
         }
-    },
-    "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-    "pipeline": {
-        "extract_binary_content": true,
-        "name": "ent-search-generic-ingestion",
-        "reduce_whitespace": true,
-        "run_ml_inference": true
     }
 }

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -128,7 +128,7 @@ async def _fetch_connector_metadata(es_client):
     connector = response["hits"]["hits"][0]
 
     connector_id = connector["_id"]
-    last_synced = connector["_source"]["last_synced"]
+    last_synced = connector["_source"].get("last_synced")
 
     return (connector_id, last_synced)
 
@@ -145,7 +145,9 @@ async def _monitor_service(pid):
         while True:
             _, new_last_synced = await _fetch_connector_metadata(es_client)
             lapsed = time.time() - start
-            if last_synced != new_last_synced or lapsed > sync_job_timeout:
+            if new_last_synced is not None and (
+                last_synced != new_last_synced or lapsed > sync_job_timeout
+            ):
                 if lapsed > sync_job_timeout:
                     logger.error(
                         f"Took too long to complete the sync job (over {sync_job_timeout} minutes), give up!"

--- a/tests/sources/fixtures/github/connector.json
+++ b/tests/sources/fixtures/github/connector.json
@@ -1,214 +1,198 @@
 {
-        "name": "github",
-        "index_name": "search-github",
-        "service_type": "github",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "data_source": {
-                        "display": "dropdown",
-                        "label": "Data source",
-                        "options": [
-                                {"label": "GitHub Cloud", "value": "github_cloud"},
-                                {"label": "GitHub Server", "value": "github_server"}
-                        ],
-                        "order": 1,
-                        "type": "str",
-                        "value": "github_server"
-                },
-                "host": {
-                        "depends_on": [{"field": "data_source", "value": "github_server"}],
-                        "label": "Server URL",
-                        "order": 2,
-                        "type": "str",
-                        "value": "http://127.0.0.1:9091"
-                },
-                "auth_method": {
-                        "display": "dropdown",
-                        "label": "Authentication method",
-                        "options": [
-                            {"label": "Personal access token", "value": "personal_access_token"},
-                            {"label": "GitHub App", "value": "github_app"}
-                        ],
-                        "order": 3,
-                        "type": "str",
-                        "value": "personal_access_token"
-                },
-                "token": {
-                        "depends_on": [
-                            {"field": "auth_method", "value": "personal_access_token"}
-                        ],
-                        "label": "Token",
-                        "order": 4,
-                        "sensitive": true,
-                        "type": "str",
-                        "value": "changeme"
-                },
-                "repo_type": {
-                        "display": "dropdown",
-                        "label": "Repository Type",
-                        "options": [
-                            {"label": "Organization", "value": "organization"},
-                            {"label": "Other", "value": "other"}
-                        ],
-                        "order": 5,
-                        "tooltip": "The Document Level Security feature is not available for the Other Repository Type",
-                        "type": "str",
-                        "value": "other"
-                },
-                "org_name": {
-                        "depends_on": [
-                          {"field": "auth_method", "value": "personal_access_token"},
-                          {"field": "repo_type", "value": "organization"}
-                        ],
-                        "label": "Organization Name",
-                        "order": 6,
-                        "type": "str",
-                        "value": "demo_org"
-                },
-                "app_id": {
-                        "depends_on": [{"field": "auth_method", "value": "github_app"}],
-                        "display": "numeric",
-                        "label": "App ID",
-                        "order": 7,
-                        "type": "int",
-                        "value": 0
-                },
-                "private_key": {
-                        "depends_on": [{"field": "auth_method", "value": "github_app"}],
-                        "display": "textarea",
-                        "label": "App private key",
-                        "order": 8,
-                        "sensitive": true,
-                        "type": "str",
-                        "value": "changeme"
-                },
-                "repositories": {
-                        "display": "textarea",
-                        "label": "List of repositories",
-                        "order": 9,
-                        "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
-                        "type": "list",
-                        "value": "*"
-                },
-                "ssl_enabled": {
-                        "display": "toggle",
-                        "label": "Enable SSL",
-                        "order": 10,
-                        "type": "bool",
-                        "value": false
-                },
-                "ssl_ca": {
-                        "depends_on": [{"field": "ssl_enabled", "value": true}],
-                        "label": "SSL certificate",
-                        "order": 11,
-                        "type": "str",
-                        "value": ""
-                },
-                "retry_count": {
-                        "display_value": 3,
-                        "display": "numeric",
-                        "label": "Maximum retries per request",
-                        "order": 12,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": 3,
-                        "validations": [{"type": "less_than", "constraint": 10}]
-                },
-                "use_text_extraction_service": {
-                        "default_value": null,
-                        "depends_on": [],
-                        "display": "toggle",
-                        "label": "Use text extraction service",
-                        "options": [],
-                        "order": 13,
-                        "required": true,
-                        "sensitive": false,
-                        "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-                        "type": "bool",
-                        "ui_restrictions": [],
-                        "validations": [],
-                        "value": false
-                },
-                "use_document_level_security": {
-                        "display": "toggle",
-                        "depends_on": [{"field": "repo_type", "value": "organization"}],
-                        "label": "Enable document level security",
-                        "order": 14,
-                        "tooltip": "Document level security ensures identities and permissions set in GitHub are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
-                        "type": "bool",
-                        "value": false
-                }
-        },
-        "filtering": [
+    "configuration": {
+        "data_source": {
+            "display": "dropdown",
+            "label": "Data source",
+            "options": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        },
-                        "active": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        }
+                    "label": "GitHub Cloud",
+                    "value": "github_cloud"
+                },
+                {
+                    "label": "GitHub Server",
+                    "value": "github_server"
                 }
-
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "order": 1,
+            "type": "str",
+            "value": "github_server"
+        },
+        "host": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "github_server"
+                }
+            ],
+            "label": "Server URL",
+            "order": 2,
+            "type": "str",
+            "value": "http://127.0.0.1:9091"
+        },
+        "auth_method": {
+            "display": "dropdown",
+            "label": "Authentication method",
+            "options": [
+                {
+                    "label": "Personal access token",
+                    "value": "personal_access_token"
+                },
+                {
+                    "label": "GitHub App",
+                    "value": "github_app"
+                }
+            ],
+            "order": 3,
+            "type": "str",
+            "value": "personal_access_token"
+        },
+        "token": {
+            "depends_on": [
+                {
+                    "field": "auth_method",
+                    "value": "personal_access_token"
+                }
+            ],
+            "label": "Token",
+            "order": 4,
+            "sensitive": true,
+            "type": "str",
+            "value": "changeme"
+        },
+        "repo_type": {
+            "display": "dropdown",
+            "label": "Repository Type",
+            "options": [
+                {
+                    "label": "Organization",
+                    "value": "organization"
+                },
+                {
+                    "label": "Other",
+                    "value": "other"
+                }
+            ],
+            "order": 5,
+            "tooltip": "The Document Level Security feature is not available for the Other Repository Type",
+            "type": "str",
+            "value": "other"
+        },
+        "org_name": {
+            "depends_on": [
+                {
+                    "field": "auth_method",
+                    "value": "personal_access_token"
+                },
+                {
+                    "field": "repo_type",
+                    "value": "organization"
+                }
+            ],
+            "label": "Organization Name",
+            "order": 6,
+            "type": "str",
+            "value": "demo_org"
+        },
+        "app_id": {
+            "depends_on": [
+                {
+                    "field": "auth_method",
+                    "value": "github_app"
+                }
+            ],
+            "display": "numeric",
+            "label": "App ID",
+            "order": 7,
+            "type": "int",
+            "value": 0
+        },
+        "private_key": {
+            "depends_on": [
+                {
+                    "field": "auth_method",
+                    "value": "github_app"
+                }
+            ],
+            "display": "textarea",
+            "label": "App private key",
+            "order": 8,
+            "sensitive": true,
+            "type": "str",
+            "value": "changeme"
+        },
+        "repositories": {
+            "display": "textarea",
+            "label": "List of repositories",
+            "order": 9,
+            "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
+            "type": "list",
+            "value": "*"
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "Enable SSL",
+            "order": 10,
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
+                {
+                    "field": "ssl_enabled",
+                    "value": true
+                }
+            ],
+            "label": "SSL certificate",
+            "order": 11,
+            "type": "str",
+            "value": ""
+        },
+        "retry_count": {
+            "display_value": 3,
+            "display": "numeric",
+            "label": "Maximum retries per request",
+            "order": 12,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 3,
+            "validations": [
+                {
+                    "type": "less_than",
+                    "constraint": 10
+                }
+            ]
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 13,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
+        },
+        "use_document_level_security": {
+            "display": "toggle",
+            "depends_on": [
+                {
+                    "field": "repo_type",
+                    "value": "organization"
+                }
+            ],
+            "label": "Enable document level security",
+            "order": 14,
+            "tooltip": "Document level security ensures identities and permissions set in GitHub are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+            "type": "bool",
+            "value": false
         }
+    }
 }

--- a/tests/sources/fixtures/google_cloud_storage/connector.json
+++ b/tests/sources/fixtures/google_cloud_storage/connector.json
@@ -1,148 +1,41 @@
 {
-  "api_key_id": null,
-  "configuration": {
-    "buckets": {
-      "display": "textarea",
-      "label": "Google Cloud Storage buckets",
-      "order": 1,
-      "type": "list",
-      "value": "*"
-    },
-    "service_account_credentials": {
-      "depends_on": [],
-      "display": "textarea",
-      "tooltip": null,
-      "default_value": null,
-      "label": "Google Cloud service account JSON",
-      "sensitive": true,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "{\"type\": \"service_account\", \"project_id\": \"dummy_project_id\", \"private_key_id\": \"abc\", \"private_key\": \"\\n-----BEGIN PRIVATE KEY-----\\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDY3E8o1NEFcjMM\\nHW/5ZfFJw29/8NEqpViNjQIx95Xx5KDtJ+nWn9+OW0uqsSqKlKGhAdAo+Q6bjx2c\\nuXVsXTu7XrZUY5Kltvj94DvUa1wjNXs606r/RxWTJ58bfdC+gLLxBfGnB6CwK0YQ\\nxnfpjNbkUfVVzO0MQD7UP0Hl5ZcY0Puvxd/yHuONQn/rIAieTHH1pqgW+zrH/y3c\\n59IGThC9PPtugI9ea8RSnVj3PWz1bX2UkCDpy9IRh9LzJLaYYX9RUd7++dULUlat\\nAaXBh1U6emUDzhrIsgApjDVtimOPbmQWmX1S60mqQikRpVYZ8u+NDD+LNw+/Eovn\\nxCj2Y3z1AgMBAAECggEAWDBzoqO1IvVXjBA2lqId10T6hXmN3j1ifyH+aAqK+FVl\\nGjyWjDj0xWQcJ9ync7bQ6fSeTeNGzP0M6kzDU1+w6FgyZqwdmXWI2VmEizRjwk+/\\n/uLQUcL7I55Dxn7KUoZs/rZPmQDxmGLoue60Gg6z3yLzVcKiDc7cnhzhdBgDc8vd\\nQorNAlqGPRnm3EqKQ6VQp6fyQmCAxrr45kspRXNLddat3AMsuqImDkqGKBmF3Q1y\\nxWGe81LphUiRqvqbyUlh6cdSZ8pLBpc9m0c3qWPKs9paqBIvgUPlvOZMqec6x4S6\\nChbdkkTRLnbsRr0Yg/nDeEPlkhRBhasXpxpMUBgPywKBgQDs2axNkFjbU94uXvd5\\nznUhDVxPFBuxyUHtsJNqW4p/ujLNimGet5E/YthCnQeC2P3Ym7c3fiz68amM6hiA\\nOnW7HYPZ+jKFnefpAtjyOOs46AkftEg07T9XjwWNPt8+8l0DYawPoJgbM5iE0L2O\\nx8TU1Vs4mXc+ql9F90GzI0x3VwKBgQDqZOOqWw3hTnNT07Ixqnmd3dugV9S7eW6o\\nU9OoUgJB4rYTpG+yFqNqbRT8bkx37iKBMEReppqonOqGm4wtuRR6LSLlgcIU9Iwx\\nyfH12UWqVmFSHsgZFqM/cK3wGev38h1WBIOx3/djKn7BdlKVh8kWyx6uC8bmV+E6\\nOoK0vJD6kwKBgHAySOnROBZlqzkiKW8c+uU2VATtzJSydrWm0J4wUPJifNBa/hVW\\ndcqmAzXC9xznt5AVa3wxHBOfyKaE+ig8CSsjNyNZ3vbmr0X04FoV1m91k2TeXNod\\njMTobkPThaNm4eLJMN2SQJuaHGTGERWC0l3T18t+/zrDMDCPiSLX1NAvAoGBAN1T\\nVLJYdjvIMxf1bm59VYcepbK7HLHFkRq6xMJMZbtG0ryraZjUzYvB4q4VjHk2UDiC\\nlhx13tXWDZH7MJtABzjyg+AI7XWSEQs2cBXACos0M4Myc6lU+eL+iA+OuoUOhmrh\\nqmT8YYGu76/IBWUSqWuvcpHPpwl7871i4Ga/I3qnAoGBANNkKAcMoeAbJQK7a/Rn\\nwPEJB+dPgNDIaboAsh1nZhVhN5cvdvCWuEYgOGCPQLYQF0zmTLcM+sVxOYgfy8mV\\nfbNgPgsP5xmu6dw2COBKdtozw0HrWSRjACd1N4yGu75+wPCcX/gQarcjRcXXZeEa\\nNtBLSfcqPULqD+h7br9lEJio\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"123-abc@developer.gserviceaccount.com\", \"client_id\": \"123-abc.apps.googleusercontent.com\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"http://localhost:4444/token\"}",
-      "order": 2,
-      "ui_restrictions": []
-    },
-    "use_text_extraction_service": {
-      "default_value": null,
-      "depends_on": [],
-      "display": "toggle",
-      "label": "Use text extraction service",
-      "options": [],
-      "order": 3,
-      "required": true,
-      "sensitive": false,
-      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-      "type": "bool",
-      "ui_restrictions": [],
-      "validations": [],
-      "value": false
-    }
-  },
-  "custom_scheduling": {},
-  "description": null,
-  "error": null,
-  "features": {
-    "incremental_sync": {
-      "enabled": false
-    },
-    "document_level_security": {
-      "enabled": false
-    },
-    "sync_rules": {
-      "advanced": {
-        "enabled": false
-      },
-      "basic": {
-        "enabled": true
-      }
-    }
-  },
-  "filtering": [
-    {
-      "active": {
-        "advanced_snippet": {
-          "created_at": "2023-06-30T08:20:14.686Z",
-          "updated_at": "2023-06-30T08:20:14.686Z",
-          "value": {}
+    "configuration": {
+        "buckets": {
+            "display": "textarea",
+            "label": "Google Cloud Storage buckets",
+            "order": 1,
+            "type": "list",
+            "value": "*"
         },
-        "rules": [
-          {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
-        }
-      },
-      "domain": "DEFAULT",
-      "draft": {
-        "advanced_snippet": {
-          "created_at": "2023-06-30T08:20:14.686Z",
-          "updated_at": "2023-06-30T08:20:14.686Z",
-          "value": {}
+        "service_account_credentials": {
+            "depends_on": [],
+            "display": "textarea",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Google Cloud service account JSON",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "{\"type\": \"service_account\", \"project_id\": \"dummy_project_id\", \"private_key_id\": \"abc\", \"private_key\": \"\\n-----BEGIN PRIVATE KEY-----\\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDY3E8o1NEFcjMM\\nHW/5ZfFJw29/8NEqpViNjQIx95Xx5KDtJ+nWn9+OW0uqsSqKlKGhAdAo+Q6bjx2c\\nuXVsXTu7XrZUY5Kltvj94DvUa1wjNXs606r/RxWTJ58bfdC+gLLxBfGnB6CwK0YQ\\nxnfpjNbkUfVVzO0MQD7UP0Hl5ZcY0Puvxd/yHuONQn/rIAieTHH1pqgW+zrH/y3c\\n59IGThC9PPtugI9ea8RSnVj3PWz1bX2UkCDpy9IRh9LzJLaYYX9RUd7++dULUlat\\nAaXBh1U6emUDzhrIsgApjDVtimOPbmQWmX1S60mqQikRpVYZ8u+NDD+LNw+/Eovn\\nxCj2Y3z1AgMBAAECggEAWDBzoqO1IvVXjBA2lqId10T6hXmN3j1ifyH+aAqK+FVl\\nGjyWjDj0xWQcJ9ync7bQ6fSeTeNGzP0M6kzDU1+w6FgyZqwdmXWI2VmEizRjwk+/\\n/uLQUcL7I55Dxn7KUoZs/rZPmQDxmGLoue60Gg6z3yLzVcKiDc7cnhzhdBgDc8vd\\nQorNAlqGPRnm3EqKQ6VQp6fyQmCAxrr45kspRXNLddat3AMsuqImDkqGKBmF3Q1y\\nxWGe81LphUiRqvqbyUlh6cdSZ8pLBpc9m0c3qWPKs9paqBIvgUPlvOZMqec6x4S6\\nChbdkkTRLnbsRr0Yg/nDeEPlkhRBhasXpxpMUBgPywKBgQDs2axNkFjbU94uXvd5\\nznUhDVxPFBuxyUHtsJNqW4p/ujLNimGet5E/YthCnQeC2P3Ym7c3fiz68amM6hiA\\nOnW7HYPZ+jKFnefpAtjyOOs46AkftEg07T9XjwWNPt8+8l0DYawPoJgbM5iE0L2O\\nx8TU1Vs4mXc+ql9F90GzI0x3VwKBgQDqZOOqWw3hTnNT07Ixqnmd3dugV9S7eW6o\\nU9OoUgJB4rYTpG+yFqNqbRT8bkx37iKBMEReppqonOqGm4wtuRR6LSLlgcIU9Iwx\\nyfH12UWqVmFSHsgZFqM/cK3wGev38h1WBIOx3/djKn7BdlKVh8kWyx6uC8bmV+E6\\nOoK0vJD6kwKBgHAySOnROBZlqzkiKW8c+uU2VATtzJSydrWm0J4wUPJifNBa/hVW\\ndcqmAzXC9xznt5AVa3wxHBOfyKaE+ig8CSsjNyNZ3vbmr0X04FoV1m91k2TeXNod\\njMTobkPThaNm4eLJMN2SQJuaHGTGERWC0l3T18t+/zrDMDCPiSLX1NAvAoGBAN1T\\nVLJYdjvIMxf1bm59VYcepbK7HLHFkRq6xMJMZbtG0ryraZjUzYvB4q4VjHk2UDiC\\nlhx13tXWDZH7MJtABzjyg+AI7XWSEQs2cBXACos0M4Myc6lU+eL+iA+OuoUOhmrh\\nqmT8YYGu76/IBWUSqWuvcpHPpwl7871i4Ga/I3qnAoGBANNkKAcMoeAbJQK7a/Rn\\nwPEJB+dPgNDIaboAsh1nZhVhN5cvdvCWuEYgOGCPQLYQF0zmTLcM+sVxOYgfy8mV\\nfbNgPgsP5xmu6dw2COBKdtozw0HrWSRjACd1N4yGu75+wPCcX/gQarcjRcXXZeEa\\nNtBLSfcqPULqD+h7br9lEJio\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"123-abc@developer.gserviceaccount.com\", \"client_id\": \"123-abc.apps.googleusercontent.com\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"http://localhost:4444/token\"}",
+            "order": 2,
+            "ui_restrictions": []
         },
-        "rules": [
-          {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 3,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
-      }
     }
-  ],
-  "index_name": "search-google_cloud_storage",
-  "is_native": false,
-  "language": null,
-  "last_access_control_sync_error": null,
-  "last_access_control_sync_scheduled_at": null,
-  "last_access_control_sync_status": null,
-  "last_incremental_sync_scheduled_at": null,
-  "last_seen": "2023-06-30T09:26:21.281198+00:00",
-  "last_sync_error": null,
-  "last_sync_scheduled_at": null,
-  "last_sync_status": null,
-  "last_synced": null,
-  "name": "google-drive",
-  "pipeline": {
-    "extract_binary_content": true,
-    "name": "ent-search-generic-ingestion",
-    "reduce_whitespace": true,
-    "run_ml_inference": true
-  },
-  "scheduling": {
-    "access_control": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    },
-    "full": {
-      "enabled": true,
-      "interval": "* * * * * *"
-    },
-    "incremental": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    }
-  },
-  "service_type": "google_cloud_storage",
-  "status": "configured",
-  "sync_now": true
 }

--- a/tests/sources/fixtures/google_drive/connector.json
+++ b/tests/sources/fixtures/google_drive/connector.json
@@ -1,268 +1,161 @@
 {
-  "api_key_id": null,
-  "configuration": {
-    "service_account_credentials": {
-      "depends_on": [],
-      "display": "textarea",
-      "tooltip": null,
-      "default_value": null,
-      "label": "Google Drive service account JSON",
-      "sensitive": true,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "{\"type\":\"service_account\",\"project_id\":\"project_id\",\"private_key_id\":\"abc\",\"private_key\":\"-----BEGIN PRIVATE KEY-----\\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDY3E8o1NEFcjMM\\nHW\/5ZfFJw29\/8NEqpViNjQIx95Xx5KDtJ+nWn9+OW0uqsSqKlKGhAdAo+Q6bjx2c\\nuXVsXTu7XrZUY5Kltvj94DvUa1wjNXs606r\/RxWTJ58bfdC+gLLxBfGnB6CwK0YQ\\nxnfpjNbkUfVVzO0MQD7UP0Hl5ZcY0Puvxd\/yHuONQn\/rIAieTHH1pqgW+zrH\/y3c\\n59IGThC9PPtugI9ea8RSnVj3PWz1bX2UkCDpy9IRh9LzJLaYYX9RUd7++dULUlat\\nAaXBh1U6emUDzhrIsgApjDVtimOPbmQWmX1S60mqQikRpVYZ8u+NDD+LNw+\/Eovn\\nxCj2Y3z1AgMBAAECggEAWDBzoqO1IvVXjBA2lqId10T6hXmN3j1ifyH+aAqK+FVl\\nGjyWjDj0xWQcJ9ync7bQ6fSeTeNGzP0M6kzDU1+w6FgyZqwdmXWI2VmEizRjwk+\/\\n\/uLQUcL7I55Dxn7KUoZs\/rZPmQDxmGLoue60Gg6z3yLzVcKiDc7cnhzhdBgDc8vd\\nQorNAlqGPRnm3EqKQ6VQp6fyQmCAxrr45kspRXNLddat3AMsuqImDkqGKBmF3Q1y\\nxWGe81LphUiRqvqbyUlh6cdSZ8pLBpc9m0c3qWPKs9paqBIvgUPlvOZMqec6x4S6\\nChbdkkTRLnbsRr0Yg\/nDeEPlkhRBhasXpxpMUBgPywKBgQDs2axNkFjbU94uXvd5\\nznUhDVxPFBuxyUHtsJNqW4p\/ujLNimGet5E\/YthCnQeC2P3Ym7c3fiz68amM6hiA\\nOnW7HYPZ+jKFnefpAtjyOOs46AkftEg07T9XjwWNPt8+8l0DYawPoJgbM5iE0L2O\\nx8TU1Vs4mXc+ql9F90GzI0x3VwKBgQDqZOOqWw3hTnNT07Ixqnmd3dugV9S7eW6o\\nU9OoUgJB4rYTpG+yFqNqbRT8bkx37iKBMEReppqonOqGm4wtuRR6LSLlgcIU9Iwx\\nyfH12UWqVmFSHsgZFqM\/cK3wGev38h1WBIOx3\/djKn7BdlKVh8kWyx6uC8bmV+E6\\nOoK0vJD6kwKBgHAySOnROBZlqzkiKW8c+uU2VATtzJSydrWm0J4wUPJifNBa\/hVW\\ndcqmAzXC9xznt5AVa3wxHBOfyKaE+ig8CSsjNyNZ3vbmr0X04FoV1m91k2TeXNod\\njMTobkPThaNm4eLJMN2SQJuaHGTGERWC0l3T18t+\/zrDMDCPiSLX1NAvAoGBAN1T\\nVLJYdjvIMxf1bm59VYcepbK7HLHFkRq6xMJMZbtG0ryraZjUzYvB4q4VjHk2UDiC\\nlhx13tXWDZH7MJtABzjyg+AI7XWSEQs2cBXACos0M4Myc6lU+eL+iA+OuoUOhmrh\\nqmT8YYGu76\/IBWUSqWuvcpHPpwl7871i4Ga\/I3qnAoGBANNkKAcMoeAbJQK7a\/Rn\\nwPEJB+dPgNDIaboAsh1nZhVhN5cvdvCWuEYgOGCPQLYQF0zmTLcM+sVxOYgfy8mV\\nfbNgPgsP5xmu6dw2COBKdtozw0HrWSRjACd1N4yGu75+wPCcX\/gQarcjRcXXZeEa\\nNtBLSfcqPULqD+h7br9lEJio\\n-----END PRIVATE KEY-----\\n\",\"client_email\":\"123-abc@developer.gserviceaccount.com\",\"client_id\":\"123-abc.apps.googleusercontent.com\",\"auth_uri\":\"https:\/\/accounts.google.com\/o\/oauth2\/auth\",\"token_uri\":\"http:\/\/localhost:10339\/token\"}",
-      "order": 1,
-      "ui_restrictions": []
-    },
-    "use_domain_wide_delegation_for_sync": {
-      "depends_on": [],
-      "display": "toggle",
-      "tooltip": "Enable domain-wide delegation to automatically sync content from all shared and personal drives in the Google workspace. This eliminates the need to manually share Google Drive data with your service account, though it may increase sync time. If disabled, only items and folders manually shared with the service account will be synced. Please refer to the connector documentation to ensure domain-wide delegation is correctly configured and has the appropriate scopes.",
-      "default_value": null,
-      "label": "Use domain-wide delegation for data sync",
-      "sensitive": false,
-      "type": "bool",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": false,
-      "order": 2,
-      "ui_restrictions": []
-    },
-    "google_workspace_admin_email_for_data_sync": {
-      "depends_on": [
-        {
-          "field": "use_domain_wide_delegation_for_sync",
-          "value": true
-        }
-      ],
-      "display": "text",
-      "tooltip": "Provide the admin email to be used with domain-wide delegation for data sync. This email enables the connector to utilize the Admin Directory API for listing organization users. Please refer to the connector documentation to ensure domain-wide delegation is correctly configured and has the appropriate scopes.",
-      "default_value": null,
-      "label": "Google Workspace admin email",
-      "sensitive": false,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [
-        {
-          "constraint": "^\\S+@\\S+\\.\\S+$",
-          "type": "regex"
-        }
-      ],
-      "value": "admin@your-organization.com",
-      "order": 3,
-      "ui_restrictions": []
-    },
-    "google_workspace_email_for_shared_drives_sync": {
-      "depends_on": [
-        {
-          "field": "use_domain_wide_delegation_for_sync",
-          "value": true
-        }
-      ],
-      "display": "text",
-      "tooltip": "Provide the Google Workspace user email for discovery and syncing of shared drives. Only the shared drives this user has access to will be synced.",
-      "default_value": null,
-      "label": "Google Workspace email for syncing shared drives",
-      "sensitive": false,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [
-        {
-          "constraint": "^\\S+@\\S+\\.\\S+$",
-          "type": "regex"
-        }
-      ],
-      "value": "email@your-organization.com",
-      "order": 4,
-      "ui_restrictions": []
-    },
-    "use_document_level_security": {
-      "depends_on": [],
-      "display": "toggle",
-      "tooltip": "Document level security ensures identities and permissions set in Google Drive are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
-      "default_value": null,
-      "label": "Enable document level security",
-      "sensitive": false,
-      "type": "bool",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": false,
-      "order": 5,
-      "ui_restrictions": []
-    },
-    "google_workspace_admin_email": {
-      "depends_on": [
-        {
-          "field": "use_document_level_security",
-          "value": true
-        }
-      ],
-      "display": "text",
-      "tooltip": "In order to use Document Level Security you need to enable Google Workspace domain-wide delegation of authority for your service account. A service account with delegated authority can impersonate admin user with sufficient permissions to fetch all users and their corresponding permissions.",
-      "default_value": null,
-      "label": "Google Workspace admin email",
-      "sensitive": false,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [
-        {
-          "constraint": "^\\S+@\\S+\\.\\S+$",
-          "type": "regex"
-        }
-      ],
-      "value": "admin@your-organization.com",
-      "order": 6,
-      "ui_restrictions": []
-    },
-    "max_concurrency": {
-      "depends_on": [],
-      "display": "numeric",
-      "tooltip": "This setting determines the maximum number of concurrent HTTP requests sent to the Google API to fetch data. Increasing this value can improve data retrieval speed, but it may also place higher demands on system resources and network bandwidth.",
-      "default_value": 25,
-      "label": "Maximum concurrent HTTP requests",
-      "sensitive": false,
-      "type": "int",
-      "required": false,
-      "options": [],
-      "validations": [
-        {
-          "constraint": 0,
-          "type": "greater_than"
-        }
-      ],
-      "value": 25,
-      "order": 7,
-      "ui_restrictions": [
-        "advanced"
-      ]
-    },
-    "use_text_extraction_service": {
-      "default_value": null,
-      "depends_on": [],
-      "display": "toggle",
-      "label": "Use text extraction service",
-      "options": [],
-      "order": 8,
-      "required": true,
-      "sensitive": false,
-      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-      "type": "bool",
-      "ui_restrictions": [],
-      "validations": [],
-      "value": false
-    }
-  },
-  "custom_scheduling": {},
-  "description": null,
-  "error": null,
-  "features": {
-    "incremental_sync": {
-      "enabled": false
-    },
-    "document_level_security": {
-      "enabled": false
-    },
-    "sync_rules": {
-      "advanced": {
-        "enabled": false
-      },
-      "basic": {
-        "enabled": true
-      }
-    }
-  },
-  "filtering": [
-    {
-      "active": {
-        "advanced_snippet": {
-          "created_at": "2023-06-30T08:20:14.686Z",
-          "updated_at": "2023-06-30T08:20:14.686Z",
-          "value": {}
+    "configuration": {
+        "service_account_credentials": {
+            "depends_on": [],
+            "display": "textarea",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Google Drive service account JSON",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "{\"type\":\"service_account\",\"project_id\":\"project_id\",\"private_key_id\":\"abc\",\"private_key\":\"-----BEGIN PRIVATE KEY-----\\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDY3E8o1NEFcjMM\\nHW/5ZfFJw29/8NEqpViNjQIx95Xx5KDtJ+nWn9+OW0uqsSqKlKGhAdAo+Q6bjx2c\\nuXVsXTu7XrZUY5Kltvj94DvUa1wjNXs606r/RxWTJ58bfdC+gLLxBfGnB6CwK0YQ\\nxnfpjNbkUfVVzO0MQD7UP0Hl5ZcY0Puvxd/yHuONQn/rIAieTHH1pqgW+zrH/y3c\\n59IGThC9PPtugI9ea8RSnVj3PWz1bX2UkCDpy9IRh9LzJLaYYX9RUd7++dULUlat\\nAaXBh1U6emUDzhrIsgApjDVtimOPbmQWmX1S60mqQikRpVYZ8u+NDD+LNw+/Eovn\\nxCj2Y3z1AgMBAAECggEAWDBzoqO1IvVXjBA2lqId10T6hXmN3j1ifyH+aAqK+FVl\\nGjyWjDj0xWQcJ9ync7bQ6fSeTeNGzP0M6kzDU1+w6FgyZqwdmXWI2VmEizRjwk+/\\n/uLQUcL7I55Dxn7KUoZs/rZPmQDxmGLoue60Gg6z3yLzVcKiDc7cnhzhdBgDc8vd\\nQorNAlqGPRnm3EqKQ6VQp6fyQmCAxrr45kspRXNLddat3AMsuqImDkqGKBmF3Q1y\\nxWGe81LphUiRqvqbyUlh6cdSZ8pLBpc9m0c3qWPKs9paqBIvgUPlvOZMqec6x4S6\\nChbdkkTRLnbsRr0Yg/nDeEPlkhRBhasXpxpMUBgPywKBgQDs2axNkFjbU94uXvd5\\nznUhDVxPFBuxyUHtsJNqW4p/ujLNimGet5E/YthCnQeC2P3Ym7c3fiz68amM6hiA\\nOnW7HYPZ+jKFnefpAtjyOOs46AkftEg07T9XjwWNPt8+8l0DYawPoJgbM5iE0L2O\\nx8TU1Vs4mXc+ql9F90GzI0x3VwKBgQDqZOOqWw3hTnNT07Ixqnmd3dugV9S7eW6o\\nU9OoUgJB4rYTpG+yFqNqbRT8bkx37iKBMEReppqonOqGm4wtuRR6LSLlgcIU9Iwx\\nyfH12UWqVmFSHsgZFqM/cK3wGev38h1WBIOx3/djKn7BdlKVh8kWyx6uC8bmV+E6\\nOoK0vJD6kwKBgHAySOnROBZlqzkiKW8c+uU2VATtzJSydrWm0J4wUPJifNBa/hVW\\ndcqmAzXC9xznt5AVa3wxHBOfyKaE+ig8CSsjNyNZ3vbmr0X04FoV1m91k2TeXNod\\njMTobkPThaNm4eLJMN2SQJuaHGTGERWC0l3T18t+/zrDMDCPiSLX1NAvAoGBAN1T\\nVLJYdjvIMxf1bm59VYcepbK7HLHFkRq6xMJMZbtG0ryraZjUzYvB4q4VjHk2UDiC\\nlhx13tXWDZH7MJtABzjyg+AI7XWSEQs2cBXACos0M4Myc6lU+eL+iA+OuoUOhmrh\\nqmT8YYGu76/IBWUSqWuvcpHPpwl7871i4Ga/I3qnAoGBANNkKAcMoeAbJQK7a/Rn\\nwPEJB+dPgNDIaboAsh1nZhVhN5cvdvCWuEYgOGCPQLYQF0zmTLcM+sVxOYgfy8mV\\nfbNgPgsP5xmu6dw2COBKdtozw0HrWSRjACd1N4yGu75+wPCcX/gQarcjRcXXZeEa\\nNtBLSfcqPULqD+h7br9lEJio\\n-----END PRIVATE KEY-----\\n\",\"client_email\":\"123-abc@developer.gserviceaccount.com\",\"client_id\":\"123-abc.apps.googleusercontent.com\",\"auth_uri\":\"https://accounts.google.com/o/oauth2/auth\",\"token_uri\":\"http://localhost:10339/token\"}",
+            "order": 1,
+            "ui_restrictions": []
         },
-        "rules": [
-          {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
-        }
-      },
-      "domain": "DEFAULT",
-      "draft": {
-        "advanced_snippet": {
-          "created_at": "2023-06-30T08:20:14.686Z",
-          "updated_at": "2023-06-30T08:20:14.686Z",
-          "value": {}
+        "use_domain_wide_delegation_for_sync": {
+            "depends_on": [],
+            "display": "toggle",
+            "tooltip": "Enable domain-wide delegation to automatically sync content from all shared and personal drives in the Google workspace. This eliminates the need to manually share Google Drive data with your service account, though it may increase sync time. If disabled, only items and folders manually shared with the service account will be synced. Please refer to the connector documentation to ensure domain-wide delegation is correctly configured and has the appropriate scopes.",
+            "default_value": null,
+            "label": "Use domain-wide delegation for data sync",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 2,
+            "ui_restrictions": []
         },
-        "rules": [
-          {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
+        "google_workspace_admin_email_for_data_sync": {
+            "depends_on": [
+                {
+                    "field": "use_domain_wide_delegation_for_sync",
+                    "value": true
+                }
+            ],
+            "display": "text",
+            "tooltip": "Provide the admin email to be used with domain-wide delegation for data sync. This email enables the connector to utilize the Admin Directory API for listing organization users. Please refer to the connector documentation to ensure domain-wide delegation is correctly configured and has the appropriate scopes.",
+            "default_value": null,
+            "label": "Google Workspace admin email",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [
+                {
+                    "constraint": "^\\S+@\\S+\\.\\S+$",
+                    "type": "regex"
+                }
+            ],
+            "value": "admin@your-organization.com",
+            "order": 3,
+            "ui_restrictions": []
+        },
+        "google_workspace_email_for_shared_drives_sync": {
+            "depends_on": [
+                {
+                    "field": "use_domain_wide_delegation_for_sync",
+                    "value": true
+                }
+            ],
+            "display": "text",
+            "tooltip": "Provide the Google Workspace user email for discovery and syncing of shared drives. Only the shared drives this user has access to will be synced.",
+            "default_value": null,
+            "label": "Google Workspace email for syncing shared drives",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [
+                {
+                    "constraint": "^\\S+@\\S+\\.\\S+$",
+                    "type": "regex"
+                }
+            ],
+            "value": "email@your-organization.com",
+            "order": 4,
+            "ui_restrictions": []
+        },
+        "use_document_level_security": {
+            "depends_on": [],
+            "display": "toggle",
+            "tooltip": "Document level security ensures identities and permissions set in Google Drive are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+            "default_value": null,
+            "label": "Enable document level security",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 5,
+            "ui_restrictions": []
+        },
+        "google_workspace_admin_email": {
+            "depends_on": [
+                {
+                    "field": "use_document_level_security",
+                    "value": true
+                }
+            ],
+            "display": "text",
+            "tooltip": "In order to use Document Level Security you need to enable Google Workspace domain-wide delegation of authority for your service account. A service account with delegated authority can impersonate admin user with sufficient permissions to fetch all users and their corresponding permissions.",
+            "default_value": null,
+            "label": "Google Workspace admin email",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [
+                {
+                    "constraint": "^\\S+@\\S+\\.\\S+$",
+                    "type": "regex"
+                }
+            ],
+            "value": "admin@your-organization.com",
+            "order": 6,
+            "ui_restrictions": []
+        },
+        "max_concurrency": {
+            "depends_on": [],
+            "display": "numeric",
+            "tooltip": "This setting determines the maximum number of concurrent HTTP requests sent to the Google API to fetch data. Increasing this value can improve data retrieval speed, but it may also place higher demands on system resources and network bandwidth.",
+            "default_value": 25,
+            "label": "Maximum concurrent HTTP requests",
+            "sensitive": false,
+            "type": "int",
+            "required": false,
+            "options": [],
+            "validations": [
+                {
+                    "constraint": 0,
+                    "type": "greater_than"
+                }
+            ],
+            "value": 25,
+            "order": 7,
+            "ui_restrictions": [
+                "advanced"
+            ]
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 8,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
-      }
     }
-  ],
-  "index_name": "search-google_drive",
-  "is_native": false,
-  "language": null,
-  "last_access_control_sync_error": null,
-  "last_access_control_sync_scheduled_at": null,
-  "last_access_control_sync_status": null,
-  "last_incremental_sync_scheduled_at": null,
-  "last_seen": "2023-06-30T09:26:21.281198+00:00",
-  "last_sync_error": null,
-  "last_sync_scheduled_at": null,
-  "last_sync_status": null,
-  "last_synced": null,
-  "name": "google-drive",
-  "pipeline": {
-    "extract_binary_content": true,
-    "name": "ent-search-generic-ingestion",
-    "reduce_whitespace": true,
-    "run_ml_inference": true
-  },
-  "scheduling": {
-    "access_control": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    },
-    "full": {
-      "enabled": true,
-      "interval": "* * * * * *"
-    },
-    "incremental": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    }
-  },
-  "service_type": "google_drive",
-  "status": "configured",
-  "sync_now": true
 }

--- a/tests/sources/fixtures/graphql/connector.json
+++ b/tests/sources/fixtures/graphql/connector.json
@@ -1,5 +1,4 @@
 {
-    "api_key_id": null,
     "configuration": {
         "http_endpoint": {
             "label": "HTTP URL & Endpoint",
@@ -11,8 +10,14 @@
             "display": "dropdown",
             "label": "GET/POST",
             "options": [
-                {"label": "GET", "value": "get"},
-                {"label": "POST", "value": "post"}
+                {
+                    "label": "GET",
+                    "value": "get"
+                },
+                {
+                    "label": "POST",
+                    "value": "post"
+                }
             ],
             "order": 2,
             "type": "str",
@@ -22,29 +27,53 @@
             "display": "dropdown",
             "label": "Authentication Method",
             "options": [
-                {"label": "No Auth", "value": "none"},
-                {"label": "Basic Auth", "value": "basic"},
-                {"label": "Bearer Token", "value": "bearer"}
+                {
+                    "label": "No Auth",
+                    "value": "none"
+                },
+                {
+                    "label": "Basic Auth",
+                    "value": "basic"
+                },
+                {
+                    "label": "Bearer Token",
+                    "value": "bearer"
+                }
             ],
             "order": 3,
             "type": "str",
             "value": "none"
         },
         "username": {
-            "depends_on": [{"field": "authentication_method", "value": "basic"}],
+            "depends_on": [
+                {
+                    "field": "authentication_method",
+                    "value": "basic"
+                }
+            ],
             "label": "Username",
             "order": 4,
             "type": "str"
         },
         "password": {
-            "depends_on": [{"field": "authentication_method", "value": "basic"}],
+            "depends_on": [
+                {
+                    "field": "authentication_method",
+                    "value": "basic"
+                }
+            ],
             "label": "Password",
             "order": 5,
             "sensitive": true,
             "type": "str"
         },
         "token": {
-            "depends_on": [{"field": "authentication_method", "value": "bearer"}],
+            "depends_on": [
+                {
+                    "field": "authentication_method",
+                    "value": "bearer"
+                }
+            ],
             "label": "Bearer Token",
             "order": 6,
             "sensitive": true,
@@ -58,7 +87,12 @@
             "value": "query($cursor: String!) {sampleData {users(after: $cursor) {pageInfo {endCursor hasNextPage} nodes {id first_name updatedAt description}}}}"
         },
         "graphql_variables": {
-            "depends_on": [{"field": "http_method", "value": "post"}],
+            "depends_on": [
+                {
+                    "field": "http_method",
+                    "value": "post"
+                }
+            ],
             "display": "textarea",
             "label": "Graphql Variables",
             "order": 8,
@@ -78,142 +112,46 @@
             "required": false
         },
         "pagination_model": {
-          "display": "dropdown",
-          "label": "Pagination model",
-          "options": [
-              {"label": "No pagination", "value": "no_pagination"},
-              {"label": "Cursor-based pagination", "value": "cursor_pagination"}
-          ],
-          "order": 11,
-          "tooltip": "Cursor based pagination requires 'pageInfo' field along with argument 'after' for objects mentioned in 'GraphQL Objects List'. It also requires variable for 'after' argument.",
-          "type": "str",
-          "value": "cursor_pagination"
-      },
-      "pagination_key": {
-          "depends_on": [
-              {"field": "pagination_model", "value": "cursor_pagination"}
-          ],
-          "label": "Pagination key",
-          "order": 12,
-          "tooltip": "Specifies which GraphQL object is used for pagination. Use '.' to provide full path of the object from the root of the response. For example 'organization.users'",
-          "type": "str",
-          "value": "sampleData.users"
-      },
-      "connection_timeout": {
-          "default_value": 300,
-          "display": "numeric",
-          "label": "Connection Timeout",
-          "order": 13,
-          "required": false,
-          "type": "int",
-          "ui_restrictions": ["advanced"]
-      }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": null,
-    "features": {
-      "incremental_sync": {
-        "enabled": false
-      },
-      "document_level_security": {
-        "enabled": false
-      },
-      "sync_rules": {
-        "advanced": {
-          "enabled": false
+            "display": "dropdown",
+            "label": "Pagination model",
+            "options": [
+                {
+                    "label": "No pagination",
+                    "value": "no_pagination"
+                },
+                {
+                    "label": "Cursor-based pagination",
+                    "value": "cursor_pagination"
+                }
+            ],
+            "order": 11,
+            "tooltip": "Cursor based pagination requires 'pageInfo' field along with argument 'after' for objects mentioned in 'GraphQL Objects List'. It also requires variable for 'after' argument.",
+            "type": "str",
+            "value": "cursor_pagination"
         },
-        "basic": {
-          "enabled": true
-        }
-      }
-    },
-    "filtering": [
-      {
-        "active": {
-          "advanced_snippet": {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "created_at": "2023-06-30T08:20:14.686Z",
-              "field": "_",
-              "id": "DEFAULT",
-              "order": 0,
-              "policy": "include",
-              "rule": "regex",
-              "updated_at": "2023-06-30T08:20:14.686Z",
-              "value": ".*"
-            }
-          ],
-          "validation": {
-            "errors": [],
-            "state": "valid"
-          }
+        "pagination_key": {
+            "depends_on": [
+                {
+                    "field": "pagination_model",
+                    "value": "cursor_pagination"
+                }
+            ],
+            "label": "Pagination key",
+            "order": 12,
+            "tooltip": "Specifies which GraphQL object is used for pagination. Use '.' to provide full path of the object from the root of the response. For example 'organization.users'",
+            "type": "str",
+            "value": "sampleData.users"
         },
-        "domain": "DEFAULT",
-        "draft": {
-          "advanced_snippet": {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "created_at": "2023-06-30T08:20:14.686Z",
-              "field": "_",
-              "id": "DEFAULT",
-              "order": 0,
-              "policy": "include",
-              "rule": "regex",
-              "updated_at": "2023-06-30T08:20:14.686Z",
-              "value": ".*"
-            }
-          ],
-          "validation": {
-            "errors": [],
-            "state": "valid"
-          }
+        "connection_timeout": {
+            "default_value": 300,
+            "display": "numeric",
+            "label": "Connection Timeout",
+            "order": 13,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ]
         }
-      }
-    ],
-    "index_name": "search-graphql",
-    "is_native": false,
-    "language": null,
-    "last_access_control_sync_error": null,
-    "last_access_control_sync_scheduled_at": null,
-    "last_access_control_sync_status": null,
-    "last_incremental_sync_scheduled_at": null,
-    "last_seen": "2023-06-30T09:26:21.281198+00:00",
-    "last_sync_error": null,
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": null,
-    "name": "grapqhql",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "access_control": {
-        "enabled": false,
-        "interval": "0 0 0 * * ?"
-      },
-      "full": {
-        "enabled": true,
-        "interval": "* * * * * *"
-      },
-      "incremental": {
-        "enabled": false,
-        "interval": "0 0 0 * * ?"
-      }
-    },
-    "service_type": "graphql",
-    "status": "configured",
-    "sync_now": true
-  }
-  
+    }
+}

--- a/tests/sources/fixtures/jira/connector.json
+++ b/tests/sources/fixtures/jira/connector.json
@@ -1,227 +1,163 @@
 {
-  "api_key_id": null,
-  "configuration": {
-    "data_source": {
-      "display": "dropdown",
-      "label": "Jira data source",
-      "options": [
-        {"label": "Jira Cloud", "value": "jira_cloud"},
-        {"label": "Jira Server", "value": "jira_server"}
-      ],
-      "order": 1,
-      "type": "str",
-      "value": "jira_cloud"
-    },
-    "username": {
-      "depends_on": [{"field": "data_source", "value": "jira_server"}],
-      "label": "Jira Server username",
-      "order": 2,
-      "type": "str",
-      "value": "admin"
-    },
-    "password": {
-      "depends_on": [{"field": "data_source", "value": "jira_server"}],
-      "label": "Jira Server password",
-      "sensitive": true,
-      "order": 3,
-      "type": "str",
-      "value": "changeme"
-    },
-    "account_email": {
-      "depends_on": [{"field": "data_source", "value": "jira_cloud"}],
-      "label": "Jira Cloud service account id",
-      "order": 4,
-      "type": "str",
-      "value": "me@example.com"
-    },
-    "api_token": {
-      "depends_on": [{"field": "data_source", "value": "jira_cloud"}],
-      "label": "Jira Cloud API token",
-      "order": 5,
-      "sensitive": true,
-      "type": "str",
-      "value": "abc#123"
-    },
-    "jira_url": {
-      "label": "Jira host url",
-      "order": 6,
-      "type": "str",
-      "value": "http://127.0.0.1:8080"
-    },
-    "projects": {
-      "display": "textarea",
-      "label": "Jira project keys",
-      "order": 7,
-      "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
-      "type": "list",
-      "value": "*"
-    },
-    "ssl_enabled": {
-      "display": "toggle",
-      "label": "Enable SSL",
-      "order": 8,
-      "type": "bool",
-      "value": false
-    },
-    "ssl_ca": {
-      "depends_on": [{"field": "ssl_enabled", "value": true}],
-      "label": "SSL certificate",
-      "order": 9,
-      "type": "str",
-      "value": ""
-    },
-    "retry_count": {
-      "default_value": 3,
-      "display": "numeric",
-      "label": "Retries for failed requests",
-      "order": 10,
-      "required": false,
-      "type": "int",
-      "ui_restrictions": ["advanced"],
-      "value": 3
-    },
-    "concurrent_downloads": {
-      "default_value": 100,
-      "display": "numeric",
-      "label": "Maximum concurrent downloads",
-      "order": 11,
-      "required": false,
-      "type": "int",
-      "ui_restrictions": ["advanced"],
-      "validations": [
-        {"type": "less_than", "constraint": 101}
-      ],
-      "value": 100
-    },
-    "use_document_level_security": {
-      "display": "toggle",
-      "depends_on": [{"field": "data_source", "value": "jira_cloud"}],
-      "label": "Enable document level security",
-      "order": 12,
-      "tooltip": "Document level security ensures identities and permissions set in Jira are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
-      "type": "bool",
-      "value": false
-    },
-    "use_text_extraction_service": {
-      "default_value": null,
-      "depends_on": [],
-      "display": "toggle",
-      "label": "Use text extraction service",
-      "options": [],
-      "order": 13,
-      "required": true,
-      "sensitive": false,
-      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-      "type": "bool",
-      "ui_restrictions": [],
-      "validations": [],
-      "value": false
-    }
-  },
-  "custom_scheduling": {},
-  "description": null,
-  "error": null,
-  "features": {
-    "incremental_sync": {
-      "enabled": false
-    },
-    "document_level_security": {
-      "enabled": false
-    },
-    "sync_rules": {
-      "advanced": {
-        "enabled": false
-      },
-      "basic": {
-        "enabled": true
-      }
-    }
-  },
-  "filtering": [
-    {
-      "active": {
-        "advanced_snippet": {
-          "created_at": "2023-06-30T08:20:14.686Z",
-          "updated_at": "2023-06-30T08:20:14.686Z",
-          "value": {}
+    "configuration": {
+        "data_source": {
+            "display": "dropdown",
+            "label": "Jira data source",
+            "options": [
+                {
+                    "label": "Jira Cloud",
+                    "value": "jira_cloud"
+                },
+                {
+                    "label": "Jira Server",
+                    "value": "jira_server"
+                }
+            ],
+            "order": 1,
+            "type": "str",
+            "value": "jira_cloud"
         },
-        "rules": [
-          {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
-        }
-      },
-      "domain": "DEFAULT",
-      "draft": {
-        "advanced_snippet": {
-          "created_at": "2023-06-30T08:20:14.686Z",
-          "updated_at": "2023-06-30T08:20:14.686Z",
-          "value": {}
+        "username": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "jira_server"
+                }
+            ],
+            "label": "Jira Server username",
+            "order": 2,
+            "type": "str",
+            "value": "admin"
         },
-        "rules": [
-          {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
+        "password": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "jira_server"
+                }
+            ],
+            "label": "Jira Server password",
+            "sensitive": true,
+            "order": 3,
+            "type": "str",
+            "value": "changeme"
+        },
+        "account_email": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "jira_cloud"
+                }
+            ],
+            "label": "Jira Cloud service account id",
+            "order": 4,
+            "type": "str",
+            "value": "me@example.com"
+        },
+        "api_token": {
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "jira_cloud"
+                }
+            ],
+            "label": "Jira Cloud API token",
+            "order": 5,
+            "sensitive": true,
+            "type": "str",
+            "value": "abc#123"
+        },
+        "jira_url": {
+            "label": "Jira host url",
+            "order": 6,
+            "type": "str",
+            "value": "http://127.0.0.1:8080"
+        },
+        "projects": {
+            "display": "textarea",
+            "label": "Jira project keys",
+            "order": 7,
+            "tooltip": "This configurable field is ignored when Advanced Sync Rules are used.",
+            "type": "list",
+            "value": "*"
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "Enable SSL",
+            "order": 8,
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
+                {
+                    "field": "ssl_enabled",
+                    "value": true
+                }
+            ],
+            "label": "SSL certificate",
+            "order": 9,
+            "type": "str",
+            "value": ""
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries for failed requests",
+            "order": 10,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 3
+        },
+        "concurrent_downloads": {
+            "default_value": 100,
+            "display": "numeric",
+            "label": "Maximum concurrent downloads",
+            "order": 11,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "validations": [
+                {
+                    "type": "less_than",
+                    "constraint": 101
+                }
+            ],
+            "value": 100
+        },
+        "use_document_level_security": {
+            "display": "toggle",
+            "depends_on": [
+                {
+                    "field": "data_source",
+                    "value": "jira_cloud"
+                }
+            ],
+            "label": "Enable document level security",
+            "order": 12,
+            "tooltip": "Document level security ensures identities and permissions set in Jira are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+            "type": "bool",
+            "value": false
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 13,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
-      }
     }
-  ],
-  "index_name": "search-jira",
-  "is_native": false,
-  "language": null,
-  "last_access_control_sync_error": null,
-  "last_access_control_sync_scheduled_at": null,
-  "last_access_control_sync_status": null,
-  "last_incremental_sync_scheduled_at": null,
-  "last_seen": "2023-06-30T09:26:21.281198+00:00",
-  "last_sync_error": null,
-  "last_sync_scheduled_at": null,
-  "last_sync_status": null,
-  "last_synced": null,
-  "name": "google-drive",
-  "pipeline": {
-    "extract_binary_content": true,
-    "name": "ent-search-generic-ingestion",
-    "reduce_whitespace": true,
-    "run_ml_inference": true
-  },
-  "scheduling": {
-    "access_control": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    },
-    "full": {
-      "enabled": true,
-      "interval": "* * * * * *"
-    },
-    "incremental": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    }
-  },
-  "service_type": "jira",
-  "status": "configured",
-  "sync_now": true
 }

--- a/tests/sources/fixtures/microsoft_teams/connector.json
+++ b/tests/sources/fixtures/microsoft_teams/connector.json
@@ -1,119 +1,79 @@
 {
-    "api_key_id": "",
     "configuration": {
-      "tenant_id": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Tenant ID",
-        "sensitive": false,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "00000000-0000-0000-0000-000000000000",
-        "order": 1,
-        "ui_restrictions": []
-      },
-      "client_id": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Client ID",
-        "sensitive": true,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
-        "order": 4,
-        "ui_restrictions": []
-      },
-      "secret_value": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Secret value",
-        "sensitive": true,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "00000000-0000-0000-0000-000000000000",
-        "order": 3,
-        "ui_restrictions": []
-      },
-      "username": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Username",
-        "sensitive": true,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "dummy",
-        "order": 4,
-        "ui_restrictions": []
-      },
-      "password": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Password",
-        "sensitive": true,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "changeme",
-        "order": 5,
-        "ui_restrictions": []
-      }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": "Cannot connect to host enterprisesearchasd.microsoft.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "features": {
-      "filtering_advanced_config": false,
-      "filtering_rules": false,
-      "sync_rules": {
-        "advanced": {
-          "enabled": true
+        "tenant_id": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Tenant ID",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "00000000-0000-0000-0000-000000000000",
+            "order": 1,
+            "ui_restrictions": []
         },
-        "basic": {
-          "enabled": true
+        "client_id": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Client ID",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
+            "order": 4,
+            "ui_restrictions": []
+        },
+        "secret_value": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Secret value",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "00000000-0000-0000-0000-000000000000",
+            "order": 3,
+            "ui_restrictions": []
+        },
+        "username": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Username",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "dummy",
+            "order": 4,
+            "ui_restrictions": []
+        },
+        "password": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Password",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "changeme",
+            "order": 5,
+            "ui_restrictions": []
         }
-      }
-    },
-    "index_name": "search-microsoft_teams",
-    "is_native": false,
-    "language": null,
-    "last_seen": "2023-06-02T16:05:43.247794+00:00",
-    "last_sync_error": "Cannot connect to host enterprisesearchasd.microsoft.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": "2023-06-02T16:08:30.745527+00:00",
-    "name": "microsoft_teams-connector",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "full": {
-        "enabled": true,
-        "interval": "0 * * * * ?"
-      }
-    },
-    "service_type": "microsoft_teams",
-    "status": "connected",
-    "sync_now": false
-  }
+    }
+}

--- a/tests/sources/fixtures/mongodb/connector.json
+++ b/tests/sources/fixtures/mongodb/connector.json
@@ -1,139 +1,81 @@
 {
-        "name": "mongodb",
-        "service_type": "mongodb",
-        "index_name": "search-mongodb",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": null,
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-            "host": {
-                "label": "Server Hostname",
-                "order": 1,
-                "type": "str",
-                "value": "mongodb://127.0.0.1:27021"
-            },
-            "user": {
-                "default_value": "",
-                "label": "Username",
-                "order": 2,
-                "type": "str",
-                "value": "admin",
-                "required": false
-            },
-            "password": {
-                "default_value": "",
-                "label": "Password",
-                "order": 3,
-                "sensitive": true,
-                "type": "str",
-                "value": "justtesting",
-                "required": false
-            },
-            "database": {
-                "label": "Database",
-                "order": 4,
-                "type": "str",
-                "value": "sample_database"
-            },
-            "collection": {
-                "label": "Collection",
-                "order": 5,
-                "type": "str",
-                "value": "sample_collection"
-            },
-            "direct_connection": {
-                "display": "toggle",
-                "label": "Direct connection",
-                "order": 6,
-                "type": "bool",
-                "value": true
-            },
-            "ssl_enabled": {
-                "display": "toggle",
-                "label": "SSL/TLS Connection",
-                "order": 7,
-                "tooltip": "This option establishes a secure connection to the MongoDB server using SSL/TLS encryption. Ensure that your MongoDB deployment supports SSL/TLS connections. Enable if MongoDB cluster uses DNS SRV records.",
-                "type": "bool",
-                "value": false
-            },
-            "ssl_ca": {
-                "depends_on": [{"field": "ssl_enabled", "value": true}],
-                "label": "Certificate Authority (.pem)",
-                "order": 8,
-                "required": false,
-                "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the MongoDB instance.",
-                "type": "str"
-            },
-            "tls_insecure": {
-                "display": "toggle",
-                "depends_on": [{"field": "ssl_enabled", "value": true}],
-                "label": "Skip certificate verification",
-                "order": 9,
-                "tooltip": "This option skips certificate validation for TLS/SSL connections to your MongoDB server. We strongly recommend setting this option to 'disable'.",
-                "type": "bool",
-                "value": false
-            }
+    "configuration": {
+        "host": {
+            "label": "Server Hostname",
+            "order": 1,
+            "type": "str",
+            "value": "mongodb://127.0.0.1:27021"
         },
-        "filtering": [
+        "user": {
+            "default_value": "",
+            "label": "Username",
+            "order": 2,
+            "type": "str",
+            "value": "admin",
+            "required": false
+        },
+        "password": {
+            "default_value": "",
+            "label": "Password",
+            "order": 3,
+            "sensitive": true,
+            "type": "str",
+            "value": "justtesting",
+            "required": false
+        },
+        "database": {
+            "label": "Database",
+            "order": 4,
+            "type": "str",
+            "value": "sample_database"
+        },
+        "collection": {
+            "label": "Collection",
+            "order": 5,
+            "type": "str",
+            "value": "sample_collection"
+        },
+        "direct_connection": {
+            "display": "toggle",
+            "label": "Direct connection",
+            "order": 6,
+            "type": "bool",
+            "value": true
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "SSL/TLS Connection",
+            "order": 7,
+            "tooltip": "This option establishes a secure connection to the MongoDB server using SSL/TLS encryption. Ensure that your MongoDB deployment supports SSL/TLS connections. Enable if MongoDB cluster uses DNS SRV records.",
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                        "advanced_snippet": {
-                          "updated_at": "2023-01-31T16:41:27.341Z",
-                          "created_at": "2023-01-31T16:38:49.244Z",
-                          "value": {}
-                        },
-                        "rules": [
-                          {
-                              "field": "_",
-                              "updated_at": "2023-01-31T16:41:27.341Z",
-                              "created_at": "2023-01-31T16:38:49.244Z",
-                              "rule": "regex",
-                              "id": "DEFAULT",
-                              "value": ".*",
-                              "order": 1,
-                              "policy": "include"
-                          }
-                        ],
-                        "validation": {"state": "valid", "errors": []}
-                  },
-                  "active": {
-                        "advanced_snippet": {
-                          "updated_at": "2023-01-31T16:41:27.341Z",
-                          "created_at": "2023-01-31T16:38:49.244Z",
-                          "value": {}
-                        },
-                        "rules": [
-                          {
-                              "field": "_",
-                              "updated_at": "2023-01-31T16:41:27.341Z",
-                              "created_at": "2023-01-31T16:38:49.244Z",
-                              "rule": "regex",
-                              "id": "DEFAULT",
-                              "value": ".*",
-                              "order": 1,
-                              "policy": "include"
-                          }
-                        ],
-                        "validation": {"state": "valid", "errors": []}
-                        }
+                    "field": "ssl_enabled",
+                    "value": true
                 }
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "label": "Certificate Authority (.pem)",
+            "order": 8,
+            "required": false,
+            "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the MongoDB instance.",
+            "type": "str"
+        },
+        "tls_insecure": {
+            "display": "toggle",
+            "depends_on": [
+                {
+                    "field": "ssl_enabled",
+                    "value": true
+                }
+            ],
+            "label": "Skip certificate verification",
+            "order": 9,
+            "tooltip": "This option skips certificate validation for TLS/SSL connections to your MongoDB server. We strongly recommend setting this option to 'disable'.",
+            "type": "bool",
+            "value": false
         }
+    }
 }

--- a/tests/sources/fixtures/mongodb_serverless/connector.json
+++ b/tests/sources/fixtures/mongodb_serverless/connector.json
@@ -1,149 +1,81 @@
 {
-  "name": "mongodb",
-  "service_type": "mongodb",
-  "index_name": "search-mongodb",
-  "sync_cursor": null,
-  "is_native": false,
-  "api_key_id": null,
-  "status": "configured",
-  "language": "en",
-  "last_sync_status": null,
-  "last_permissions_sync_status": null,
-  "last_sync_error": null,
-  "last_synced": null,
-  "last_seen": null,
-  "created_at": null,
-  "updated_at": null,
-  "configuration": {
-    "host": {
-      "label": "Server Hostname",
-      "order": 1,
-      "type": "str",
-      "value": "mongodb://127.0.0.1:27021"
-    },
-    "user": {
-      "default_value": "",
-      "label": "Username",
-      "order": 2,
-      "type": "str",
-      "value": "admin",
-      "required": false
-    },
-    "password": {
-      "default_value": "",
-      "label": "Password",
-      "order": 3,
-      "sensitive": true,
-      "type": "str",
-      "value": "justtesting",
-      "required": false
-    },
-    "database": {
-      "label": "Database",
-      "order": 4,
-      "type": "str",
-      "value": "sample_database"
-    },
-    "collection": {
-      "label": "Collection",
-      "order": 5,
-      "type": "str",
-      "value": "sample_collection"
-    },
-    "direct_connection": {
-      "display": "toggle",
-      "label": "Direct connection",
-      "order": 6,
-      "type": "bool",
-      "value": true
-    },
-    "ssl_enabled": {
-        "display": "toggle",
-        "label": "SSL/TLS Connection",
-        "order": 7,
-        "tooltip": "This option establishes a secure connection to the MongoDB server using SSL/TLS encryption. Ensure that your MongoDB deployment supports SSL/TLS connections. Enable if MongoDB cluster uses DNS SRV records.",
-        "type": "bool",
-        "value": false
-    },
-    "ssl_ca": {
-        "depends_on": [{"field": "ssl_enabled", "value": true}],
-        "label": "Certificate Authority (.pem)",
-        "order": 8,
-        "required": false,
-        "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the MongoDB instance.",
-        "type": "str"
-    },
-    "tls_insecure": {
-        "display": "toggle",
-        "depends_on": [{"field": "ssl_enabled", "value": true}],
-        "label": "Skip certificate verification",
-        "order": 9,
-        "tooltip": "This option skips certificate validation for TLS/SSL connections to your MongoDB server. We strongly recommend setting this option to 'disable'.",
-        "type": "bool",
-        "value": false
-    }
-  },
-  "filtering": [
-    {
-      "domain": "DEFAULT",
-      "draft": {
-        "advanced_snippet": {
-          "updated_at": "2023-01-31T16:41:27.341Z",
-          "created_at": "2023-01-31T16:38:49.244Z",
-          "value": {}
-        },
-        "rules": [
-          {
-            "field": "_",
-            "updated_at": "2023-01-31T16:41:27.341Z",
-            "created_at": "2023-01-31T16:38:49.244Z",
-            "rule": "regex",
-            "id": "DEFAULT",
-            "value": ".*",
+    "configuration": {
+        "host": {
+            "label": "Server Hostname",
             "order": 1,
-            "policy": "include"
-          }
-        ],
-        "validation": {
-          "state": "valid",
-          "errors": []
-        }
-      },
-      "active": {
-        "advanced_snippet": {
-          "updated_at": "2023-01-31T16:41:27.341Z",
-          "created_at": "2023-01-31T16:38:49.244Z",
-          "value": {}
+            "type": "str",
+            "value": "mongodb://127.0.0.1:27021"
         },
-        "rules": [
-          {
-            "field": "_",
-            "updated_at": "2023-01-31T16:41:27.341Z",
-            "created_at": "2023-01-31T16:38:49.244Z",
-            "rule": "regex",
-            "id": "DEFAULT",
-            "value": ".*",
-            "order": 1,
-            "policy": "include"
-          }
-        ],
-        "validation": {
-          "state": "valid",
-          "errors": []
+        "user": {
+            "default_value": "",
+            "label": "Username",
+            "order": 2,
+            "type": "str",
+            "value": "admin",
+            "required": false
+        },
+        "password": {
+            "default_value": "",
+            "label": "Password",
+            "order": 3,
+            "sensitive": true,
+            "type": "str",
+            "value": "justtesting",
+            "required": false
+        },
+        "database": {
+            "label": "Database",
+            "order": 4,
+            "type": "str",
+            "value": "sample_database"
+        },
+        "collection": {
+            "label": "Collection",
+            "order": 5,
+            "type": "str",
+            "value": "sample_collection"
+        },
+        "direct_connection": {
+            "display": "toggle",
+            "label": "Direct connection",
+            "order": 6,
+            "type": "bool",
+            "value": true
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "SSL/TLS Connection",
+            "order": 7,
+            "tooltip": "This option establishes a secure connection to the MongoDB server using SSL/TLS encryption. Ensure that your MongoDB deployment supports SSL/TLS connections. Enable if MongoDB cluster uses DNS SRV records.",
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
+                {
+                    "field": "ssl_enabled",
+                    "value": true
+                }
+            ],
+            "label": "Certificate Authority (.pem)",
+            "order": 8,
+            "required": false,
+            "tooltip": "Specifies the root certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the MongoDB instance.",
+            "type": "str"
+        },
+        "tls_insecure": {
+            "display": "toggle",
+            "depends_on": [
+                {
+                    "field": "ssl_enabled",
+                    "value": true
+                }
+            ],
+            "label": "Skip certificate verification",
+            "order": 9,
+            "tooltip": "This option skips certificate validation for TLS/SSL connections to your MongoDB server. We strongly recommend setting this option to 'disable'.",
+            "type": "bool",
+            "value": false
         }
-      }
     }
-  ],
-  "scheduling": {
-    "full": {
-      "enabled": true,
-      "interval": "1 * * * * *"
-    }
-  },
-  "pipeline": {
-    "extract_binary_content": true,
-    "name": "ent-search-generic-ingestion",
-    "reduce_whitespace": true,
-    "run_ml_inference": true
-  }
 }

--- a/tests/sources/fixtures/mssql/connector.json
+++ b/tests/sources/fixtures/mssql/connector.json
@@ -1,166 +1,100 @@
 {
-        "name": "mssql",
-        "index_name": "search-mssql",
-        "service_type": "mssql",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "host": {
-                        "label": "Host",
-                        "order": 1,
-                        "type": "str",
-                        "value": "127.0.0.1"
-                },
-                "port": {
-                        "display": "numeric",
-                        "label": "Port",
-                        "order": 2,
-                        "type": "int",
-                        "value": 9090
-                },
-                "username": {
-                        "label": "Username",
-                        "order": 3,
-                        "type": "str",
-                        "value": "admin"
-                },
-                "password": {
-                        "label": "Password",
-                        "order": 4,
-                        "sensitive": true,
-                        "type": "str",
-                        "value": "Password_123"
-                },
-                "database": {
-                        "label": "Database",
-                        "order": 5,
-                        "type": "str",
-                        "value": "xe"
-                },
-                "tables": {
-                        "display": "textarea",
-                        "label": "Comma-separated list of tables",
-                        "options": [],
-                        "order": 6,
-                        "type": "list",
-                        "value": "*"
-                },
-                "fetch_size": {
-                        "default_value": 50,
-                        "display": "numeric",
-                        "label": "Rows fetched per request",
-                        "order": 7,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": null
-                },
-                "retry_count": {
-                        "default_value": 3,
-                        "display": "numeric",
-                        "label": "Retries per request",
-                        "order": 8,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": null
-                },
-                "schema": {
-                        "label": "Schema",
-                        "order": 9,
-                        "type": "str",
-                        "value": "dbo"
-                },
-                "ssl_enabled": {
-                        "display": "toggle",
-                        "label": "Enable SSL verification",
-                        "order": 10,
-                        "type": "bool",
-                        "value": false
-                },
-                "ssl_ca": {
-                        "depends_on": [{"field": "ssl_enabled", "value": true}],
-                        "label": "SSL certificate",
-                        "order": 11,
-                        "type": "str",
-                        "value": ""
-                },
-                "validate_host": {
-                        "display": "toggle",
-                        "label": "Validate host",
-                        "order": 12,
-                        "type": "bool",
-                        "value": false
-                }
+    "configuration": {
+        "host": {
+            "label": "Host",
+            "order": 1,
+            "type": "str",
+            "value": "127.0.0.1"
         },
-        "filtering": [
+        "port": {
+            "display": "numeric",
+            "label": "Port",
+            "order": 2,
+            "type": "int",
+            "value": 9090
+        },
+        "username": {
+            "label": "Username",
+            "order": 3,
+            "type": "str",
+            "value": "admin"
+        },
+        "password": {
+            "label": "Password",
+            "order": 4,
+            "sensitive": true,
+            "type": "str",
+            "value": "Password_123"
+        },
+        "database": {
+            "label": "Database",
+            "order": 5,
+            "type": "str",
+            "value": "xe"
+        },
+        "tables": {
+            "display": "textarea",
+            "label": "Comma-separated list of tables",
+            "options": [],
+            "order": 6,
+            "type": "list",
+            "value": "*"
+        },
+        "fetch_size": {
+            "default_value": 50,
+            "display": "numeric",
+            "label": "Rows fetched per request",
+            "order": 7,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": null
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries per request",
+            "order": 8,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": null
+        },
+        "schema": {
+            "label": "Schema",
+            "order": 9,
+            "type": "str",
+            "value": "dbo"
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "Enable SSL verification",
+            "order": 10,
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        },
-                        "active": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        }
+                    "field": "ssl_enabled",
+                    "value": true
                 }
-
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "label": "SSL certificate",
+            "order": 11,
+            "type": "str",
+            "value": ""
+        },
+        "validate_host": {
+            "display": "toggle",
+            "label": "Validate host",
+            "order": 12,
+            "type": "bool",
+            "value": false
         }
+    }
 }

--- a/tests/sources/fixtures/mysql/connector.json
+++ b/tests/sources/fixtures/mysql/connector.json
@@ -1,152 +1,86 @@
 {
-        "name": "mysql",
-        "index_name": "search-mysql",
-        "service_type": "mysql",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "host": {
-                        "label": "Host",
-                        "order": 1,
-                        "type": "str",
-                        "value": "127.0.0.1"
-                },
-                "port": {
-                        "display": "numeric",
-                        "label": "Port",
-                        "order": 2,
-                        "type": "int",
-                        "value": 3306
-                },
-                "user": {
-                        "label": "Username",
-                        "order": 3,
-                        "type": "str",
-                        "value": "root"
-                },
-                "password": {
-                        "label": "Password",
-                        "order": 4,
-                        "sensitive": true,
-                        "type": "str",
-                        "value": "changeme"
-                },
-                "database": {
-                        "label": "Database",
-                        "order": 5,
-                        "type": "str",
-                        "value": "customerinfo"
-                },
-                "tables": {
-                        "display": "textarea",
-                        "label": "Comma-separated list of tables",
-                        "order": 6,
-                        "type": "list",
-                        "value": "*"
-                },
-                "ssl_enabled": {
-                        "display": "toggle",
-                        "label": "Enable SSL",
-                        "order": 7,
-                        "type": "bool",
-                        "value": false
-                },
-                "ssl_ca": {
-                        "depends_on": [{"field": "ssl_enabled", "value": true}],
-                        "label": "SSL certificate",
-                        "order": 8,
-                        "type": "str",
-                        "value": "" 
-                },
-                "fetch_size": {
-                        "default_value": 50,
-                        "display": "numeric",
-                        "label": "Rows fetched per request",
-                        "order": 9,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": 50 
-                },
-                "retry_count": {
-                        "default_value": 3,
-                        "display": "numeric",
-                        "label": "Retries per request",
-                        "order": 10,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": 3
-                }
+    "configuration": {
+        "host": {
+            "label": "Host",
+            "order": 1,
+            "type": "str",
+            "value": "127.0.0.1"
         },
-        "filtering": [
+        "port": {
+            "display": "numeric",
+            "label": "Port",
+            "order": 2,
+            "type": "int",
+            "value": 3306
+        },
+        "user": {
+            "label": "Username",
+            "order": 3,
+            "type": "str",
+            "value": "root"
+        },
+        "password": {
+            "label": "Password",
+            "order": 4,
+            "sensitive": true,
+            "type": "str",
+            "value": "changeme"
+        },
+        "database": {
+            "label": "Database",
+            "order": 5,
+            "type": "str",
+            "value": "customerinfo"
+        },
+        "tables": {
+            "display": "textarea",
+            "label": "Comma-separated list of tables",
+            "order": 6,
+            "type": "list",
+            "value": "*"
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "Enable SSL",
+            "order": 7,
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        },
-                        "active": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        }
+                    "field": "ssl_enabled",
+                    "value": true
                 }
-
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "label": "SSL certificate",
+            "order": 8,
+            "type": "str",
+            "value": ""
+        },
+        "fetch_size": {
+            "default_value": 50,
+            "display": "numeric",
+            "label": "Rows fetched per request",
+            "order": 9,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 50
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries per request",
+            "order": 10,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 3
         }
+    }
 }

--- a/tests/sources/fixtures/network_drive/connector.json
+++ b/tests/sources/fixtures/network_drive/connector.json
@@ -1,148 +1,97 @@
 {
-        "name": "network_drive",
-        "index_name": "search-network_drive",
-        "service_type": "network_drive",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "username": {
-                        "label": "Username",
-                        "order": 1,
-                        "type": "str",
-                        "value": "admin"
-                },
-                "password": {
-                        "label": "Password",
-                        "order": 2,
-                        "sensitive": true,
-                        "type": "str",
-                        "value": "abc@123"
-                },
-                "server_ip": {
-                        "label": "SMB IP",
-                        "order": 3,
-                        "type": "str",
-                        "value": "127.0.0.1"
-                },
-                "server_port": {
-                        "display": "numeric",
-                        "label": "SMB port",
-                        "order": 4,
-                        "type": "int",
-                        "value": 445
-                },
-                "drive_path": {
-                        "label": "SMB path",
-                        "order": 5,
-                        "type": "str",
-                        "value": "Folder1"
-                },
-                "use_document_level_security": {
-                    "depends_on": [],
-                    "display": "toggle",
-                    "tooltip": null,
-                    "default_value": false,
-                    "label": "Enable document level security",
-                    "sensitive": false,
-                    "type": "bool",
-                    "required": false,
-                    "options": [],
-                    "validations": [],
-                    "value": false,
-                    "order": 6,
-                    "ui_restrictions": []
-                },
-                "drive_type":{
-                    "display": "dropdown",
-                    "label": "Drive type",
-                    "depends_on": [{"field": "use_document_level_security", "value": true}],
-                    "options": [
-                        {"label": "Windows", "value": "windows"},
-                        {"label": "Linux", "value": "linux"}
-                      ],
-                    "order":7,
-                    "type": "str",
-                    "ui_restrictions": ["advanced"],
-                    "value":"linux"
-                },
-                "identity_mappings": {
-                    "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",
-                    "depends_on": [{"field": "use_document_level_security", "value": true}, {"field": "drive_type", "value": "linux"}],
-                    "order": 8,
-                    "type": "str",
-                    "required": false,
-                    "ui_restrictions": ["advanced"],
-                    "value": ""
-                }
+    "configuration": {
+        "username": {
+            "label": "Username",
+            "order": 1,
+            "type": "str",
+            "value": "admin"
         },
-        "filtering": [
+        "password": {
+            "label": "Password",
+            "order": 2,
+            "sensitive": true,
+            "type": "str",
+            "value": "abc@123"
+        },
+        "server_ip": {
+            "label": "SMB IP",
+            "order": 3,
+            "type": "str",
+            "value": "127.0.0.1"
+        },
+        "server_port": {
+            "display": "numeric",
+            "label": "SMB port",
+            "order": 4,
+            "type": "int",
+            "value": 445
+        },
+        "drive_path": {
+            "label": "SMB path",
+            "order": 5,
+            "type": "str",
+            "value": "Folder1"
+        },
+        "use_document_level_security": {
+            "depends_on": [],
+            "display": "toggle",
+            "tooltip": null,
+            "default_value": false,
+            "label": "Enable document level security",
+            "sensitive": false,
+            "type": "bool",
+            "required": false,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 6,
+            "ui_restrictions": []
+        },
+        "drive_type": {
+            "display": "dropdown",
+            "label": "Drive type",
+            "depends_on": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        },
-                        "active": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        }
+                    "field": "use_document_level_security",
+                    "value": true
                 }
-
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "options": [
+                {
+                    "label": "Windows",
+                    "value": "windows"
+                },
+                {
+                    "label": "Linux",
+                    "value": "linux"
+                }
+            ],
+            "order": 7,
+            "type": "str",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": "linux"
+        },
+        "identity_mappings": {
+            "label": "Path of CSV file containing users and groups SID (For Linux Network Drive)",
+            "depends_on": [
+                {
+                    "field": "use_document_level_security",
+                    "value": true
+                },
+                {
+                    "field": "drive_type",
+                    "value": "linux"
+                }
+            ],
+            "order": 8,
+            "type": "str",
+            "required": false,
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": ""
         }
+    }
 }

--- a/tests/sources/fixtures/notion/connector.json
+++ b/tests/sources/fixtures/notion/connector.json
@@ -1,8 +1,7 @@
 {
-    "api_key_id": null,
     "configuration": {
         "notion_secret_key": {
-            "display": "string",
+            "display": "text",
             "label": "Notion Secret Key",
             "order": 1,
             "required": true,
@@ -12,19 +11,19 @@
         },
         "databases": {
             "label": "List of Databases",
-            "display": "string",
+            "display": "text",
             "order": 2,
             "required": true,
             "type": "list",
-            "value": ["*"]
+            "value": "*"
         },
         "pages": {
             "label": "List of Pages",
-            "display": "string",
+            "display": "text",
             "order": 3,
             "required": true,
             "type": "list",
-            "value": ["*"]
+            "value": "*"
         },
         "index_comments": {
             "display": "toggle",
@@ -41,114 +40,9 @@
             "order": 6,
             "required": false,
             "type": "int",
-            "ui_restrictions": ["advanced"]
+            "ui_restrictions": [
+                "advanced"
+            ]
         }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": null,
-    "features": {
-      "incremental_sync": {
-        "enabled": false
-      },
-      "document_level_security": {
-        "enabled": false
-      },
-      "sync_rules": {
-        "advanced": {
-          "enabled": false
-        },
-        "basic": {
-          "enabled": true
-        }
-      }
-    },
-    "filtering": [
-      {
-        "active": {
-          "advanced_snippet": {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "created_at": "2023-06-30T08:20:14.686Z",
-              "field": "_",
-              "id": "DEFAULT",
-              "order": 0,
-              "policy": "include",
-              "rule": "regex",
-              "updated_at": "2023-06-30T08:20:14.686Z",
-              "value": ".*"
-            }
-          ],
-          "validation": {
-            "errors": [],
-            "state": "valid"
-          }
-        },
-        "domain": "DEFAULT",
-        "draft": {
-          "advanced_snippet": {
-            "created_at": "2023-06-30T08:20:14.686Z",
-            "updated_at": "2023-06-30T08:20:14.686Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "created_at": "2023-06-30T08:20:14.686Z",
-              "field": "_",
-              "id": "DEFAULT",
-              "order": 0,
-              "policy": "include",
-              "rule": "regex",
-              "updated_at": "2023-06-30T08:20:14.686Z",
-              "value": ".*"
-            }
-          ],
-          "validation": {
-            "errors": [],
-            "state": "valid"
-          }
-        }
-      }
-    ],
-    "index_name": "search-notion",
-    "is_native": false,
-    "language": null,
-    "last_access_control_sync_error": null,
-    "last_access_control_sync_scheduled_at": null,
-    "last_access_control_sync_status": null,
-    "last_incremental_sync_scheduled_at": null,
-    "last_seen": "2023-06-30T09:26:21.281198+00:00",
-    "last_sync_error": null,
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": null,
-    "name": "notion",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "access_control": {
-        "enabled": false,
-        "interval": "0 0 0 * * ?"
-      },
-      "full": {
-        "enabled": true,
-        "interval": "* * * * * *"
-      },
-      "incremental": {
-        "enabled": false,
-        "interval": "0 0 0 * * ?"
-      }
-    },
-    "service_type": "notion",
-    "status": "configured",
-    "sync_now": true
-  }
-  
+    }
+}

--- a/tests/sources/fixtures/onedrive/connector.json
+++ b/tests/sources/fixtures/onedrive/connector.json
@@ -1,148 +1,108 @@
 {
-  "api_key_id": "xyzIbIgBFjJwEZQV7bda",
-  "configuration": {
-    "tenant_id": {
-      "depends_on": [],
-      "display": "text",
-      "tooltip": null,
-      "default_value": null,
-      "label": "Tenant Id",
-      "sensitive": false,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "00000000-0000-0000-0000-000000000000",
-      "order": 3,
-      "ui_restrictions": []
-    },
-    "client_secret": {
-      "depends_on": [],
-      "display": "text",
-      "tooltip": null,
-      "default_value": null,
-      "label": "Client Secret Value",
-      "sensitive": true,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
-      "order": 2,
-      "ui_restrictions": []
-    },
-    "client_id": {
-      "depends_on": [],
-      "display": "text",
-      "tooltip": null,
-      "default_value": null,
-      "label": "Client Id",
-      "sensitive": true,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "00000000-0000-0000-0000-000000000000",
-      "order": 1,
-      "ui_restrictions": []
-    },
-    "retry_count": {
-      "default_value": 3,
-      "display": "numeric",
-      "label": "Retries per request",
-      "order": 4,
-      "required": false,
-      "type": "int",
-      "ui_restrictions": ["advanced"],
-      "value": 3
-    },
-    "concurrent_downloads": {
-      "depends_on": [],
-      "display": "numeric",
-      "tooltip": null,
-      "default_value": 15,
-      "label": "Maximum concurrent downloads",
-      "sensitive": false,
-      "type": "int",
-      "required": false,
-      "options": [],
-      "validations": [],
-      "value": 15,
-      "order": 5,
-      "ui_restrictions": [
-        "advanced"
-      ]
-    },
-    "use_document_level_security": {
-      "depends_on": [],
-      "display": "toggle",
-      "tooltip": null,
-      "default_value": false,
-      "label": "Enable document level security",
-      "sensitive": false,
-      "type": "bool",
-      "required": false,
-      "options": [],
-      "validations": [],
-      "value": false,
-      "order": 6,
-      "ui_restrictions": []
-    },
-    "use_text_extraction_service": {
-      "default_value": null,
-      "depends_on": [],
-      "display": "toggle",
-      "label": "Use text extraction service",
-      "options": [],
-      "order": 7,
-      "required": true,
-      "sensitive": false,
-      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-      "type": "bool",
-      "ui_restrictions": [],
-      "validations": [],
-      "value": false
+    "configuration": {
+        "tenant_id": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Tenant Id",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "00000000-0000-0000-0000-000000000000",
+            "order": 3,
+            "ui_restrictions": []
+        },
+        "client_secret": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Client Secret Value",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
+            "order": 2,
+            "ui_restrictions": []
+        },
+        "client_id": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Client Id",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "00000000-0000-0000-0000-000000000000",
+            "order": 1,
+            "ui_restrictions": []
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries per request",
+            "order": 4,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 3
+        },
+        "concurrent_downloads": {
+            "depends_on": [],
+            "display": "numeric",
+            "tooltip": null,
+            "default_value": 15,
+            "label": "Maximum concurrent downloads",
+            "sensitive": false,
+            "type": "int",
+            "required": false,
+            "options": [],
+            "validations": [],
+            "value": 15,
+            "order": 5,
+            "ui_restrictions": [
+                "advanced"
+            ]
+        },
+        "use_document_level_security": {
+            "depends_on": [],
+            "display": "toggle",
+            "tooltip": null,
+            "default_value": false,
+            "label": "Enable document level security",
+            "sensitive": false,
+            "type": "bool",
+            "required": false,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 6,
+            "ui_restrictions": []
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 7,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
+        }
     }
-  },
-  "custom_scheduling": {},
-  "description": null,
-  "error": "Cannot connect to host enterprisesearchasd.microsoft.com:443 ssl:default [nodename nor servname provided, or not known]",
-  "features": {
-    "filtering_advanced_config": false,
-    "filtering_rules": false,
-    "sync_rules": {
-      "advanced": {
-        "enabled": true
-      },
-      "basic": {
-        "enabled": true
-      }
-    }
-  },
-  "index_name": "search-onedrive",
-  "is_native": false,
-  "language": null,
-  "last_seen": "2023-06-02T16:05:43.247794+00:00",
-  "last_sync_error": "Cannot connect to host enterprisesearchasd.microsoft.com:443 ssl:default [nodename nor servname provided, or not known]",
-  "last_sync_scheduled_at": null,
-  "last_sync_status": null,
-  "last_synced": "2023-06-02T16:08:30.745527+00:00",
-  "name": "onedrive-connector",
-  "pipeline": {
-    "extract_binary_content": true,
-    "name": "ent-search-generic-ingestion",
-    "reduce_whitespace": true,
-    "run_ml_inference": true
-  },
-  "scheduling": {
-    "full": {
-      "enabled": true,
-      "interval": "0 * * * * ?"
-    }
-  },
-  "service_type": "onedrive",
-  "status": "connected",
-  "id": "onedrive",
-  "last_indexed_document_count": 0,
-  "last_deleted_document_count": 0
 }

--- a/tests/sources/fixtures/oracle/connector.json
+++ b/tests/sources/fixtures/oracle/connector.json
@@ -1,188 +1,145 @@
 {
-        "name": "oracle",
-        "index_name": "search-oracle",
-        "service_type": "oracle",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "host": {
-                        "label": "Host",
-                        "order": 1,
-                        "type": "str",
-                        "value": "127.0.0.1"
-                },
-                "port": {
-                        "display": "numeric",
-                        "label": "Port",
-                        "order": 2,
-                        "type": "int",
-                        "value": 1521
-                },
-                "username": {
-                        "label": "Username",
-                        "order": 3,
-                        "type": "str",
-                        "value": "c##admin"
-                },
-                "password": {
-                        "label": "Password",
-                        "order": 4,
-                        "sensitive": true,
-                        "type": "str",
-                        "value": "Password_123"
-                },
-                "connection_source": {
-                        "display": "dropdown",
-                        "label": "Connection Source",
-                        "options": [
-                            {"label": "SID", "value": "sid"},
-                            {"label": "Service Name", "value": "service_name"}
-                        ],
-                        "order": 5,
-                        "type": "str",
-                        "value": "sid"
-                },
-                "sid": {
-                        "depends_on": [{"field": "connection_source", "value": "sid"}],
-                        "label": "SID",
-                        "order": 6,
-                        "type": "str",
-                        "value": "FREE"
-                    },
-                "service_name": {
-                        "depends_on": [{"field": "connection_source", "value": "service_name"}],
-                        "label": "Service Name",
-                        "order": 7,
-                        "type": "str",
-                        "value": "FREE"
-                    },
-                "tables": {
-                        "display": "textarea",
-                        "label": "Comma-separated list of tables",
-                        "options": [],
-                        "order": 8,
-                        "type": "list",
-                        "value": "*"
-                },
-                "fetch_size": {
-                        "default_value": 50,
-                        "display": "numeric",
-                        "label": "Rows fetched per request",
-                        "order": 9,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": null
-                },
-                "retry_count": {
-                        "default_value": 3,
-                        "display": "numeric",
-                        "label": "Retries per request",
-                        "order": 10,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": null
-                },
-                "oracle_protocol": {
-                        "display": "dropdown",
-                        "label": "Oracle connection protocol",
-                        "options": [
-                                {"label": "TCP", "value": "TCP"},
-                                {"label": "TCPS", "value": "TCPS"}
-                        ],
-                        "order": 11,
-                        "type": "str",
-                        "value": "TCP",
-                        "ui_restrictions": ["advanced"]
-                },
-                "oracle_home": {
-                        "default_value": "",
-                        "label": "Path to Oracle Home",
-                        "order": 12,
-                        "required": false,
-                        "type": "str",
-                        "value": "",
-                        "ui_restrictions": ["advanced"]
-                },
-                "wallet_configuration_path": {
-                        "default_value": "",
-                        "label": "Path to SSL Wallet configuration files",
-                        "order": 13,
-                        "required": false,
-                        "type": "str",
-                        "value": "",
-                        "ui_restrictions": ["advanced"]
-                }
+    "configuration": {
+        "host": {
+            "label": "Host",
+            "order": 1,
+            "type": "str",
+            "value": "127.0.0.1"
         },
-        "filtering": [
+        "port": {
+            "display": "numeric",
+            "label": "Port",
+            "order": 2,
+            "type": "int",
+            "value": 1521
+        },
+        "username": {
+            "label": "Username",
+            "order": 3,
+            "type": "str",
+            "value": "c##admin"
+        },
+        "password": {
+            "label": "Password",
+            "order": 4,
+            "sensitive": true,
+            "type": "str",
+            "value": "Password_123"
+        },
+        "connection_source": {
+            "display": "dropdown",
+            "label": "Connection Source",
+            "options": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        },
-                        "active": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        }
+                    "label": "SID",
+                    "value": "sid"
+                },
+                {
+                    "label": "Service Name",
+                    "value": "service_name"
                 }
-
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "order": 5,
+            "type": "str",
+            "value": "sid"
+        },
+        "sid": {
+            "depends_on": [
+                {
+                    "field": "connection_source",
+                    "value": "sid"
+                }
+            ],
+            "label": "SID",
+            "order": 6,
+            "type": "str",
+            "value": "FREE"
+        },
+        "service_name": {
+            "depends_on": [
+                {
+                    "field": "connection_source",
+                    "value": "service_name"
+                }
+            ],
+            "label": "Service Name",
+            "order": 7,
+            "type": "str",
+            "value": "FREE"
+        },
+        "tables": {
+            "display": "textarea",
+            "label": "Comma-separated list of tables",
+            "options": [],
+            "order": 8,
+            "type": "list",
+            "value": "*"
+        },
+        "fetch_size": {
+            "default_value": 50,
+            "display": "numeric",
+            "label": "Rows fetched per request",
+            "order": 9,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": null
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries per request",
+            "order": 10,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": null
+        },
+        "oracle_protocol": {
+            "display": "dropdown",
+            "label": "Oracle connection protocol",
+            "options": [
+                {
+                    "label": "TCP",
+                    "value": "TCP"
+                },
+                {
+                    "label": "TCPS",
+                    "value": "TCPS"
+                }
+            ],
+            "order": 11,
+            "type": "str",
+            "value": "TCP",
+            "ui_restrictions": [
+                "advanced"
+            ]
+        },
+        "oracle_home": {
+            "default_value": "",
+            "label": "Path to Oracle Home",
+            "order": 12,
+            "required": false,
+            "type": "str",
+            "value": "",
+            "ui_restrictions": [
+                "advanced"
+            ]
+        },
+        "wallet_configuration_path": {
+            "default_value": "",
+            "label": "Path to SSL Wallet configuration files",
+            "order": 13,
+            "required": false,
+            "type": "str",
+            "value": "",
+            "ui_restrictions": [
+                "advanced"
+            ]
         }
+    }
 }

--- a/tests/sources/fixtures/postgresql/connector.json
+++ b/tests/sources/fixtures/postgresql/connector.json
@@ -1,159 +1,93 @@
 {
-        "name": "postgresql",
-        "index_name": "search-postgresql",
-        "service_type": "postgresql",
-        "sync_cursor": null,
-        "is_native": false,
-        "api_key_id": null,
-        "status": "configured",
-        "language": "en",
-        "last_access_control_sync_error": null,
-        "last_access_control_sync_status": null,
-        "last_sync_status": "canceled",
-        "last_sync_error": null,
-        "last_synced": null,
-        "last_seen": null,
-        "created_at": null,
-        "updated_at": null,
-        "configuration": {
-                "host": {
-                        "label": "Host",
-                        "order": 1,
-                        "type": "str",
-                        "value": "127.0.0.1"
-                },
-                "port": {
-                        "display": "numeric",
-                        "label": "Port",
-                        "order": 2,
-                        "type": "int",
-                        "value": 9090
-                },
-                "username": {
-                        "label": "Username",
-                        "order": 3,
-                        "type": "str",
-                        "value": "readonly"
-                },
-                "password": {
-                        "label": "Password",
-                        "order": 4,
-                        "sensitive": true,
-                        "type": "str",
-                        "value": "foobar123"
-                },
-                "database": {
-                        "label": "Database",
-                        "order": 5,
-                        "type": "str",
-                        "value": "xe"
-                },
-                "schema": {
-                        "label": "Schema",
-                        "order": 6,
-                        "type": "str",
-                        "value": "public"
-                },
-                "tables": {
-                        "display": "textarea",
-                        "label": "Comma-separated list of tables",
-                        "options": [],
-                        "order": 7,
-                        "type": "list",
-                        "value": "*"
-                },
-                "fetch_size": {
-                        "default_value": 50,
-                        "display": "numeric",
-                        "label": "Rows fetched per request",
-                        "order": 8,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": null
-                },
-                "retry_count": {
-                        "default_value": 3,
-                        "display": "numeric",
-                        "label": "Retries per request",
-                        "order": 9,
-                        "required": false,
-                        "type": "int",
-                        "ui_restrictions": ["advanced"],
-                        "value": null
-                },
-                "ssl_enabled": {
-                        "display": "toggle",
-                        "label": "Enable SSL verification",
-                        "order": 10,
-                        "type": "bool",
-                        "value": false
-                },
-                "ssl_ca": {
-                        "depends_on": [{"field": "ssl_enabled", "value": true}],
-                        "label": "SSL certificate",
-                        "order": 11,
-                        "type": "str",
-                        "value": ""
-                }
+    "configuration": {
+        "host": {
+            "label": "Host",
+            "order": 1,
+            "type": "str",
+            "value": "127.0.0.1"
         },
-        "filtering": [
+        "port": {
+            "display": "numeric",
+            "label": "Port",
+            "order": 2,
+            "type": "int",
+            "value": 9090
+        },
+        "username": {
+            "label": "Username",
+            "order": 3,
+            "type": "str",
+            "value": "readonly"
+        },
+        "password": {
+            "label": "Password",
+            "order": 4,
+            "sensitive": true,
+            "type": "str",
+            "value": "foobar123"
+        },
+        "database": {
+            "label": "Database",
+            "order": 5,
+            "type": "str",
+            "value": "xe"
+        },
+        "schema": {
+            "label": "Schema",
+            "order": 6,
+            "type": "str",
+            "value": "public"
+        },
+        "tables": {
+            "display": "textarea",
+            "label": "Comma-separated list of tables",
+            "options": [],
+            "order": 7,
+            "type": "list",
+            "value": "*"
+        },
+        "fetch_size": {
+            "default_value": 50,
+            "display": "numeric",
+            "label": "Rows fetched per request",
+            "order": 8,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": null
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries per request",
+            "order": 9,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": null
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "Enable SSL verification",
+            "order": 10,
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
                 {
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        },
-                        "active": {
-                            "advanced_snippet": {
-                                "updated_at": "2023-01-31T16:41:27.341Z",
-                                "created_at": "2023-01-31T16:38:49.244Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "field": "_",
-                                    "updated_at": "2023-01-31T16:41:27.341Z",
-                                    "created_at": "2023-01-31T16:38:49.244Z",
-                                    "rule": "regex",
-                                    "id": "DEFAULT",
-                                    "value": ".*",
-                                    "order": 1,
-                                    "policy": "include"
-                                }
-                            ],
-                            "validation": {
-                                "state": "valid",
-                                "errors": []
-                            }
-                        }
+                    "field": "ssl_enabled",
+                    "value": true
                 }
-
-        ],
-        "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
-        "pipeline": {
-                "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
-                "reduce_whitespace": true,
-                "run_ml_inference": true
+            ],
+            "label": "SSL certificate",
+            "order": 11,
+            "type": "str",
+            "value": ""
         }
+    }
 }

--- a/tests/sources/fixtures/redis/connector.json
+++ b/tests/sources/fixtures/redis/connector.json
@@ -1,164 +1,86 @@
 {
-    "api_key_id": "clvIfIgBFjJwEZQV7bda",
     "configuration": {
-      "host": {
-        "label": "Host",
-        "order": 1,
-        "type": "str",
-        "value": "localhost"
-      },
-      "port": {
-        "label": "Port",
-        "order": 2,
-        "type": "str",
-        "value": "6379"
-      },
-      "username": {
-        "label": "Username",
-        "order": 3,
-        "type": "str",
-        "value": ""
-      },
-      "password": {
-          "label": "Password",
-          "order": 4,
-          "type": "str",
-          "value": ""
-      },
-      "database": {
-        "display": "textarea",
-        "label": "Comma-separated list of databases",
-        "order": 5,
-        "type": "list",
-        "value": "*",
-        "sensitive": true
-      },
-      "tls_enabled": {
-        "display": "toggle",
-        "label": "SSL/TLS Connection",
-        "order": 6,
-        "tooltip": "This option establishes a secure connection to the Redis using SSL/TLS encryption. Ensure that your Redis deployment supports SSL/TLS connections.",
-        "type": "bool",
-        "value": false
-      },
-      "mutual_tls_enabled": {
-          "depends_on": [{"field": "tls_enabled", "value": true}],
-          "display": "toggle",
-          "label": "Mutual SSL/TLS Connection",
-          "order": 7,
-          "tooltip": "This option establishes a secure connection to the Redis using mutual SSL/TLS encryption. Ensure that your Redis deployment supports mutual SSL/TLS connections.",
-          "type": "bool",
-          "value": false
-      },
-      "tls_certfile": {
-          "depends_on": [{"field": "mutual_tls_enabled", "value": true}],
-          "label": "client certificate file for SSL/TLS",
-          "order": 8,
-          "required": false,
-          "tooltip": "Specifies the client certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Redis instance.",
-          "type": "str",
-          "value": ""
-      },
-      "tls_keyfile": {
-          "depends_on": [{"field": "mutual_tls_enabled", "value": true}],
-          "label": "client private key file for SSL/TLS",
-          "order": 9,
-          "required": false,
-          "tooltip": "Specifies the client private key from the Certificate Authority. The value of the key is used to validate the connection in Redis instance",
-          "type": "str",
-          "value": ""
-      }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": "Cannot connect to host enterprisesearchasd.redis.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "features": {
-      "filtering_advanced_config": false,
-      "filtering_rules": false,
-      "sync_rules": {
-        "advanced": {
-          "enabled": true
+        "host": {
+            "label": "Host",
+            "order": 1,
+            "type": "str",
+            "value": "localhost"
         },
-        "basic": {
-          "enabled": true
-        }
-      }
-    },
-    "filtering": [
-      {
-        "domain": "DEFAULT",
-        "draft": {
-          "advanced_snippet": {
-            "updated_at": "2023-06-02T15:50:23.157Z",
-            "created_at": "2023-06-02T15:50:23.157Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "field": "_",
-              "updated_at": "2023-06-02T15:50:23.157Z",
-              "created_at": "2023-06-02T15:44:59.416Z",
-              "rule": "regex",
-              "id": "DEFAULT",
-              "value": ".*",
-              "order": 0,
-              "policy": "include"
-            }
-          ],
-          "validation": {
-            "state": "valid",
-            "errors": []
-          }
+        "port": {
+            "label": "Port",
+            "order": 2,
+            "type": "str",
+            "value": "6379"
         },
-        "active": {
-          "advanced_snippet": {
-            "updated_at": "2023-06-02T15:50:23.157Z",
-            "created_at": "2023-06-02T15:50:23.157Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "field": "_",
-              "updated_at": "2023-06-02T15:50:23.157Z",
-              "created_at": "2023-06-02T15:44:59.416Z",
-              "rule": "regex",
-              "id": "DEFAULT",
-              "value": ".*",
-              "order": 0,
-              "policy": "include"
-            }
-          ],
-          "validation": {
-            "state": "valid",
-            "errors": []
-          }
+        "username": {
+            "label": "Username",
+            "order": 3,
+            "type": "str",
+            "value": ""
+        },
+        "password": {
+            "label": "Password",
+            "order": 4,
+            "type": "str",
+            "value": ""
+        },
+        "database": {
+            "display": "textarea",
+            "label": "Comma-separated list of databases",
+            "order": 5,
+            "type": "list",
+            "value": "*",
+            "sensitive": true
+        },
+        "tls_enabled": {
+            "display": "toggle",
+            "label": "SSL/TLS Connection",
+            "order": 6,
+            "tooltip": "This option establishes a secure connection to the Redis using SSL/TLS encryption. Ensure that your Redis deployment supports SSL/TLS connections.",
+            "type": "bool",
+            "value": false
+        },
+        "mutual_tls_enabled": {
+            "depends_on": [
+                {
+                    "field": "tls_enabled",
+                    "value": true
+                }
+            ],
+            "display": "toggle",
+            "label": "Mutual SSL/TLS Connection",
+            "order": 7,
+            "tooltip": "This option establishes a secure connection to the Redis using mutual SSL/TLS encryption. Ensure that your Redis deployment supports mutual SSL/TLS connections.",
+            "type": "bool",
+            "value": false
+        },
+        "tls_certfile": {
+            "depends_on": [
+                {
+                    "field": "mutual_tls_enabled",
+                    "value": true
+                }
+            ],
+            "label": "client certificate file for SSL/TLS",
+            "order": 8,
+            "required": false,
+            "tooltip": "Specifies the client certificate from the Certificate Authority. The value of the certificate is used to validate the certificate presented by the Redis instance.",
+            "type": "str",
+            "value": ""
+        },
+        "tls_keyfile": {
+            "depends_on": [
+                {
+                    "field": "mutual_tls_enabled",
+                    "value": true
+                }
+            ],
+            "label": "client private key file for SSL/TLS",
+            "order": 9,
+            "required": false,
+            "tooltip": "Specifies the client private key from the Certificate Authority. The value of the key is used to validate the connection in Redis instance",
+            "type": "str",
+            "value": ""
         }
-      }
-    ],
-    "index_name": "search-redis",
-    "is_native": false,
-    "language": null,
-    "last_seen": "2023-06-02T16:05:43.247794+00:00",
-    "last_sync_error": null,
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": "2023-06-02T16:08:30.745527+00:00",
-    "name": "redis-adv",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "full": {
-        "enabled": true,
-        "interval": "0 * * * * ?"
-      }
-    },
-    "service_type": "redis",
-    "status": "connected",
-    "id": "redis",
-    "last_indexed_document_count": 0,
-    "last_deleted_document_count": 0
-  }
+    }
+}

--- a/tests/sources/fixtures/s3/connector.json
+++ b/tests/sources/fixtures/s3/connector.json
@@ -1,172 +1,87 @@
 {
-    "api_key_id": "clvIfIgBFjJwEZQV7bda",
     "configuration": {
-      "buckets": {
-        "display": "textarea",
-        "label": "AWS Buckets",
-        "order": 1,
-        "type": "list",
-        "value": "ent-search-ingest-dev"
-      },
-      "aws_access_key_id": {
-        "label": "AWS Access Key Id",
-        "order": 2,
-        "type": "str",
-        "value": "A1B2C3D4"
-      },
-      "aws_secret_access_key": {
-        "label": "AWS Secret Key",
-        "order": 3,
-        "type": "str",
-        "value": "A1B2C3D4",
-        "sensitive": true
-      },
-      "read_timeout": {
-        "default_value": 90,
-        "display": "numeric",
-        "label": "Read timeout",
-        "order": 4,
-        "required": false,
-        "type": "int",
-        "ui_restrictions": ["advanced"],
-        "value": 90
-      },
-      "connect_timeout": {
-        "default_value": 90,
-        "display": "numeric",
-        "label": "Connection timeout",
-        "order": 5,
-        "required": false,
-        "type": "int",
-        "ui_restrictions": ["advanced"],
-        "value": 90
-      },
-      "max_attempts": {
-        "default_value": 5,
-        "display": "numeric",
-        "label": "Maximum retry attempts",
-        "order": 6,
-        "required": false,
-        "type": "int",
-        "ui_restrictions": ["advanced"],
-        "value": 5
-      },
-      "page_size": {
-        "default_value": 100,
-        "display": "numeric",
-        "label": "Maximum size of page",
-        "order": 7,
-        "required": false,
-        "type": "int",
-        "ui_restrictions": ["advanced"],
-        "value": 100
-      },
-      "use_text_extraction_service": {
-        "default_value": null,
-        "depends_on": [],
-        "display": "toggle",
-        "label": "Use text extraction service",
-        "options": [],
-        "order": 13,
-        "required": true,
-        "sensitive": false,
-        "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-        "type": "bool",
-        "ui_restrictions": [],
-        "validations": [],
-        "value": false
-      }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": "Cannot connect to host enterprisesearchasd.sharepoint.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "features": {
-      "filtering_advanced_config": false,
-      "filtering_rules": false,
-      "sync_rules": {
-        "advanced": {
-          "enabled": true
+        "buckets": {
+            "display": "textarea",
+            "label": "AWS Buckets",
+            "order": 1,
+            "type": "list",
+            "value": "ent-search-ingest-dev"
         },
-        "basic": {
-          "enabled": true
-        }
-      }
-    },
-    "filtering": [
-      {
-        "domain": "DEFAULT",
-        "draft": {
-          "advanced_snippet": {
-            "updated_at": "2023-06-02T15:50:23.157Z",
-            "created_at": "2023-06-02T15:50:23.157Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "field": "_",
-              "updated_at": "2023-06-02T15:50:23.157Z",
-              "created_at": "2023-06-02T15:44:59.416Z",
-              "rule": "regex",
-              "id": "DEFAULT",
-              "value": ".*",
-              "order": 0,
-              "policy": "include"
-            }
-          ],
-          "validation": {
-            "state": "valid",
-            "errors": []
-          }
+        "aws_access_key_id": {
+            "label": "AWS Access Key Id",
+            "order": 2,
+            "type": "str",
+            "value": "A1B2C3D4"
         },
-        "active": {
-          "advanced_snippet": {
-            "updated_at": "2023-06-02T15:50:23.157Z",
-            "created_at": "2023-06-02T15:50:23.157Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "field": "_",
-              "updated_at": "2023-06-02T15:50:23.157Z",
-              "created_at": "2023-06-02T15:44:59.416Z",
-              "rule": "regex",
-              "id": "DEFAULT",
-              "value": ".*",
-              "order": 0,
-              "policy": "include"
-            }
-          ],
-          "validation": {
-            "state": "valid",
-            "errors": []
-          }
+        "aws_secret_access_key": {
+            "label": "AWS Secret Key",
+            "order": 3,
+            "type": "str",
+            "value": "A1B2C3D4",
+            "sensitive": true
+        },
+        "read_timeout": {
+            "default_value": 90,
+            "display": "numeric",
+            "label": "Read timeout",
+            "order": 4,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 90
+        },
+        "connect_timeout": {
+            "default_value": 90,
+            "display": "numeric",
+            "label": "Connection timeout",
+            "order": 5,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 90
+        },
+        "max_attempts": {
+            "default_value": 5,
+            "display": "numeric",
+            "label": "Maximum retry attempts",
+            "order": 6,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 5
+        },
+        "page_size": {
+            "default_value": 100,
+            "display": "numeric",
+            "label": "Maximum size of page",
+            "order": 7,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": 100
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 13,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
-      }
-    ],
-    "index_name": "search-s3",
-    "is_native": false,
-    "language": null,
-    "last_seen": "2023-06-02T16:05:43.247794+00:00",
-    "last_sync_error": null,
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": "2023-06-02T16:08:30.745527+00:00",
-    "name": "sharepoint-online-adv",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "full": {
-        "enabled": true,
-        "interval": "0 * * * * ?"
-      }
-    },
-    "service_type": "s3",
-    "status": "connected",
-    "id": "s3",
-    "last_indexed_document_count": 0,
-    "last_deleted_document_count": 0
-  }
+    }
+}

--- a/tests/sources/fixtures/salesforce/connector.json
+++ b/tests/sources/fixtures/salesforce/connector.json
@@ -1,141 +1,34 @@
 {
-  "api_key_id": "",
-  "configuration": {
-    "client_id": {
-      "label": "Client ID",
-      "type": "str",
-      "value": "1234"
-    },
-    "client_secret": {
-      "label": "Client Secret",
-      "type": "str",
-      "value": "abcd"
-    },
-    "domain": {
-      "label": "Domain",
-      "type": "str",
-      "value": "fake.sandbox"
-    },
-    "use_text_extraction_service": {
-      "default_value": null,
-      "depends_on": [],
-      "display": "toggle",
-      "label": "Use text extraction service",
-      "options": [],
-      "order": 7,
-      "required": true,
-      "sensitive": false,
-      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-      "type": "bool",
-      "ui_restrictions": [],
-      "validations": [],
-      "value": false
-    }
-  },
-  "custom_scheduling": {},
-  "description": null,
-  "error": null,
-  "features": {
-    "incremental_sync": {
-      "enabled": false
-    },
-    "document_level_security": {
-      "enabled": false
-    },
-    "sync_rules": {
-      "advanced": {
-        "enabled": false
-      },
-      "basic": {
-        "enabled": true
-      }
-    }
-  },
-  "filtering": [
-    {
-      "active": {
-        "advanced_snippet": {
-          "created_at": "2023-08-03T11:30:14.061Z",
-          "updated_at": "2023-08-03T11:30:14.061Z",
-          "value": {}
+    "configuration": {
+        "client_id": {
+            "label": "Client ID",
+            "type": "str",
+            "value": "1234"
         },
-        "rules": [
-          {
-            "created_at": "2023-08-03T11:30:14.061Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-08-03T11:30:14.061Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
-        }
-      },
-      "domain": "DEFAULT",
-      "draft": {
-        "advanced_snippet": {
-          "created_at": "2023-08-03T11:30:14.061Z",
-          "updated_at": "2023-08-03T11:30:14.061Z",
-          "value": {}
+        "client_secret": {
+            "label": "Client Secret",
+            "type": "str",
+            "value": "abcd"
         },
-        "rules": [
-          {
-            "created_at": "2023-08-03T11:30:14.061Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-08-03T11:30:14.061Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
+        "domain": {
+            "label": "Domain",
+            "type": "str",
+            "value": "fake.sandbox"
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 7,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
-      }
     }
-  ],
-  "index_name": "search-salesforce",
-  "is_native": false,
-  "language": null,
-  "last_access_control_sync_error": null,
-  "last_access_control_sync_scheduled_at": null,
-  "last_access_control_sync_status": null,
-  "last_incremental_sync_scheduled_at": null,
-  "last_seen": "2023-08-03T11:31:00.668430+00:00",
-  "last_sync_error": null,
-  "last_sync_scheduled_at": null,
-  "last_sync_status": null,
-  "last_synced": null,
-  "name": "salesforce",
-  "pipeline": {
-    "extract_binary_content": true,
-    "name": "ent-search-generic-ingestion",
-    "reduce_whitespace": true,
-    "run_ml_inference": true
-  },
-  "scheduling": {
-    "access_control": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    },
-    "full": {
-      "enabled": true,
-      "interval": "1 * * * * ?"
-    },
-    "incremental": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    }
-  },
-  "service_type": "salesforce",
-  "status": "configured",
-  "sync_now": false
 }

--- a/tests/sources/fixtures/servicenow/connector.json
+++ b/tests/sources/fixtures/servicenow/connector.json
@@ -1,235 +1,128 @@
 {
-  "api_key_id": "",
-  "configuration": {
-    "password": {
-      "depends_on": [],
-      "display": "text",
-      "tooltip": null,
-      "default_value": null,
-      "label": "Password",
-      "sensitive": true,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "pwd@123",
-      "order": 3,
-      "ui_restrictions": []
-    },
-    "concurrent_downloads": {
-      "depends_on": [],
-      "display": "numeric",
-      "tooltip": null,
-      "default_value": 10,
-      "label": "Maximum concurrent downloads",
-      "sensitive": false,
-      "type": "int",
-      "required": false,
-      "options": [],
-      "validations": [],
-      "value": 10,
-      "order": 6,
-      "ui_restrictions": [
-        "advanced"
-      ]
-    },
-    "retry_count": {
-      "depends_on": [],
-      "display": "numeric",
-      "tooltip": null,
-      "default_value": 3,
-      "label": "Retries per request",
-      "sensitive": false,
-      "type": "int",
-      "required": false,
-      "options": [],
-      "validations": [],
-      "value": 3,
-      "order": 5,
-      "ui_restrictions": [
-        "advanced"
-      ]
-    },
-    "services": {
-      "depends_on": [],
-      "display": "textarea",
-      "tooltip": "List of services is ignored when Advanced Sync Rules are used.",
-      "default_value": null,
-      "label": "Comma-separated list of services",
-      "sensitive": false,
-      "type": "list",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "*",
-      "order": 4,
-      "ui_restrictions": []
-    },
-    "url": {
-      "depends_on": [],
-      "display": "text",
-      "tooltip": null,
-      "default_value": null,
-      "label": "Service URL",
-      "sensitive": false,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "http://127.0.0.1:9318",
-      "order": 1,
-      "ui_restrictions": []
-    },
-    "username": {
-      "depends_on": [],
-      "display": "text",
-      "tooltip": null,
-      "default_value": null,
-      "label": "Username",
-      "sensitive": false,
-      "type": "str",
-      "required": true,
-      "options": [],
-      "validations": [],
-      "value": "some_test_user",
-      "order": 2,
-      "ui_restrictions": []
-    },
-    "use_text_extraction_service": {
-      "default_value": null,
-      "depends_on": [],
-      "display": "toggle",
-      "label": "Use text extraction service",
-      "options": [],
-      "order": 7,
-      "required": true,
-      "sensitive": false,
-      "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-      "type": "bool",
-      "ui_restrictions": [],
-      "validations": [],
-      "value": false
-    },
-    "use_document_level_security": {
-      "default_value": null,
-      "depends_on": [],
-      "display": "toggle",
-      "label": "Enable document level security",
-      "options": [],
-      "order": 8,
-      "required": true,
-      "sensitive": false,
-      "tooltip": "Document level security ensures identities and permissions set in ServiceNow are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
-      "type": "bool",
-      "ui_restrictions": [],
-      "validations": [],
-      "value": false
-    }
-  },
-  "custom_scheduling": {},
-  "description": null,
-  "error": null,
-  "features": {
-    "incremental_sync": {
-      "enabled": false
-    },
-    "document_level_security": {
-      "enabled": false
-    },
-    "sync_rules": {
-      "advanced": {
-        "enabled": false
-      },
-      "basic": {
-        "enabled": true
-      }
-    }
-  },
-  "filtering": [
-    {
-      "active": {
-        "advanced_snippet": {
-          "created_at": "2023-08-03T11:30:14.061Z",
-          "updated_at": "2023-08-03T11:30:14.061Z",
-          "value": {}
+    "configuration": {
+        "password": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Password",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "pwd@123",
+            "order": 3,
+            "ui_restrictions": []
         },
-        "rules": [
-          {
-            "created_at": "2023-08-03T11:30:14.061Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-08-03T11:30:14.061Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
-        }
-      },
-      "domain": "DEFAULT",
-      "draft": {
-        "advanced_snippet": {
-          "created_at": "2023-08-03T11:30:14.061Z",
-          "updated_at": "2023-08-03T11:30:14.061Z",
-          "value": {}
+        "concurrent_downloads": {
+            "depends_on": [],
+            "display": "numeric",
+            "tooltip": null,
+            "default_value": 10,
+            "label": "Maximum concurrent downloads",
+            "sensitive": false,
+            "type": "int",
+            "required": false,
+            "options": [],
+            "validations": [],
+            "value": 10,
+            "order": 6,
+            "ui_restrictions": [
+                "advanced"
+            ]
         },
-        "rules": [
-          {
-            "created_at": "2023-08-03T11:30:14.061Z",
-            "field": "_",
-            "id": "DEFAULT",
-            "order": 0,
-            "policy": "include",
-            "rule": "regex",
-            "updated_at": "2023-08-03T11:30:14.061Z",
-            "value": ".*"
-          }
-        ],
-        "validation": {
-          "errors": [],
-          "state": "valid"
+        "retry_count": {
+            "depends_on": [],
+            "display": "numeric",
+            "tooltip": null,
+            "default_value": 3,
+            "label": "Retries per request",
+            "sensitive": false,
+            "type": "int",
+            "required": false,
+            "options": [],
+            "validations": [],
+            "value": 3,
+            "order": 5,
+            "ui_restrictions": [
+                "advanced"
+            ]
+        },
+        "services": {
+            "depends_on": [],
+            "display": "textarea",
+            "tooltip": "List of services is ignored when Advanced Sync Rules are used.",
+            "default_value": null,
+            "label": "Comma-separated list of services",
+            "sensitive": false,
+            "type": "list",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "*",
+            "order": 4,
+            "ui_restrictions": []
+        },
+        "url": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Service URL",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "http://127.0.0.1:9318",
+            "order": 1,
+            "ui_restrictions": []
+        },
+        "username": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Username",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "some_test_user",
+            "order": 2,
+            "ui_restrictions": []
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 7,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
+        },
+        "use_document_level_security": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Enable document level security",
+            "options": [],
+            "order": 8,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Document level security ensures identities and permissions set in ServiceNow are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
-      }
     }
-  ],
-  "index_name": "search-servicenow",
-  "is_native": false,
-  "language": null,
-  "last_access_control_sync_error": null,
-  "last_access_control_sync_scheduled_at": null,
-  "last_access_control_sync_status": null,
-  "last_incremental_sync_scheduled_at": null,
-  "last_seen": "2023-08-03T11:31:00.668430+00:00",
-  "last_sync_error": null,
-  "last_sync_scheduled_at": null,
-  "last_sync_status": null,
-  "last_synced": null,
-  "name": "servicenow",
-  "pipeline": {
-    "extract_binary_content": true,
-    "name": "ent-search-generic-ingestion",
-    "reduce_whitespace": true,
-    "run_ml_inference": true
-  },
-  "scheduling": {
-    "access_control": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    },
-    "full": {
-      "enabled": true,
-      "interval": "1 * * * * ?"
-    },
-    "incremental": {
-      "enabled": false,
-      "interval": "0 0 0 * * ?"
-    }
-  },
-  "service_type": "servicenow",
-  "status": "configured",
-  "sync_now": false
 }

--- a/tests/sources/fixtures/sharepoint_online/connector.json
+++ b/tests/sources/fixtures/sharepoint_online/connector.json
@@ -1,297 +1,204 @@
 {
-    "api_key_id": "clvIfIgBFjJwEZQV7bda",
     "configuration": {
-      "tenant_id": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Tenant Id",
-        "sensitive": false,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "00000000-0000-0000-0000-000000000000",
-        "order": 1,
-        "ui_restrictions": []
-      },
-      "tenant_name": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Tenant Name",
-        "sensitive": false,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "sharepoint-online-ftest",
-        "order": 2,
-        "ui_restrictions": []
-      },
-      "secret_value": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Secret Value",
-        "sensitive": true,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
-        "order": 4,
-        "ui_restrictions": []
-      },
-      "client_id": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Client Id",
-        "sensitive": true,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "00000000-0000-0000-0000-000000000000",
-        "order": 3,
-        "ui_restrictions": []
-      },
-      "site_collections": {
-        "depends_on": [],
-        "display": "textarea",
-        "tooltip": "Site names are expected in this field. Providing \"*\" will make the connector fetch all sites on the tenant.",
-        "default_value": null,
-        "label": "Comma-separated list of SharePoint site collections to index",
-        "sensitive": false,
-        "type": "list",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "*",
-        "order": 5,
-        "ui_restrictions": []
-      },
-      "enumerate_all_sites": {
-        "depends_on": [],
-        "display": "toggle",
-        "tooltip": "Enumerate all sites?",
-        "default_value": null,
-        "label": "Enumerate all sites?",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": true,
-        "order": 6,
-        "ui_restrictions": []
-      },
-      "use_text_extraction_service": {
-        "depends_on": [],
-        "display": "toggle",
-        "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-        "default_value": null,
-        "label": "Use text extraction service",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": false,
-        "order": 7,
-        "ui_restrictions": []
-      },
-      "use_document_level_security": {
-        "depends_on": [],
-        "display": "toggle",
-        "tooltip": "Document level security ensures identities and permissions set in Sharepoint Online are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
-        "default_value": null,
-        "label": "Enable document level security",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": false,
-        "order": 8,
-        "ui_restrictions": []
-      },
-      "fetch_drive_item_permissions": {
-        "depends_on": [
-          {
-            "field": "use_document_level_security",
-            "value": true
-          }
-        ],
-        "display": "toggle",
-        "tooltip": "Enable this option to fetch drive item specific permissions. This setting can increase sync time.",
-        "default_value": true,
-        "label": "Fetch drive item permissions",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": false,
-        "order": 9,
-        "ui_restrictions": []
-      },
-      "fetch_unique_page_permissions": {
-        "depends_on": [
-          {
-            "field": "use_document_level_security",
-            "value": true
-          }
-        ],
-        "display": "toggle",
-        "tooltip": "Enable this option to fetch unique page permissions. This setting can increase sync time. If this setting is disabled a page will inherit permissions from its parent site.",
-        "default_value": true,
-        "label": "Fetch unique page permissions",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": false,
-        "order": 10,
-        "ui_restrictions": []
-      },
-      "fetch_unique_list_permissions": {
-        "depends_on": [
-          {
-            "field": "use_document_level_security",
-            "value": true
-          }
-        ],
-        "display": "toggle",
-        "tooltip": "Enable this option to fetch unique list permissions. This setting can increase sync time. If this setting is disabled a list will inherit permissions from its parent site.",
-        "default_value": true,
-        "label": "Fetch unique list permissions",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": false,
-        "order": 11,
-        "ui_restrictions": []
-      },
-      "fetch_unique_list_item_permissions": {
-        "depends_on": [
-          {
-            "field": "use_document_level_security",
-            "value": true
-          }
-        ],
-        "display": "toggle",
-        "tooltip": "Enable this option to fetch unique list item permissions. This setting can increase sync time. If this setting is disabled a list item will inherit permissions from its parent site.",
-        "default_value": null,
-        "label": "Fetch unique list item permissions",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": true,
-        "order": 12,
-        "ui_restrictions": []
-      }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": "Cannot connect to host enterprisesearchasd.sharepoint.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "features": {
-      "filtering_advanced_config": false,
-      "filtering_rules": false,
-      "sync_rules": {
-        "advanced": {
-          "enabled": true
+        "tenant_id": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Tenant Id",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "00000000-0000-0000-0000-000000000000",
+            "order": 1,
+            "ui_restrictions": []
         },
-        "basic": {
-          "enabled": true
-        }
-      }
-    },
-    "filtering": [
-      {
-        "domain": "DEFAULT",
-        "draft": {
-          "advanced_snippet": {
-            "updated_at": "2023-06-02T15:50:23.157Z",
-            "created_at": "2023-06-02T15:50:23.157Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "field": "_",
-              "updated_at": "2023-06-02T15:50:23.157Z",
-              "created_at": "2023-06-02T15:44:59.416Z",
-              "rule": "regex",
-              "id": "DEFAULT",
-              "value": ".*",
-              "order": 0,
-              "policy": "include"
-            }
-          ],
-          "validation": {
-            "state": "valid",
-            "errors": []
-          }
+        "tenant_name": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Tenant Name",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "sharepoint-online-ftest",
+            "order": 2,
+            "ui_restrictions": []
         },
-        "active": {
-          "advanced_snippet": {
-            "updated_at": "2023-06-02T15:50:23.157Z",
-            "created_at": "2023-06-02T15:50:23.157Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "field": "_",
-              "updated_at": "2023-06-02T15:50:23.157Z",
-              "created_at": "2023-06-02T15:44:59.416Z",
-              "rule": "regex",
-              "id": "DEFAULT",
-              "value": ".*",
-              "order": 0,
-              "policy": "include"
-            }
-          ],
-          "validation": {
-            "state": "valid",
-            "errors": []
-          }
+        "secret_value": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Secret Value",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
+            "order": 4,
+            "ui_restrictions": []
+        },
+        "client_id": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Client Id",
+            "sensitive": true,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "00000000-0000-0000-0000-000000000000",
+            "order": 3,
+            "ui_restrictions": []
+        },
+        "site_collections": {
+            "depends_on": [],
+            "display": "textarea",
+            "tooltip": "Site names are expected in this field. Providing \"*\" will make the connector fetch all sites on the tenant.",
+            "default_value": null,
+            "label": "Comma-separated list of SharePoint site collections to index",
+            "sensitive": false,
+            "type": "list",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "*",
+            "order": 5,
+            "ui_restrictions": []
+        },
+        "enumerate_all_sites": {
+            "depends_on": [],
+            "display": "toggle",
+            "tooltip": "Enumerate all sites?",
+            "default_value": null,
+            "label": "Enumerate all sites?",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": true,
+            "order": 6,
+            "ui_restrictions": []
+        },
+        "use_text_extraction_service": {
+            "depends_on": [],
+            "display": "toggle",
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "default_value": null,
+            "label": "Use text extraction service",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 7,
+            "ui_restrictions": []
+        },
+        "use_document_level_security": {
+            "depends_on": [],
+            "display": "toggle",
+            "tooltip": "Document level security ensures identities and permissions set in Sharepoint Online are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
+            "default_value": null,
+            "label": "Enable document level security",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 8,
+            "ui_restrictions": []
+        },
+        "fetch_drive_item_permissions": {
+            "depends_on": [
+                {
+                    "field": "use_document_level_security",
+                    "value": true
+                }
+            ],
+            "display": "toggle",
+            "tooltip": "Enable this option to fetch drive item specific permissions. This setting can increase sync time.",
+            "default_value": true,
+            "label": "Fetch drive item permissions",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 9,
+            "ui_restrictions": []
+        },
+        "fetch_unique_page_permissions": {
+            "depends_on": [
+                {
+                    "field": "use_document_level_security",
+                    "value": true
+                }
+            ],
+            "display": "toggle",
+            "tooltip": "Enable this option to fetch unique page permissions. This setting can increase sync time. If this setting is disabled a page will inherit permissions from its parent site.",
+            "default_value": true,
+            "label": "Fetch unique page permissions",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 10,
+            "ui_restrictions": []
+        },
+        "fetch_unique_list_permissions": {
+            "depends_on": [
+                {
+                    "field": "use_document_level_security",
+                    "value": true
+                }
+            ],
+            "display": "toggle",
+            "tooltip": "Enable this option to fetch unique list permissions. This setting can increase sync time. If this setting is disabled a list will inherit permissions from its parent site.",
+            "default_value": true,
+            "label": "Fetch unique list permissions",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 11,
+            "ui_restrictions": []
+        },
+        "fetch_unique_list_item_permissions": {
+            "depends_on": [
+                {
+                    "field": "use_document_level_security",
+                    "value": true
+                }
+            ],
+            "display": "toggle",
+            "tooltip": "Enable this option to fetch unique list item permissions. This setting can increase sync time. If this setting is disabled a list item will inherit permissions from its parent site.",
+            "default_value": null,
+            "label": "Fetch unique list item permissions",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": true,
+            "order": 12,
+            "ui_restrictions": []
         }
-      }
-    ],
-    "index_name": "search-sharepoint_online",
-    "is_native": false,
-    "language": null,
-    "last_seen": "2023-06-02T16:05:43.247794+00:00",
-    "last_sync_error": "Cannot connect to host enterprisesearchasd.sharepoint.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": "2023-06-02T16:08:30.745527+00:00",
-    "name": "sharepoint-online-adv",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "full": {
-        "enabled": true,
-        "interval": "0 * * * * ?"
-      }
-    },
-    "service_type": "sharepoint_online",
-    "status": "connected",
-    "id": "sharepoint_online",
-    "last_indexed_document_count": 0,
-    "last_deleted_document_count": 0
-  }
+    }
+}

--- a/tests/sources/fixtures/sharepoint_server/connector.json
+++ b/tests/sources/fixtures/sharepoint_server/connector.json
@@ -1,173 +1,93 @@
 {
-    "api_key_id": "clvIfIgBFjJwEZQV7bda",
     "configuration": {
-      "authentication": {
-        "label": "Authentication mode",
-        "order": 1,
-        "type": "str",
-        "options": [
-            {"label": "Basic", "value": "Basic"},
-            {"label": "NTLM", "value": "NTLM"}
-        ],
-        "display": "dropdown",
-        "value": "Basic"
-      },
-      "username": {
-        "label": "SharePoint Server username",
-        "order": 2,
-        "type": "str",
-        "value": "demo_user"
-      },
-      "password": {
-        "label": "SharePoint Server password",
-        "sensitive": true,
-        "order": 3,
-        "type": "str",
-        "value": "abc@123"
-      },
-      "host_url": {
-        "label": "SharePoint host",
-        "order": 4,
-        "type": "str",
-        "value": "http://127.0.0.1:8491"
-      },
-      "site_collections": {
-        "display": "textarea",
-        "label": "Comma-separated list of SharePoint site collections to index",
-        "order": 5,
-        "type": "list",
-        "value": "collection1"
-      },
-      "ssl_enabled": {
-        "display": "toggle",
-        "label": "Enable SSL",
-        "order": 6,
-        "type": "bool",
-        "value": false
-      },
-      "ssl_ca": {
-        "depends_on": [{"field": "ssl_enabled", "value": true}],
-        "label": "SSL certificate",
-        "order": 7,
-        "type": "str",
-        "value": ""
-      },
-      "retry_count": {
-        "default_value": 3,
-        "display": "numeric",
-        "label": "Retries per request",
-        "order": 8,
-        "required": false,
-        "type": "int",
-        "ui_restrictions": ["advanced"],
-        "value": null
-      },
-      "use_text_extraction_service": {
-        "default_value": null,
-        "depends_on": [],
-        "display": "toggle",
-        "label": "Use text extraction service",
-        "options": [],
-        "order": 9,
-        "required": true,
-        "sensitive": false,
-        "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-        "type": "bool",
-        "ui_restrictions": [],
-        "validations": [],
-        "value": false
-      }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": "Cannot connect to host enterprisesearchasd.sharepoint.com:443 ssl:default [nodename nor servname provided, or not known]",
-    "features": {
-      "filtering_advanced_config": false,
-      "filtering_rules": false,
-      "sync_rules": {
-        "advanced": {
-          "enabled": true
+        "authentication": {
+            "label": "Authentication mode",
+            "order": 1,
+            "type": "str",
+            "options": [
+                {
+                    "label": "Basic",
+                    "value": "Basic"
+                },
+                {
+                    "label": "NTLM",
+                    "value": "NTLM"
+                }
+            ],
+            "display": "dropdown",
+            "value": "Basic"
         },
-        "basic": {
-          "enabled": true
-        }
-      }
-    },
-    "filtering": [
-      {
-        "domain": "DEFAULT",
-        "draft": {
-          "advanced_snippet": {
-            "updated_at": "2023-06-02T15:50:23.157Z",
-            "created_at": "2023-06-02T15:50:23.157Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "field": "_",
-              "updated_at": "2023-06-02T15:50:23.157Z",
-              "created_at": "2023-06-02T15:44:59.416Z",
-              "rule": "regex",
-              "id": "DEFAULT",
-              "value": ".*",
-              "order": 0,
-              "policy": "include"
-            }
-          ],
-          "validation": {
-            "state": "valid",
-            "errors": []
-          }
+        "username": {
+            "label": "SharePoint Server username",
+            "order": 2,
+            "type": "str",
+            "value": "demo_user"
         },
-        "active": {
-          "advanced_snippet": {
-            "updated_at": "2023-06-02T15:50:23.157Z",
-            "created_at": "2023-06-02T15:50:23.157Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "field": "_",
-              "updated_at": "2023-06-02T15:50:23.157Z",
-              "created_at": "2023-06-02T15:44:59.416Z",
-              "rule": "regex",
-              "id": "DEFAULT",
-              "value": ".*",
-              "order": 0,
-              "policy": "include"
-            }
-          ],
-          "validation": {
-            "state": "valid",
-            "errors": []
-          }
+        "password": {
+            "label": "SharePoint Server password",
+            "sensitive": true,
+            "order": 3,
+            "type": "str",
+            "value": "abc@123"
+        },
+        "host_url": {
+            "label": "SharePoint host",
+            "order": 4,
+            "type": "str",
+            "value": "http://127.0.0.1:8491"
+        },
+        "site_collections": {
+            "display": "textarea",
+            "label": "Comma-separated list of SharePoint site collections to index",
+            "order": 5,
+            "type": "list",
+            "value": "collection1"
+        },
+        "ssl_enabled": {
+            "display": "toggle",
+            "label": "Enable SSL",
+            "order": 6,
+            "type": "bool",
+            "value": false
+        },
+        "ssl_ca": {
+            "depends_on": [
+                {
+                    "field": "ssl_enabled",
+                    "value": true
+                }
+            ],
+            "label": "SSL certificate",
+            "order": 7,
+            "type": "str",
+            "value": ""
+        },
+        "retry_count": {
+            "default_value": 3,
+            "display": "numeric",
+            "label": "Retries per request",
+            "order": 8,
+            "required": false,
+            "type": "int",
+            "ui_restrictions": [
+                "advanced"
+            ],
+            "value": null
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 9,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
-      }
-    ],
-    "index_name": "search-sharepoint_server",
-    "is_native": false,
-    "language": null,
-    "last_seen": "2023-06-02T16:05:43.247794+00:00",
-    "last_sync_error": null,
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": "2023-06-02T16:08:30.745527+00:00",
-    "name": "sharepoint-online-adv",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "full": {
-        "enabled": true,
-        "interval": "0 * * * * ?"
-      }
-    },
-    "service_type": "sharepoint_server",
-    "status": "connected",
-    "id": "sharepoint_server",
-    "last_indexed_document_count": 0,
-    "last_deleted_document_count": 0
-  }
+    }
+}

--- a/tests/sources/fixtures/zoom/connector.json
+++ b/tests/sources/fixtures/zoom/connector.json
@@ -1,201 +1,94 @@
 {
-    "api_key_id": "",
     "configuration": {
-      "account_id": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Account ID",
-        "sensitive": false,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "00000000",
-        "order": 1,
-        "ui_restrictions": []
-      },
-      "client_id": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Client ID",
-        "sensitive": false,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "00000000-0000-0000-0000-000000000000",
-        "order": 2,
-        "ui_restrictions": []
-      },
-      "client_secret": {
-        "depends_on": [],
-        "display": "text",
-        "tooltip": null,
-        "default_value": null,
-        "label": "Client secret",
-        "sensitive": false,
-        "type": "str",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-        "order": 3,
-        "ui_restrictions": []
-      },
-      "fetch_past_meeting_details": {
-        "depends_on": [],
-        "display": "toggle",
-        "tooltip": "Enable this option to fetch past past meeting details. This setting can increase sync time",
-        "default_value": false,
-        "label": "Fetch past meeting details",
-        "sensitive": false,
-        "type": "bool",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": false,
-        "order": 4,
-        "ui_restrictions": []
-      },
-      "recording_age": {
-        "depends_on": [],
-        "display": "numeric",
-        "tooltip": "How far back in time to request recordings from zoom. Recordings older than this will not be indexed.",
-        "default_value": null,
-        "label": "Recording Age Limit (Months)",
-        "sensitive": false,
-        "type": "int",
-        "required": true,
-        "options": [],
-        "validations": [],
-        "value": 4,
-        "order": 5,
-        "ui_restrictions": []
-      },
-      "use_text_extraction_service": {
-        "default_value": null,
-        "depends_on": [],
-        "display": "toggle",
-        "label": "Use text extraction service",
-        "options": [],
-        "order": 6,
-        "required": true,
-        "sensitive": false,
-        "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
-        "type": "bool",
-        "ui_restrictions": [],
-        "validations": [],
-        "value": false
-      }
-    },
-    "custom_scheduling": {},
-    "description": null,
-    "error": null,
-    "features": {
-      "incremental_sync": {
-        "enabled": false
-      },
-      "document_level_security": {
-        "enabled": false
-      },
-      "sync_rules": {
-        "advanced": {
-          "enabled": false
+        "account_id": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Account ID",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "00000000",
+            "order": 1,
+            "ui_restrictions": []
         },
-        "basic": {
-          "enabled": true
-        }
-      }
-    },
-    "filtering": [
-      {
-        "active": {
-          "advanced_snippet": {
-            "created_at": "2023-08-03T11:30:14.061Z",
-            "updated_at": "2023-08-03T11:30:14.061Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "created_at": "2023-08-03T11:30:14.061Z",
-              "field": "_",
-              "id": "DEFAULT",
-              "order": 0,
-              "policy": "include",
-              "rule": "regex",
-              "updated_at": "2023-08-03T11:30:14.061Z",
-              "value": ".*"
-            }
-          ],
-          "validation": {
-            "errors": [],
-            "state": "valid"
-          }
+        "client_id": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Client ID",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "00000000-0000-0000-0000-000000000000",
+            "order": 2,
+            "ui_restrictions": []
         },
-        "domain": "DEFAULT",
-        "draft": {
-          "advanced_snippet": {
-            "created_at": "2023-08-03T11:30:14.061Z",
-            "updated_at": "2023-08-03T11:30:14.061Z",
-            "value": {}
-          },
-          "rules": [
-            {
-              "created_at": "2023-08-03T11:30:14.061Z",
-              "field": "_",
-              "id": "DEFAULT",
-              "order": 0,
-              "policy": "include",
-              "rule": "regex",
-              "updated_at": "2023-08-03T11:30:14.061Z",
-              "value": ".*"
-            }
-          ],
-          "validation": {
-            "errors": [],
-            "state": "valid"
-          }
+        "client_secret": {
+            "depends_on": [],
+            "display": "text",
+            "tooltip": null,
+            "default_value": null,
+            "label": "Client secret",
+            "sensitive": false,
+            "type": "str",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "order": 3,
+            "ui_restrictions": []
+        },
+        "fetch_past_meeting_details": {
+            "depends_on": [],
+            "display": "toggle",
+            "tooltip": "Enable this option to fetch past past meeting details. This setting can increase sync time",
+            "default_value": false,
+            "label": "Fetch past meeting details",
+            "sensitive": false,
+            "type": "bool",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": false,
+            "order": 4,
+            "ui_restrictions": []
+        },
+        "recording_age": {
+            "depends_on": [],
+            "display": "numeric",
+            "tooltip": "How far back in time to request recordings from zoom. Recordings older than this will not be indexed.",
+            "default_value": null,
+            "label": "Recording Age Limit (Months)",
+            "sensitive": false,
+            "type": "int",
+            "required": true,
+            "options": [],
+            "validations": [],
+            "value": 4,
+            "order": 5,
+            "ui_restrictions": []
+        },
+        "use_text_extraction_service": {
+            "default_value": null,
+            "depends_on": [],
+            "display": "toggle",
+            "label": "Use text extraction service",
+            "options": [],
+            "order": 6,
+            "required": true,
+            "sensitive": false,
+            "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
+            "type": "bool",
+            "ui_restrictions": [],
+            "validations": [],
+            "value": false
         }
-      }
-    ],
-    "index_name": "search-zoom",
-    "is_native": false,
-    "language": null,
-    "last_access_control_sync_error": null,
-    "last_access_control_sync_scheduled_at": null,
-    "last_access_control_sync_status": null,
-    "last_incremental_sync_scheduled_at": null,
-    "last_seen": "2023-08-03T11:31:00.668430+00:00",
-    "last_sync_error": null,
-    "last_sync_scheduled_at": null,
-    "last_sync_status": null,
-    "last_synced": null,
-    "name": "zoom",
-    "pipeline": {
-      "extract_binary_content": true,
-      "name": "ent-search-generic-ingestion",
-      "reduce_whitespace": true,
-      "run_ml_inference": true
-    },
-    "scheduling": {
-      "access_control": {
-        "enabled": false,
-        "interval": "0 0 0 * * ?"
-      },
-      "full": {
-        "enabled": true,
-        "interval": "1 * * * * ?"
-      },
-      "incremental": {
-        "enabled": false,
-        "interval": "0 0 0 * * ?"
-      }
-    },
-    "service_type": "zoom",
-    "status": "configured",
-    "sync_now": false
-  }
+    }
+}

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -37,7 +37,15 @@ def test_main(patch_logger, mock_responses):
     headers = {"X-Elastic-Product": "Elasticsearch"}
 
     mock_responses.put(
-        "http://nowhere.com:9200/.elastic-connectors-v1/_doc/1",
+        "http://nowhere.com:9200/_connector/1",
+        headers=headers,
+    )
+    mock_responses.put(
+        "http://nowhere.com:9200/_connector/1/_scheduling",
+        headers=headers,
+    )
+    mock_responses.put(
+        "http://nowhere.com:9200/_connector/1/_configuration",
         headers=headers,
     )
     mock_index_creation("data", mock_responses, hidden=False)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Connector APIs] Enable Connector APIs framework-wide + update functional tests (#2902)](https://github.com/elastic/connectors/pull/2902)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)