### PR TITLE
Stop running MSSQL ftests for aarch64

### DIFF
--- a/.buildkite/nightly_steps.yml
+++ b/.buildkite/nightly_steps.yml
@@ -144,6 +144,7 @@ steps:
       PYTHON_VERSION: "{{ matrix }}"
       CONNECTOR: "mssql"
       DATA_SIZE: "small"
+      SKIP_AARCH64: "true"
     artifact_paths:
       - "perf8-report-*/**/*"
     matrix:


### PR DESCRIPTION
There are consistent problems with MSSQL functional tests on aarch64. See issue: https://github.com/microsoft/mssql-docker/issues/802

MSSQL server does not consistently start on aarch64 due to performance issues. We already do not run Network Drive functional tests, so the simplest way forward is to disable the functional tests for now until there's proper support for aarch64 in the docker image