### PR TITLE
Set connector status to CONNECTED after successful validation and ping

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -819,6 +819,14 @@ class Connector(ESDocument):
         }
         await self.index.update(doc_id=self.id, doc=doc)
 
+    async def connected(self):
+        doc = {
+            "status": Status.CONNECTED.value,
+            "error": None
+
+        }
+        await self.index.update(doc_id=self.id, doc=doc)
+
     async def sync_done(self, job, cursor=None):
         job_status = JobStatus.ERROR if job is None else job.status
         job_error = JOB_NOT_FOUND_ERROR if job is None else job.error

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -820,11 +820,7 @@ class Connector(ESDocument):
         await self.index.update(doc_id=self.id, doc=doc)
 
     async def connected(self):
-        doc = {
-            "status": Status.CONNECTED.value,
-            "error": None
-
-        }
+        doc = {"status": Status.CONNECTED.value, "error": None}
         await self.index.update(doc_id=self.id, doc=doc)
 
     async def sync_done(self, job, cursor=None):

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -107,7 +107,9 @@ class JobSchedulingService(BaseService):
             if connector.features.sync_rules_enabled():
                 await connector.validate_filtering(validator=data_source)
 
-            self.logger.info("Connector is configured correctly and can reach the data source")
+            self.logger.info(
+                "Connector is configured correctly and can reach the data source"
+            )
             await connector.connected()
         except Exception as e:
             connector.log_error(e, exc_info=True)

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -106,6 +106,9 @@ class JobSchedulingService(BaseService):
 
             if connector.features.sync_rules_enabled():
                 await connector.validate_filtering(validator=data_source)
+
+            self.logger.info("Connector is configured correctly and can reach the data source")
+            await connector.connected()
         except Exception as e:
             connector.log_error(e, exc_info=True)
             await connector.error(e)

--- a/tests/commons.py
+++ b/tests/commons.py
@@ -15,18 +15,28 @@ class AsyncIterator:
     Async documents generator fake class, which records the args and kwargs it was called with.
     """
 
-    def __init__(self, items):
+    def __init__(self, items, reusable=False):
+        """
+        AsyncIterator is a test-only abstraction to mock async iterables.
+        By default it's usable only once: once iterated over, he iterator will not
+        iterate again any more.
+        If reusable is True, then iterator can be re-used, but only if it's used by a single coroutine.
+        If AsyncIterator is used in several coroutines, it'll not work correctly at all
+        """
         self.items = items
         self.call_args = []
         self.call_kwargs = []
         self.i = 0
         self.call_count = 0
+        self.reusable = reusable
 
     def __aiter__(self):
         return self
 
     async def __anext__(self):
         if self.i >= len(self.items):
+            if self.reusable:
+                self.i = 0
             raise StopAsyncIteration
 
         item = self.items[self.i]

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -403,7 +403,9 @@ async def test_run_when_connector_failed_validation_then_succeeded(
     data_source_mock.close = AsyncMock()
 
     connector = mock_connector(next_sync=datetime.now(timezone.utc))
-    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector], reusable=True)
+    connector_index_mock.supported_connectors.return_value = AsyncIterator(
+        [connector], reusable=True
+    )
     await create_and_run_service(JobSchedulingService, stop_after=0.15)
 
     data_source_mock.validate_config_fields.assert_called()


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3021
## Closes https://github.com/elastic/search-team/issues/8535

Currently connectors have no way to report they're connected.

This PR makes it so that if a data source succeeds in validation and ping, then its status is set to CONNECTED.

In practice it means, that a user who had problems with their setup will see an error in UI. If they fix the credentials, before the error would go away after a sync starts. After this change the error will disappear within the service poll interval from user's action.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Release Note

Fix a UI issue with connector reporting problems with connection even if wrong configuration was fixed. Before the error would go away only when a sync is executed.
