### PR TITLE
[8.x] Update elasticsearch client to 8.17 (#3033)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3441,7 +3441,7 @@ SOFTWARE
   to the Commercial Software.
 
 elasticsearch
-8.16.0
+8.17.0
 Apache Software License
 
                                  Apache License

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -3,7 +3,7 @@ aiofiles==23.2.1
 aiomysql==0.1.1
 httpx==0.27.0
 httpx-ntlm==1.4.0
-elasticsearch[async]==8.16.0
+elasticsearch[async]==8.17.0
 elastic-transport==8.15.1
 pyyaml==6.0.1
 cffi==1.16.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Update elasticsearch client to 8.17 (#3033)](https://github.com/elastic/connectors/pull/3033)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)