### PR TITLE
Stringify doc[id] field

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -661,7 +661,8 @@ class Extractor:
                 if count % self.display_every == 0:
                     self._log_progress()
 
-                doc_id = doc["id"] = doc.pop("_id")
+                doc_id = doc.pop("_id")
+                doc["id"] = str(doc_id)
 
                 if self.basic_rule_engine and not self.basic_rule_engine.should_ingest(
                     doc
@@ -738,7 +739,8 @@ class Extractor:
             if count % self.display_every == 0:
                 self._log_progress()
 
-            doc_id = doc["id"] = doc.pop("_id")
+            doc_id = doc.pop("_id")
+            doc["id"] = str(doc_id)
             doc_exists = doc_id in existing_ids
 
             if doc_exists:

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -545,7 +545,8 @@ class Extractor:
                 if count % self.display_every == 0:
                     self._log_progress()
 
-                doc_id = doc["id"] = doc.pop("_id")
+                doc_id = doc.pop("_id")
+                doc["id"] = str(doc_id)
 
                 if self.basic_rule_engine and not self.basic_rule_engine.should_ingest(
                     doc

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -361,7 +361,8 @@ async def test_async_bulk(mock_responses):
 def index_operation(doc):
     # deepcopy as get_docs mutates docs
     doc_copy = deepcopy(doc)
-    doc_id = doc_copy["id"] = doc_copy.pop("_id")
+    doc_id = doc_copy.pop("_id")
+    doc_copy["id"] = str(doc_id)
 
     return {"_op_type": "index", "_index": INDEX, "_id": doc_id, "doc": doc_copy}
 
@@ -369,7 +370,8 @@ def index_operation(doc):
 def update_operation(doc):
     # deepcopy as get_docs mutates docs
     doc_copy = deepcopy(doc)
-    doc_id = doc_copy["id"] = doc_copy.pop("_id")
+    doc_id = doc_copy.pop("_id")
+    doc_copy["id"] = str(doc_id)
 
     return {"_op_type": "update", "_index": INDEX, "_id": doc_id, "doc": doc_copy}
 
@@ -1262,7 +1264,7 @@ async def test_sync_orchestrator_done_and_cleanup(
 
 @pytest.mark.asyncio
 async def test_extractor_put_doc():
-    doc = {"id": 123}
+    doc = {"id": "123"}
     queue = Mock()
     queue.put = AsyncMock()
     extractor = Extractor(
@@ -1305,7 +1307,7 @@ async def test_extractor_get_docs_when_downloads_fail(
 
 @pytest.mark.asyncio
 async def test_force_canceled_extractor_put_doc():
-    doc = {"id": 123}
+    doc = {"id": "123"}
     queue = Mock()
     queue.put = AsyncMock()
     extractor = Extractor(

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -1264,7 +1264,7 @@ async def test_sync_orchestrator_done_and_cleanup(
 
 @pytest.mark.asyncio
 async def test_extractor_put_doc():
-    doc = {"id": "123"}
+    doc = {"id": 123}
     queue = Mock()
     queue.put = AsyncMock()
     extractor = Extractor(
@@ -1307,7 +1307,7 @@ async def test_extractor_get_docs_when_downloads_fail(
 
 @pytest.mark.asyncio
 async def test_force_canceled_extractor_put_doc():
-    doc = {"id": "123"}
+    doc = {"id": 123}
     queue = Mock()
     queue.put = AsyncMock()
     extractor = Extractor(


### PR DESCRIPTION
## Changes

Always stringify `doc["id"]` field. The default index mappings were removed in https://github.com/elastic/connectors/pull/3013. 

This limits the scenario of running into weird issues with ES mappings for numeric-like ID fields (overflows, etc). ID should be keyword never numeric ideally.