### PR TITLE
[8.x] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to bed0cbf (#3006)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:c059ea437c85aed56004fdd71dd8c2146f3b7355183d8db443ca3d1aa90e173f
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:bed0cbfaaf9595e238b0ddaeb0e05a966ffe7d5bc992fc72142779861367a349
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:c059ea437c85aed56004fdd71dd8c2146f3b7355183d8db443ca3d1aa90e173f
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:bed0cbfaaf9595e238b0ddaeb0e05a966ffe7d5bc992fc72142779861367a349
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to bed0cbf (#3006)](https://github.com/elastic/connectors/pull/3006)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)