### PR TITLE
Replace 'ent-search-generic' with 'search-default' pipeline

### DIFF
--- a/connectors/cli/connector.py
+++ b/connectors/cli/connector.py
@@ -167,7 +167,7 @@ class Connector:
                 "custom_scheduling": {},
                 "pipeline": {
                     "extract_binary_content": True,
-                    "name": "ent-search-generic-ingestion",
+                    "name": "search-default-ingestion",
                     "reduce_whitespace": True,
                     "run_ml_inference": True,
                 },

--- a/connectors/kibana.py
+++ b/connectors/kibana.py
@@ -53,7 +53,7 @@ async def prepare(service_type, index_name, config, connector_definition=None):
     connector_index = ConnectorIndex(config["elasticsearch"])
 
     await es.ensure_ingest_pipeline_exists(
-        "ent-search-generic-ingestion",
+        "search-default-ingestion",
         DEFAULT_PIPELINE["version"],
         DEFAULT_PIPELINE["description"],
         DEFAULT_PIPELINE["processors"],

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -555,7 +555,7 @@ class Filter(dict):
 
 
 PIPELINE_DEFAULT = {
-    "name": "ent-search-generic-ingestion",
+    "name": "search-default-ingestion",
     "extract_binary_content": True,
     "reduce_whitespace": True,
     "run_ml_inference": True,

--- a/docs/CONNECTOR_PROTOCOL.md
+++ b/docs/CONNECTOR_PROTOCOL.md
@@ -180,7 +180,7 @@ This is our main communication index, used to communicate the connector's config
   "_meta" : {
     "pipeline" : {
       "default_extract_binary_content" : true,
-      "default_name" : "ent-search-generic-ingestion",
+      "default_name" : "search-default-ingestion",
       "default_reduce_whitespace" : true,
       "default_run_ml_inference" : true
     },

--- a/tests/fixtures/connector.json
+++ b/tests/fixtures/connector.json
@@ -103,7 +103,7 @@
         "scheduling": {"full": {"enabled": true, "interval": "1 * * * * *"}},
         "pipeline": {
                 "extract_binary_content": true,
-                "name": "ent-search-generic-ingestion",
+                "name": "search-default-ingestion",
                 "reduce_whitespace": true,
                 "run_ml_inference": true
         }

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -2300,7 +2300,7 @@ def test_has_validation_state(
 @pytest.mark.parametrize(
     "key, value, default_value",
     [
-        ("name", "foobar", "ent-search-generic-ingestion"),
+        ("name", "foobar", "search-default-ingestion"),
         ("extract_binary_content", False, True),
         ("reduce_whitespace", False, True),
         ("run_ml_inference", False, True),

--- a/tests/test_kibana.py
+++ b/tests/test_kibana.py
@@ -50,7 +50,7 @@ def test_main(patch_logger, mock_responses):
     )
     mock_index_creation("data", mock_responses, hidden=False)
     mock_responses.get(
-        "http://nowhere.com:9200/_ingest/pipeline/ent-search-generic-ingestion",
+        "http://nowhere.com:9200/_ingest/pipeline/search-default-ingestion",
         headers=headers,
         repeat=True,
     )

--- a/tests/test_service_cli.py
+++ b/tests/test_service_cli.py
@@ -33,7 +33,7 @@ def test_main_exits_on_sigterm(mock_responses):
     mock_responses.head(f"{host}/.elastic-connectors", headers=headers)
     mock_responses.head(f"{host}/.elastic-connectors-sync-jobs", headers=headers)
     mock_responses.get(
-        f"{host}/_ingest/pipeline/ent-search-generic-ingestion", headers=headers
+        f"{host}/_ingest/pipeline/search-default-ingestion", headers=headers
     )
 
     async def kill():

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -262,7 +262,7 @@ def set_responses(mock_responses, ts=None):
     )
 
     mock_responses.put(
-        "http://nowhere.com:9200/_bulk?pipeline=ent-search-generic-ingestion",
+        "http://nowhere.com:9200/_bulk?pipeline=search-default-ingestion",
         payload={
             "took": 7,
             "errors": False,


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/8812

The `search-default-ingestion` pipeline was added in 8.15 through https://github.com/elastic/elasticsearch/pull/107558

In 9.0, Enterprise Search is going away, so we no longer want to reference "Enterprise Search" or "Ent Search". This pipeline is identical, just with a different name.

## Checklists


#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes


## Related Pull Requests


* Elasticsearch/docs changes: https://github.com/elastic/elasticsearch/pull/118899
* Kibana changes: TODO

## Release Note

The Connectors default pipeline is now `search-default-ingestion` rather than `ent-search-generic-ingestion`. These pipelines have identical functionality, only the name is different.
