### PR TITLE
[outlook] Filter users to only include active ones

### DIFF
--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -43,7 +43,7 @@ from connectors.utils import (
     hash_id,
     html_to_text,
     iso_utc,
-    retryable,
+    retryable, url_encode,
 )
 
 RETRIES = 3
@@ -410,7 +410,8 @@ class Office365Users:
     )
     async def get_users(self):
         access_token = await self._fetch_token()
-        url = f"https://graph.microsoft.com/v1.0/users?$top={TOP}"
+        filter_ = url_encode("accountEnabled eq true")
+        url = f"https://graph.microsoft.com/v1.0/users?$top={TOP}&$filter={filter_}"
         while True:
             try:
                 async with self._get_session.get(

--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -43,7 +43,8 @@ from connectors.utils import (
     hash_id,
     html_to_text,
     iso_utc,
-    retryable, url_encode,
+    retryable,
+    url_encode,
 )
 
 RETRIES = 3

--- a/tests/sources/test_outlook.py
+++ b/tests/sources/test_outlook.py
@@ -420,7 +420,10 @@ def side_effect_function(url, headers):
     Args:
         url, ssl: Params required for get call
     """
-    if url == "https://graph.microsoft.com/v1.0/users?$top=999":
+    if (
+        url
+        == "https://graph.microsoft.com/v1.0/users?$top=999&$filter=accountEnabled%20eq%20true"
+    ):
         return get_json_mock(
             mock_response={
                 "@odata.nextLink": "https://graph.microsoft.com/v1.0/users?$top=999&$skipToken=fake-skip-token",


### PR DESCRIPTION
## part of https://github.com/elastic/sdh-search/issues/1507
## closes https://github.com/elastic/connectors/issues/2931

A failure in the outlook connector was reported with a stack trace like:

```
Traceback (most recent call last):
  File "/workspaces/elastic_connectors/connectors/es/sink.py", line 487, in run
    await self.get_docs(generator)
  File "/workspaces/elastic_connectors/connectors/es/sink.py", line 539, in get_docs
    async for count, doc in aenumerate(generator):
  File "/workspaces/elastic_connectors/connectors/utils.py", line 856, in aenumerate
    async for elem in asequence:
  File "/workspaces/elastic_connectors/connectors/logger.py", line 247, in __anext__
    return await self.gen.__anext__()
  File "/workspaces/elastic_connectors/connectors/es/sink.py", line 521, in _decorate_with_metrics_span
    async for doc in generator:
  File "/workspaces/elastic_connectors/connectors/sync_job_runner.py", line 454, in prepare_docs
    async for doc, lazy_download, operation in self.generator():
  File "/workspaces/elastic_connectors/connectors/sync_job_runner.py", line 490, in generator
    async for doc, lazy_download in self.data_provider.get_docs(
  File "/workspaces/elastic_connectors/connectors/sources/outlook.py", line 1058, in get_docs
    async for account in self.client._get_user_instance.get_user_accounts():
  File "/workspaces/elastic_connectors/connectors/sources/outlook.py", line 451, in get_user_accounts
    user_account = Account(
  File "/workspaces/elastic_connectors/lib/python3.10/site-packages/exchangelib/account.py", line 205, in __init__
    self.version = self.protocol.version.copy()
  File "/workspaces/elastic_connectors/lib/python3.10/site-packages/exchangelib/protocol.py", line 480, in version
    self.config.version = Version.guess(self, api_version_hint=self.api_version_hint)
  File "/workspaces/elastic_connectors/lib/python3.10/site-packages/exchangelib/version.py", line 206, in guess
    raise TransportError(f"No valid version headers found in response ({e!r})")
exchangelib.errors.TransportError: No valid version headers found in response (ErrorNonExistentMailbox('The SMTP address has no mailbox associated with it.'))
```

After some investigation, it appears that the user record that is causing this issue is deactivated. While this feels like a bug in the underlying exchange lib, that you can't create an Account object for a deactivated user, we can avoid this situation by filtering our list of users to active users only.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)



## Release Note

Fixes a bug in the Outlook Connector where having deactivated users could cause the sync to fail. 
