### PR TITLE
Removes gratuitous 'critical' logging

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -514,7 +514,7 @@ class Extractor:
                 )
                 return
 
-            self._logger.critical("Document extractor failed", exc_info=True)
+            self._logger.error("Document extractor failed", exc_info=True)
             await self.put_doc(EXTRACTOR_ERROR)
             self.error = e
 

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -892,7 +892,7 @@ class Connector(ESDocument):
         try:
             source_klass = get_source_klass(fqn)
         except Exception as e:
-            self.log_critical(e, exc_info=True)
+            self.log_error(e, exc_info=True)
             msg = f"Could not instantiate {fqn} for {configured_service_type}"
             raise DataSourceError(msg) from e
 

--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -75,7 +75,7 @@ class JobCleanUpService(BaseService):
                     f"Successfully marked #{marked_count} out of #{total_count} orphaned idle jobs as error."
                 )
         except Exception as e:
-            self.logger.critical(e, exc_info=True)
+            self.logger.error(e, exc_info=True)
             self.raise_if_spurious(e)
 
     async def _process_idle_jobs(self):
@@ -128,5 +128,5 @@ class JobCleanUpService(BaseService):
                     f"Successfully marked #{marked_count} out of #{total_count} idle jobs as error."
                 )
         except Exception as e:
-            self.logger.critical(e, exc_info=True)
+            self.logger.error(e, exc_info=True)
             self.raise_if_spurious(e)

--- a/connectors/services/job_execution.py
+++ b/connectors/services/job_execution.py
@@ -141,7 +141,7 @@ class JobExecutionService(BaseService):
                         ):
                             await self._sync(sync_job)
                 except Exception as e:
-                    self.logger.critical(e, exc_info=True)
+                    self.logger.error(e, exc_info=True)
                     self.raise_if_spurious(e)
 
                 # Immediately break instead of sleeping

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -62,7 +62,7 @@ class JobSchedulingService(BaseService):
             return
         except DataSourceError as e:
             await connector.error(e)
-            connector.log_critical(e, exc_info=True)
+            connector.log_error(e, exc_info=True)
             raise
 
         # the heartbeat is always triggered
@@ -160,7 +160,7 @@ class JobSchedulingService(BaseService):
                         await self._schedule(connector)
 
                 except Exception as e:
-                    self.logger.critical(e, exc_info=True)
+                    self.logger.error(e, exc_info=True)
                     self.raise_if_spurious(e)
 
                 # Immediately break instead of sleeping
@@ -214,7 +214,7 @@ class JobSchedulingService(BaseService):
                 next_sync = connector.next_sync(job_type, last_wake_up_time)
                 connector.log_debug(f"Next '{job_type_value}' sync is at {next_sync}")
             except Exception as e:
-                connector.log_critical(e, exc_info=True)
+                connector.log_error(e, exc_info=True)
                 await connector.error(str(e))
                 return False
 


### PR DESCRIPTION
Related to https://github.com/elastic/connectors/pull/2916, which reminded me that this has been annoying for a while. We should only use CRITICAL when the process is imminently crashing. Sync errors are not "CRITICAL".