### PR TITLE
also cast doc_id to str

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -545,8 +545,8 @@ class Extractor:
                 if count % self.display_every == 0:
                     self._log_progress()
 
-                doc_id = doc.pop("_id")
-                doc["id"] = str(doc_id)
+                doc_id = str(doc.pop("_id"))
+                doc["id"] = doc_id
 
                 if self.basic_rule_engine and not self.basic_rule_engine.should_ingest(
                     doc

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -485,14 +485,18 @@ class Extractor:
         await self.queue.put(doc)
 
     async def run(self, generator, job_type):
-        sanitized_generator = ((sanitize(doc), *other) async for doc, *other in generator)
+        sanitized_generator = (
+            (sanitize(doc), *other) async for doc, *other in generator
+        )
         try:
             match job_type:
                 case JobType.FULL:
                     await self.get_docs(sanitized_generator)
                 case JobType.INCREMENTAL:
                     if self.skip_unchanged_documents:
-                        await self.get_docs(sanitized_generator, skip_unchanged_documents=True)
+                        await self.get_docs(
+                            sanitized_generator, skip_unchanged_documents=True
+                        )
                     else:
                         await self.get_docs_incrementally(sanitized_generator)
                 case JobType.ACCESS_CONTROL:

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -986,6 +986,7 @@ def sanitize(doc):
 
     return doc
 
+
 class Counters:
     """
     A utility to provide code readability to managing a collection of counts

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -978,6 +978,14 @@ def nested_get_from_dict(dictionary, keys, default=None):
     return nested_get(dictionary, keys, default)
 
 
+def sanitize(doc):
+    if doc["_id"]:
+        # guarantee that IDs are strings, and not numeric
+        doc["_id"] = str(doc["_id"])
+        doc["id"] = doc["_id"]
+
+    return doc
+
 class Counters:
     """
     A utility to provide code readability to managing a collection of counts

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -361,8 +361,8 @@ async def test_async_bulk(mock_responses):
 def index_operation(doc):
     # deepcopy as get_docs mutates docs
     doc_copy = deepcopy(doc)
-    doc_id = doc_copy.pop("_id")
-    doc_copy["id"] = str(doc_id)
+    doc_id = str(doc_copy.pop("_id"))
+    doc_copy["id"] = doc_id
 
     return {"_op_type": "index", "_index": INDEX, "_id": doc_id, "doc": doc_copy}
 
@@ -370,14 +370,14 @@ def index_operation(doc):
 def update_operation(doc):
     # deepcopy as get_docs mutates docs
     doc_copy = deepcopy(doc)
-    doc_id = doc_copy.pop("_id")
-    doc_copy["id"] = str(doc_id)
+    doc_id = str(doc_copy.pop("_id"))
+    doc_copy["id"] = doc_id
 
     return {"_op_type": "update", "_index": INDEX, "_id": doc_id, "doc": doc_copy}
 
 
 def delete_operation(doc):
-    return {"_op_type": "delete", "_index": INDEX, "_id": doc["_id"]}
+    return {"_op_type": "delete", "_index": INDEX, "_id": str(doc["_id"])}
 
 
 def end_docs_operation():
@@ -730,7 +730,7 @@ async def test_get_docs(
     lazy_downloads = await lazy_downloads_mock()
 
     yield_existing_documents_metadata.return_value = AsyncIterator(
-        [(doc["_id"], doc["_timestamp"]) for doc in existing_docs]
+        [(str(doc["_id"]), doc["_timestamp"]) for doc in existing_docs]
     )
 
     with mock.patch("connectors.utils.ConcurrentTasks", return_value=lazy_downloads):
@@ -1020,7 +1020,7 @@ async def test_get_access_control_docs(
     expected_total_docs_deleted,
 ):
     yield_existing_documents_metadata.return_value = AsyncIterator(
-        [(doc["_id"], doc["_timestamp"]) for doc in existing_docs]
+        [(str(doc["_id"]), doc["_timestamp"]) for doc in existing_docs]
     )
 
     queue = await queue_mock()


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/8956

We were ensuring that the ingested `doc[id]` was a string, but at the time we computed:
```
                if doc_id in existing_ids:
```

`doc_id` could be numeric, but `existing_ids` were guaranteed to be strings.

## Checklists



#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

### Release Note

Fixes a bug where full syncs may delete documents they just ingested if the document ID when fetched from the 3rd party was numeric.