### PR TITLE
Make local stack scripts work

### DIFF
--- a/scripts/stack/run-stack.sh
+++ b/scripts/stack/run-stack.sh
@@ -41,10 +41,10 @@ if [[ "${connectors_only}" != true ]]; then
   source $CURDIR/wait-for-elasticsearch.sh
 
   # Start Kibana
+  source $CURDIR/update-kibana-user-password.sh
   echo "Starting Kibana..."
   docker-compose -f $compose_file up --detach kibana
   source $CURDIR/wait-for-kibana.sh
-  source $CURDIR/update-kibana-user-password.sh
 fi
 
 source ./copy-config.sh

--- a/scripts/stack/update-kibana-user-password.sh
+++ b/scripts/stack/update-kibana-user-password.sh
@@ -11,10 +11,6 @@ if [[ ${CURDIR:-} == "" ]]; then
     export CURDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 fi
 
-if [[ "${ELASTIC_PASSWORD:-}" == "" ]]; then
-    source $CURDIR/read-env.sh $CURDIR/.env
-fi
-
 echo "Updating Kibana password in Elasticsearch running on $ELASTICSEARCH_URL"
 change_data="{ \"password\": \"${ELASTIC_PASSWORD}\" }"
 curl -u elastic:$ELASTIC_PASSWORD "$@" -X POST "${ELASTICSEARCH_URL}/_security/user/kibana_system/_password?pretty" -H 'Content-Type: application/json' -d"${change_data}"


### PR DESCRIPTION
I noticed that `script/stack/start-stack.sh` wasn't working. It would wait for kibana indefinitely, and if you checked kibana logs, you'd see auth errors because kibana_system didn't have the right credentials.

Two problems:
- we were not setting the kibana_system password until _after_ kibana was supposed to have started up
- we were trying to source some `read-env.sh` script that doesn't exist.

IDK how this ever worked, or what broke it. But this makes things start up as expected, now.

## Checklists



#### Pre-Review Checklist
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
