### PR TITLE
Upgrade aiohttp to 3.11.7

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,4 +1,4 @@
-aiohttp==3.10.4
+aiohttp==3.11.7
 aiofiles==23.2.1
 aiomysql==0.1.1
 httpx==0.27.0


### PR DESCRIPTION
Response to https://github.com/elastic/search-team/issues/8737:

Upgrading `aiohttp` to latest.