### PR TITLE
[8.17] Update for 8.17 FF (#2994)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,20 +2,15 @@
   "targetBranchChoices": [
     { "name": "main", "checked": true },
     "8.x",
+    "8.17",
     "8.16",
-    "8.15",
-    "8.14",
-    "8.13",
-    "8.12",
-    "8.11",
-    "8.10",
-    "8.9"
+    "8.15"
   ],
   "fork": false,
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v9.0.0$": "main",
-    "^v8.17.0$": "8.x",
+    "^v8.18.0$": "8.x",
     "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
   },
   "upstream": "elastic/connectors"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -567,7 +567,7 @@ steps:
   # ----
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"8.x\" || build.branch == \"8.16\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"8.x\" || build.branch == \"8.16\" || build.branch == \"8.17\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Update for 8.17 FF (#2994)](https://github.com/elastic/connectors/pull/2994)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)