### PR TITLE
[8.x] [Publishing] Load ES image for ftest from DRA artifact (#2979)

### DIFF
--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -14,13 +14,115 @@ VIRTUAL_ENV="$ROOT_DIR/.venv"
 PLATFORM='unknown'
 MAX_RSS="200M"
 MAX_DURATION=600
+CONNECTORS_VERSION=$(cat "$ROOT_DIR/connectors/VERSION")
+ARTIFACT_BASE_URL="https://artifacts-snapshot.elastic.co"
 
 export DOCKERFILE_FTEST_PATH=${DOCKERFILE_FTEST_PATH:-Dockerfile.ftest}
 export PERF8_TRACE=${PERF8_TRACE:-False}
 export REFRESH_RATE="${REFRESH_RATE:-5}"
 export DATA_SIZE="${DATA_SIZE:-medium}"
 export RUNNING_FTEST=True
-export VERSION='8.17.0-SNAPSHOT'
+export VERSION="${CONNECTORS_VERSION}-SNAPSHOT"
+
+# Download and load ES Docker images from DRA artifacts instead of relying on the snapshot image in the registry.
+# This is needed for the release process when the ES snapshot image may not yet be available.
+# Snapshot images are pushed to the registry by the unified release workflow.
+
+# Function to resolve the DRA manifest URL
+function resolve_dra_manifest {
+  DRA_ARTIFACT=$1
+  DRA_VERSION=$2
+
+  # Perform the curl request and capture the output and exit code
+  RESPONSE=$(curl -sS -f $ARTIFACT_BASE_URL/$DRA_ARTIFACT/latest/$DRA_VERSION.json 2>&1)
+  CURL_EXIT_CODE=$?
+
+  # Check if the curl command failed
+  if [ $CURL_EXIT_CODE -ne 0 ]; then
+    echo "Error: Failed to fetch DRA manifest for artifact $DRA_ARTIFACT and version $DRA_VERSION."
+    echo "Details: $RESPONSE"
+    exit 1
+  fi
+
+  # Extract the manifest_url using jq
+  MANIFEST_URL=$(echo "$RESPONSE" | jq -r '.manifest_url' 2>/dev/null)
+
+  # Check if the jq command succeeded and if manifest_url is non-empty
+  if [ -z "$MANIFEST_URL" ] || [ "$MANIFEST_URL" == "null" ]; then
+    echo "Error: No manifest_url found in the response for artifact $DRA_ARTIFACT and version $DRA_VERSION."
+    echo "Response: $RESPONSE"
+    exit 1
+  fi
+
+  # Output the manifest URL
+  echo "$MANIFEST_URL"
+}
+
+# Function to download the Docker image tarball
+function download_docker_tarball {
+  TAR_URL=$1
+  TAR_FILE=$2
+
+  echo "Downloading Docker image tarball from $TAR_URL..."
+  curl -O "$TAR_URL"
+
+  if [ ! -f "$TAR_FILE" ]; then
+    echo "Error: Download failed. File $TAR_FILE not found."
+    exit 1
+  fi
+}
+
+# Function to load the Docker image directly from the tarball
+function load_docker_image {
+  TAR_FILE=$1
+  echo "Loading Docker image from $TAR_FILE..."
+  docker load < "$TAR_FILE"
+}
+
+# Determine system architecture
+ARCH=$(uname -m)
+
+# Normalize architecture name
+if [[ $ARCH == "arm64" ]]; then
+  ARCH="aarch64"
+fi
+
+# Select the appropriate Docker tarball name based on architecture
+case $ARCH in
+  x86_64)
+    DOCKER_TARBALL_NAME="elasticsearch-$VERSION-docker-image.tar.gz"
+    ;;
+  aarch64)
+    DOCKER_TARBALL_NAME="elasticsearch-$VERSION-docker-image-aarch64.tar.gz"
+    ;;
+  *)
+    echo "Error: Unsupported architecture $ARCH"
+    exit 1
+    ;;
+esac
+
+# Get the DRA manifest URL for Elasticsearch
+ELASTICSEARCH_DRA_MANIFEST=$(resolve_dra_manifest "elasticsearch" $VERSION)
+
+# Parse Docker image tarball information
+DOCKER_TARBALL_URL=$(curl -sS "$ELASTICSEARCH_DRA_MANIFEST" | jq -r ".projects.elasticsearch.packages.\"$DOCKER_TARBALL_NAME\".url")
+
+if [ -z "$DOCKER_TARBALL_URL" ] || [ "$DOCKER_TARBALL_URL" == "null" ]; then
+  echo "Error: Docker tarball URL not found in the manifest."
+  exit 1
+fi
+
+# Execute the functions to download and load the image
+download_docker_tarball "$DOCKER_TARBALL_URL" "$DOCKER_TARBALL_NAME"
+load_docker_image "$DOCKER_TARBALL_NAME"
+
+# Export image name following DRA conventions
+export ELASTICSEARCH_DRA_DOCKER_IMAGE="elasticsearch:$ARCH"
+
+echo "Docker image for Elasticsearch $VERSION loaded successfully. Image name: $ELASTICSEARCH_DRA_DOCKER_IMAGE"
+
+echo "Cleaning up the downloaded tarball..."
+rm -f "$DOCKER_TARBALL_NAME"
 
 if [ "$PERF8_TRACE" == true ]; then
     echo 'Tracing is enabled, memray stats will be delivered'

--- a/tests/sources/fixtures/azure_blob_storage/docker-compose.yml
+++ b/tests/sources/fixtures/azure_blob_storage/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,60 +24,11 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   azureblobstorage:
     image: mcr.microsoft.com/azure-storage/azurite
     ports:
       - 10000:10000
-    command: ["azurite-blob","--blobHost","0.0.0.0","--blobPort","10000"]    
+    command: ["azurite-blob","--blobHost","0.0.0.0","--blobPort","10000"]
 
 networks:
   esnet:

--- a/tests/sources/fixtures/box/docker-compose.yml
+++ b/tests/sources/fixtures/box/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   box:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/box/fixture.py

--- a/tests/sources/fixtures/confluence/docker-compose.yml
+++ b/tests/sources/fixtures/confluence/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-  
   confluence:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/confluence/fixture.py
@@ -82,7 +33,7 @@ services:
       - "9696:9696"
     volumes:
       - .:/python-flask
-    restart: always  
+    restart: always
 
 networks:
   esnet:

--- a/tests/sources/fixtures/dir/docker-compose.yml
+++ b/tests/sources/fixtures/dir/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -21,55 +21,6 @@ services:
       - esdata:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
-    networks:
-      - esnet
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     networks:
       - esnet
 

--- a/tests/sources/fixtures/dropbox/docker-compose.yml
+++ b/tests/sources/fixtures/dropbox/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   dropbox:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/dropbox/fixture.py

--- a/tests/sources/fixtures/fixture.py
+++ b/tests/sources/fixtures/fixture.py
@@ -183,7 +183,6 @@ async def main(args=None):
     if action in ("start_stack", "stop_stack"):
         os.chdir(os.path.join(os.path.dirname(__file__), args.name))
         if action == "start_stack":
-            await _exec_shell("docker compose pull")
             await _exec_shell("docker compose up -d")
         else:
             await _exec_shell("docker compose down --volumes")

--- a/tests/sources/fixtures/github/docker-compose.yml
+++ b/tests/sources/fixtures/github/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   github:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/github/fixture.py

--- a/tests/sources/fixtures/google_cloud_storage/docker-compose.yml
+++ b/tests/sources/fixtures/google_cloud_storage/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -25,7 +25,7 @@ services:
       - esnet
 
   gcs-mocker:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/google_cloud_storage/mocker.py
@@ -41,55 +41,6 @@ services:
     ports:
       - "4443:4443"
     command: ["-scheme", "http", "-port", "4443"]
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
 
 networks:
   esnet:

--- a/tests/sources/fixtures/google_drive/docker-compose.yml
+++ b/tests/sources/fixtures/google_drive/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-      image: docker.elastic.co/kibana/kibana:${VERSION}
-      ports:
-        - 5601:5601
-      extra_hosts:
-        - "host.docker.internal:host-gateway"
-      depends_on:
-          - "elasticsearch"
-      profiles:
-        - "enterprise-search"
-      environment:
-        ELASTICSEARCH_URL: http://host.docker.internal:9200
-        ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-        ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-        ELASTICSEARCH_USERNAME: kibana_system
-        ELASTICSEARCH_PASSWORD: changeme
-      networks:
-        - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   google_drive:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/google_drive/fixture.py

--- a/tests/sources/fixtures/graphql/docker-compose.yml
+++ b/tests/sources/fixtures/graphql/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,27 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
   graphql:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/graphql/fixture.py

--- a/tests/sources/fixtures/jira/docker-compose.yml
+++ b/tests/sources/fixtures/jira/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   jira:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/jira/fixture.py

--- a/tests/sources/fixtures/microsoft_teams/docker-compose.yml
+++ b/tests/sources/fixtures/microsoft_teams/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   microsoft_teams:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/microsoft_teams/fixture.py

--- a/tests/sources/fixtures/mongodb/docker-compose.yml
+++ b/tests/sources/fixtures/mongodb/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -38,54 +38,9 @@ services:
       # provide your credentials here
       - MONGO_INITDB_ROOT_USERNAME=admin
       - MONGO_INITDB_ROOT_PASSWORD=justtesting
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
 
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
+
+
 
 networks:
   mongo-network:

--- a/tests/sources/fixtures/mongodb_serverless/docker-compose.yml
+++ b/tests/sources/fixtures/mongodb_serverless/docker-compose.yml
@@ -113,36 +113,6 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=admin
       - MONGO_INITDB_ROOT_PASSWORD=justtesting
 
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "es01"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
 networks:
   mongo-network:
     driver: bridge

--- a/tests/sources/fixtures/mssql/docker-compose.yml
+++ b/tests/sources/fixtures/mssql/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -32,55 +32,6 @@ services:
       MSSQL_SA_PASSWORD: Password_123
     ports:
       - 9090:1433
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
 
 networks:
   esnet:

--- a/tests/sources/fixtures/mysql/docker-compose.yml
+++ b/tests/sources/fixtures/mysql/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -38,54 +38,9 @@ services:
       - 3306:3306
     restart: always
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
 
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
+
+
 
 networks:
   mysql-network:

--- a/tests/sources/fixtures/network_drive/docker-compose.yml
+++ b/tests/sources/fixtures/network_drive/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -33,56 +33,6 @@ services:
     restart: unless-stopped
     command: '-s "Folder1;/mnt;yes;no;yes;admin" -u "admin;abc@123" -p'
 
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
 networks:
   esnet:
   default:
@@ -90,4 +40,3 @@ networks:
 volumes:
   esdata:
     driver: local
-

--- a/tests/sources/fixtures/notion/docker-compose.yml
+++ b/tests/sources/fixtures/notion/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   notion:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/notion/fixture.py

--- a/tests/sources/fixtures/onedrive/docker-compose.yml
+++ b/tests/sources/fixtures/onedrive/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   onedrive:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/onedrive/fixture.py

--- a/tests/sources/fixtures/oracle/docker-compose.yml
+++ b/tests/sources/fixtures/oracle/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -21,55 +21,6 @@ services:
       - esdata:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
-    networks:
-      - esnet
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     networks:
       - esnet
 

--- a/tests/sources/fixtures/postgresql/docker-compose.yml
+++ b/tests/sources/fixtures/postgresql/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -36,55 +36,6 @@ services:
       - 9090:5432
     command: ["-c", "track_commit_timestamp=on"]
     restart: always
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
 
 networks:
   esnet:

--- a/tests/sources/fixtures/redis/docker-compose.yml
+++ b/tests/sources/fixtures/redis/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -34,25 +34,6 @@ services:
     ports:
       - 6379:6379
     restart: always
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
 
 networks:
   redis-network:

--- a/tests/sources/fixtures/s3/docker-compose.yml
+++ b/tests/sources/fixtures/s3/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -21,55 +21,6 @@ services:
       - esdata:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
-    networks:
-      - esnet
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     networks:
       - esnet
 

--- a/tests/sources/fixtures/salesforce/docker-compose.yml
+++ b/tests/sources/fixtures/salesforce/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -21,55 +21,6 @@ services:
       - esdata:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
-    networks:
-      - esnet
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     networks:
       - esnet
 

--- a/tests/sources/fixtures/servicenow/docker-compose.yml
+++ b/tests/sources/fixtures/servicenow/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   servicenow:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/servicenow/fixture.py

--- a/tests/sources/fixtures/sharepoint_online/docker-compose.yml
+++ b/tests/sources/fixtures/sharepoint_online/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   sharepoint_online:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/sharepoint_online/fixture.py

--- a/tests/sources/fixtures/sharepoint_server/docker-compose.yml
+++ b/tests/sources/fixtures/sharepoint_server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   sharepoint:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/sharepoint_server/fixture.py

--- a/tests/sources/fixtures/zoom/docker-compose.yml
+++ b/tests/sources/fixtures/zoom/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${VERSION}
+    image: ${ELASTICSEARCH_DRA_DOCKER_IMAGE}
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -24,57 +24,8 @@ services:
     networks:
       - esnet
 
-  kibana:
-    image: docker.elastic.co/kibana/kibana:${VERSION}
-    ports:
-      - 5601:5601
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    depends_on:
-        - "elasticsearch"
-    profiles:
-      - "enterprise-search"
-    environment:
-      ELASTICSEARCH_URL: http://host.docker.internal:9200
-      ELASTICSEARCH_HOSTS: http://host.docker.internal:9200
-      ENTERPRISESEARCH_HOST: http://host.docker.internal:3002
-      ELASTICSEARCH_USERNAME: kibana_system
-      ELASTICSEARCH_PASSWORD: changeme
-    networks:
-      - esnet
-
-  enterprise_search:
-    image: docker.elastic.co/enterprise-search/enterprise-search:${VERSION}
-    profiles:
-      - "enterprise-search"
-    depends_on:
-      - "elasticsearch"
-    environment:
-      - ENT_SEARCH_DEFAULT_PASSWORD=changeme
-      - elasticsearch.username=elastic
-      - elasticsearch.password=changeme
-      - elasticsearch.host=http://host.docker.internal:9200
-      - allow_es_settings_modification=true
-      - kibana.host=http://host.docker.internal:5601
-      - kibana.external_url=http://localhost:5601
-      - secret_management.encryption_keys=["4a2cd3f81d39bf28738c10db0ca782095ffac07279561809eecc722e0c20eb09"]
-      - JAVA_OPTS=-Xms2g -Xmx2g
-      - email.account.enabled=true
-      - email.account.smtp.auth=plain
-      - email.account.smtp.starttls.enable=false
-      - email.account.smtp.host=host.docker.internal
-      - email.account.smtp.port=1025
-      - email.account.email_defaults.from=local@example.com
-      - DEBUG=true
-    ports:
-      - 3002:3002
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    networks:
-      - esnet
-
   zoom:
-    build: 
+    build:
       context: ../../../../
       dockerfile: ${DOCKERFILE_FTEST_PATH}
     command: .venv/bin/python tests/sources/fixtures/zoom/fixture.py


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[Publishing] Load ES image for ftest from DRA artifact (#2979)](https://github.com/elastic/connectors/pull/2979)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)