### PR TITLE
Allow Insecure HTTPS 

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -54,6 +54,10 @@
 #elasticsearch.ssl: true
 #
 #
+##  Whether to perform verification checks for server certificates using CA bundle.
+#elasticsearch.verify_certs: true
+#
+#
 ##  Path to a CA bundle, e.g. /path/to/ca.crt
 #elasticsearch.ca_certs: null
 #

--- a/config.yml.example
+++ b/config.yml.example
@@ -55,6 +55,7 @@
 #
 #
 ##  Whether to perform verification checks for server certificates using CA bundle.
+##    This option should be avoided in production.
 #elasticsearch.verify_certs: true
 #
 #

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -64,6 +64,7 @@ def _default_config():
             "username": "elastic",
             "password": "changeme",
             "ssl": True,
+            "verify_certs": True,
             "bulk": {
                 "queue_max_size": 1024,
                 "queue_max_mem_size": 25,

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -94,10 +94,7 @@ class ESClient:
                     logger.debug(f"Verifying cert with {ca_certs}")
                     options["ca_certs"] = ca_certs
                 else:
-                    logger.debug("Verifying cert with system certificates")        
-        else:
-            options["verify_certs"] = False
-            
+                    logger.debug("Verifying cert with system certificates")
 
         level = config.get("log_level", "INFO").upper()
         es_logger = logging.getLogger("elastic_transport.node")

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -87,11 +87,17 @@ class ESClient:
             logger.debug(f"Connecting using Basic Auth (user: {config['username']})")
 
         if config.get("ssl", False):
-            options["verify_certs"] = True
-            if "ca_certs" in config:
-                ca_certs = config["ca_certs"]
-                logger.debug(f"Verifying cert with {ca_certs}")
-                options["ca_certs"] = ca_certs
+            options["verify_certs"] = config.get("verify_certs", True)
+            if options["verify_certs"]:
+                if "ca_certs" in config:
+                    ca_certs = config["ca_certs"]
+                    logger.debug(f"Verifying cert with {ca_certs}")
+                    options["ca_certs"] = ca_certs
+                else:
+                    logger.debug("Verifying cert with system certificates")        
+        else:
+            options["verify_certs"] = False
+            
 
         level = config.get("log_level", "INFO").upper()
         es_logger = logging.getLogger("elastic_transport.node")

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -12,11 +12,12 @@ Please refer to the following Docker image registry to access and pull available
 
 Follow these steps:
 
-1. [Create network](#1-create-a-docker-network)
-2. [Create directory](#2-create-a-directory-to-be-mounted-into-the-docker-image)
-3. [Download config file](#3-download-sample-configuration-file-from-this-repository-into-newly-created-directory)
-4. [Update config file](#4-update-the-configuration-file-for-your-self-managed-connectorhttpswwwelasticcoguideenenterprise-searchcurrentbuild-connectorhtmlbuild-connector-usage)
-5. [Run the docker image](#5-run-the-docker-image)
+- [Run Connector Service in Docker](#run-connector-service-in-docker)
+  - [1. Create a Docker network.](#1-create-a-docker-network)
+  - [2. Create a directory to be mounted into the Docker image.](#2-create-a-directory-to-be-mounted-into-the-docker-image)
+  - [3. Download sample configuration file from this repository into newly created directory.](#3-download-sample-configuration-file-from-this-repository-into-newly-created-directory)
+  - [4. Update the configuration file for your self-managed connector](#4-update-the-configuration-file-for-your-self-managed-connector)
+  - [5. Run the Docker image.](#5-run-the-docker-image)
 
 ## 1. Create a Docker network.
 
@@ -106,16 +107,13 @@ You might need to adjust some details here:
 
 > [!TIP]
 > When starting a Docker container with the connector service against a local Elasticsearch cluster that has security and SSL enabled (like the [docker compose example](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-compose-file) from the Elasticsearch docs), it's crucial to handle the self-signed certificate correctly:
-> 1. Configure the SSL option in connector service's `config.yml` with:
-> ```
-> elasticsearch.ssl: true
-> ```
-> 2. Ensure the Docker container running the connector service has the volume attached that contains the generated certificate. When using Docker Compose, Docker automatically adds a project-specific prefix to volume names based on the directory where your `docker-compose.yml` is located. When starting the connector service with `docker run`, use `-v <your_project>_certs:/usr/share/connectors/config/certs` to reference it. Replace `<your_project>` with the actual prefix, such as `elastic_docker_certs` if your `docker-compose.yml` that starts the Elasticsearch stack is in a directory named `elastic_docker`.
-> 3. Make sure the connector service's `config.yml` correctly references the certificate with:
+> 1. Ensure the Docker container running the connector service has the volume attached that contains the generated certificate. When using Docker Compose, Docker automatically adds a project-specific prefix to volume names based on the directory where your `docker-compose.yml` is located. When starting the connector service with `docker run`, use `-v <your_project>_certs:/usr/share/connectors/config/certs` to reference it. Replace `<your_project>` with the actual prefix, such as `elastic_docker_certs` if your `docker-compose.yml` that starts the Elasticsearch stack is in a directory named `elastic_docker`.
+> 2. Make sure the connector service's `config.yml` correctly references the certificate with:
 > ```
 > elasticsearch.ca_certs: /usr/share/connectors/config/certs/ca/ca.crt
 > ```
-> 4. To avoid the certificate verification, configure `verify_certs` parameter which is `true` by default when SSL is enabled in connector service's `config.yml` as:
+> 3. To avoid the certificate verification, configure `verify_certs` parameter which is `true` by default when SSL is enabled in connector service's `config.yml` as:
 > ```
 > elasticsearch.verify_certs: false
 > ```
+> Disclaimer: Setting `verify_certs` to `false` is not recommended in a production environment, as it may expose your application to security vulnerabilities.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -106,8 +106,16 @@ You might need to adjust some details here:
 
 > [!TIP]
 > When starting a Docker container with the connector service against a local Elasticsearch cluster that has security and SSL enabled (like the [docker compose example](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#docker-compose-file) from the Elasticsearch docs), it's crucial to handle the self-signed certificate correctly:
-> 1. Ensure the Docker container running the connector service has the volume attached that contains the generated certificate. When using Docker Compose, Docker automatically adds a project-specific prefix to volume names based on the directory where your `docker-compose.yml` is located. When starting the connector service with `docker run`, use `-v <your_project>_certs:/usr/share/connectors/config/certs` to reference it. Replace `<your_project>` with the actual prefix, such as `elastic_docker_certs` if your `docker-compose.yml` that starts the Elasticsearch stack is in a directory named `elastic_docker`.
-> 2. Make sure the connector service's `config.yml` correctly references the certificate with:
+> 1. Configure the SSL option in connector service's `config.yml` with:
+> ```
+> elasticsearch.ssl: true
+> ```
+> 2. Ensure the Docker container running the connector service has the volume attached that contains the generated certificate. When using Docker Compose, Docker automatically adds a project-specific prefix to volume names based on the directory where your `docker-compose.yml` is located. When starting the connector service with `docker run`, use `-v <your_project>_certs:/usr/share/connectors/config/certs` to reference it. Replace `<your_project>` with the actual prefix, such as `elastic_docker_certs` if your `docker-compose.yml` that starts the Elasticsearch stack is in a directory named `elastic_docker`.
+> 3. Make sure the connector service's `config.yml` correctly references the certificate with:
 > ```
 > elasticsearch.ca_certs: /usr/share/connectors/config/certs/ca/ca.crt
+> ```
+> 4. To avoid the certificate verification, configure `verify_certs` parameter which is `true` by default when SSL is enabled in connector service's `config.yml` as:
+> ```
+> elasticsearch.verify_certs: false
 > ```


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/2491

Updated the verification logic for server certificates to allow for configurable settings. The `verify_certs` option now defaults to `True` but can be set to `False` in the configuration. This change enhances flexibility, allowing users to opt out of certificate verification in environments with varying security requirements.


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [x] Security-related changes (encryption, TLS, SSRF, etc)


## Release Note


<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
