### PR TITLE
[8.17] Update aiohttp to latest (#3040)

### DIFF
--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,4 +1,4 @@
-aiohttp==3.10.4
+aiohttp==3.11.10
 aiofiles==23.2.1
 aiomysql==0.1.1
 httpx==0.27.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Update aiohttp to latest (#3040)](https://github.com/elastic/connectors/pull/3040)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)