### PR TITLE
Fix mysql advanced sync rule execute error

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -638,7 +638,7 @@ class MySqlDataSource(BaseDataSource):
             )
             return
 
-        async for row in client.yield_rows_for_query(query):
+        async for row in client.yield_rows_for_query(query, primary_key_columns):
             yield row2doc(
                 row=row,
                 column_names=column_names,


### PR DESCRIPTION
BUG: When configuring the advanced sync rule for the MySQL connector, the sync action throws an error: 'MySQLClient.yield_rows_for_query() missing 1 required positional argument: 'primary_key_columns''.

Root Cause: The yield_rows_for_query method is called without the required primary_key_columns parameter.

Fix: Add the missing primary_key_columns parameter when calling the yield_rows_for_query method.