### PR TITLE
Fix `apt` invocations in `Dockerfile`s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.11-slim-bookworm
-RUN apt update && apt upgrade && apt install make git -y
+RUN apt -y update && apt -y upgrade && apt -y install make git
 COPY . /app
 WORKDIR /app
 RUN make clean install

--- a/Dockerfile.ftest
+++ b/Dockerfile.ftest
@@ -1,6 +1,6 @@
 FROM python:3.11-slim-bookworm
 # RUN apt update && apt install make
-RUN apt update && apt upgrade && apt install make git -y
+RUN apt -y update && apt -y upgrade && apt -y install make git
 COPY . /app
 WORKDIR /app
 RUN make clean install


### PR DESCRIPTION
Without the `-y` params, `docker build` can fail when confronted with an interactive `apt` prompt:

> Do you want to continue? [Y/n] Abort.

> ERROR: failed to solve: process "/bin/sh -c apt update && apt upgrade && apt install make git -y" did not complete successfully: exit code: 1
