### PR TITLE
[CI] Add retries when fetching DRA artifacts

### DIFF
--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -62,9 +62,10 @@ function resolve_dra_manifest {
 function download_docker_tarball {
   TAR_URL=$1
   TAR_FILE=$2
+  MAX_RETRIES=3
 
   echo "Downloading Docker image tarball from $TAR_URL..."
-  curl -O "$TAR_URL"
+  curl --retry $MAX_RETRIES --retry-connrefused -O "$TAR_URL"
 
   if [ ! -f "$TAR_FILE" ]; then
     echo "Error: Download failed. File $TAR_FILE not found."


### PR DESCRIPTION
## Followup on #2979

I noticed in buildkite some sporadic errors when downloading the image tarball, let's add retries to make our pipeline stable:

Exampel of error (buildkite retried and it passed)
```

+ TAR_FILE=elasticsearch-9.0.0-SNAPSHOT-docker-image.tar.gz
--
  | + echo 'Downloading Docker image tarball from https://artifacts-snapshot.elastic.co/elasticsearch/9.0.0-925206fd/downloads/elasticsearch/elasticsearch-9.0.0-SNAPSHOT-docker-image.tar.gz...'
  | Downloading Docker image tarball from https://artifacts-snapshot.elastic.co/elasticsearch/9.0.0-925206fd/downloads/elasticsearch/elasticsearch-9.0.0-SNAPSHOT-docker-image.tar.gz...
  | + curl -O https://artifacts-snapshot.elastic.co/elasticsearch/9.0.0-925206fd/downloads/elasticsearch/elasticsearch-9.0.0-SNAPSHOT-docker-image.tar.gz
  | % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
  | Dload  Upload   Total   Spent    Left  Speed
  | 25  638M   25  162M    0     0  35.2M      0  0:00:18  0:00:04  0:00:14 35.2M
  | curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR (err 2)
  | make: *** [Makefile:77: ftest] Error 92
  | 🚨 Error: The command exited with status 2
  | user command error: exit status 2


```