### PR TITLE
Change dto for page blog documents to access fields in safe manner

### DIFF
--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -908,13 +908,19 @@ class ConfluenceDataSource(BaseDataSource):
             doc = {
                 "_id": str(document["id"]),
                 "type": document["type"],
-                "_timestamp": document["history"]["lastUpdated"]["when"],
+                "_timestamp": nested_get_from_dict(
+                    document, ["history", "lastUpdated", "when"]
+                ),
                 "title": document.get("title"),
                 "ancestors": ancestor_title,
-                "space": document["space"]["name"],
-                "body": html_to_text(document["body"]["storage"]["value"]),
+                "space": nested_get_from_dict(document, ["space", "name"]),
+                "body": html_to_text(
+                    nested_get_from_dict(document, ["body", "storage", "value"])
+                ),
                 "url": document_url,
-                "author": document["history"]["createdBy"][self.authorkey],
+                "author": nested_get_from_dict(
+                    document, ["history", "createdBy", self.authorkey]
+                ),
                 "createdDate": document["history"]["createdDate"],
             }
             if self.confluence_client.index_labels:

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -921,7 +921,9 @@ class ConfluenceDataSource(BaseDataSource):
                 "author": nested_get_from_dict(
                     document, ["history", "createdBy", self.authorkey]
                 ),
-                "createdDate": document["history"]["createdDate"],
+                "createdDate": nested_get_from_dict(
+                    document, ["history", "createdDate"]
+                ),
             }
             if self.confluence_client.index_labels:
                 doc["labels"] = document["labels"]


### PR DESCRIPTION
Minor change to replace unsafe object field access with safe one - we've received reports with errors coming from these lines because some intermediate objects were None:

```
Traceback (most recent call last):
  File "/app/connectors/sources/confluence.py", line 1154, in _page_blog_coro
    async for document, attachment_count, space_key, permissions, restrictions in self.fetch_documents(
  File "/app/connectors/sources/confluence.py", line 904, in fetch_documents
    "author": document["history"]["createdBy"][self.authorkey],
KeyError: 'publicName'
[FMWK][18:00:15][ERROR] Exception found for task Task-132
Traceback (most recent call last):
  File "/app/connectors/sources/confluence.py", line 1154, in _page_blog_coro
    async for document, attachment_count, space_key, permissions, restrictions in self.fetch_documents(
  File "/app/connectors/sources/confluence.py", line 904, in fetch_documents
    "author": document["history"]["createdBy"][self.authorkey],
KeyError: 'publicName'
```

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Fix Confluence connector not downloading some blog post documents due to unexpected response format.
