### PR TITLE
use quotes on 8.16 version in catalog-info.yml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -58,7 +58,7 @@ spec:
           cronline: '@daily'
           message: "Builds, tests, and pushes daily `8.x` DRA artifacts"
         Daily 8.16:
-          branch: 8.16
+          branch: "8.16"
           cronline: '@daily'
           message: "Builds, tests, and pushes daily `8.16` DRA artifacts"
       provider_settings:


### PR DESCRIPTION
I broke terrazo 🙈 see: https://github.com/elastic/connectors/pull/2951#issuecomment-2471635528