### PR TITLE
[8.17] Allow Insecure HTTPS  (#2913)

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -54,6 +54,11 @@
 #elasticsearch.ssl: true
 #
 #
+##  Whether to perform verification checks for server certificates using CA bundle.
+##    This option should be avoided in production.
+#elasticsearch.verify_certs: true
+#
+#
 ##  Path to a CA bundle, e.g. /path/to/ca.crt
 #elasticsearch.ca_certs: null
 #

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -64,6 +64,7 @@ def _default_config():
             "username": "elastic",
             "password": "changeme",
             "ssl": True,
+            "verify_certs": True,
             "bulk": {
                 "queue_max_size": 1024,
                 "queue_max_mem_size": 25,

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -87,11 +87,14 @@ class ESClient:
             logger.debug(f"Connecting using Basic Auth (user: {config['username']})")
 
         if config.get("ssl", False):
-            options["verify_certs"] = True
-            if "ca_certs" in config:
-                ca_certs = config["ca_certs"]
-                logger.debug(f"Verifying cert with {ca_certs}")
-                options["ca_certs"] = ca_certs
+            options["verify_certs"] = config.get("verify_certs", True)
+            if options["verify_certs"]:
+                if "ca_certs" in config:
+                    ca_certs = config["ca_certs"]
+                    logger.debug(f"Verifying cert with {ca_certs}")
+                    options["ca_certs"] = ca_certs
+                else:
+                    logger.debug("Verifying cert with system certificates")
 
         level = config.get("log_level", "INFO").upper()
         es_logger = logging.getLogger("elastic_transport.node")

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -12,11 +12,12 @@ Please refer to the following Docker image registry to access and pull available
 
 Follow these steps:
 
-1. [Create network](#1-create-a-docker-network)
-2. [Create directory](#2-create-a-directory-to-be-mounted-into-the-docker-image)
-3. [Download config file](#3-download-sample-configuration-file-from-this-repository-into-newly-created-directory)
-4. [Update config file](#4-update-the-configuration-file-for-your-self-managed-connectorhttpswwwelasticcoguideenenterprise-searchcurrentbuild-connectorhtmlbuild-connector-usage)
-5. [Run the docker image](#5-run-the-docker-image)
+- [Run Connector Service in Docker](#run-connector-service-in-docker)
+  - [1. Create a Docker network.](#1-create-a-docker-network)
+  - [2. Create a directory to be mounted into the Docker image.](#2-create-a-directory-to-be-mounted-into-the-docker-image)
+  - [3. Download sample configuration file from this repository into newly created directory.](#3-download-sample-configuration-file-from-this-repository-into-newly-created-directory)
+  - [4. Update the configuration file for your self-managed connector](#4-update-the-configuration-file-for-your-self-managed-connector)
+  - [5. Run the Docker image.](#5-run-the-docker-image)
 
 ## 1. Create a Docker network.
 
@@ -111,3 +112,8 @@ You might need to adjust some details here:
 > ```
 > elasticsearch.ca_certs: /usr/share/connectors/config/certs/ca/ca.crt
 > ```
+> 3. To avoid the certificate verification, configure `verify_certs` parameter which is `true` by default when SSL is enabled in connector service's `config.yml` as:
+> ```
+> elasticsearch.verify_certs: false
+> ```
+> Disclaimer: Setting `verify_certs` to `false` is not recommended in a production environment, as it may expose your application to security vulnerabilities.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Allow Insecure HTTPS  (#2913)](https://github.com/elastic/connectors/pull/2913)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)