### PR TITLE
Make config.yml an order dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ DOCKERFILE_FTEST_PATH?=Dockerfile.ftest
 config.yml:
 	- cp -n config.yml.example config.yml
 
-.venv/bin/python: config.yml
+.venv/bin/python: | config.yml
 	$(PYTHON) -m venv .venv
 	.venv/bin/pip install --upgrade pip
 	.venv/bin/pip install --upgrade setuptools


### PR DESCRIPTION
Minor improvement for local development: running `make` commands will not re-init your venv and dependencies any more unless it's really needed.

Before every time you ran a makefile command that has `config.yml` as a dependency, your whole venv gets reinitialised:

```
artemshelkovnikov-m2@Mac connectors-py % make lint
python3 -m venv .venv
.venv/bin/pip install --upgrade pip
... tons of stuff that reinstalls requirements.txt
```

This happened because of this dependency:

```
.venv/bin/python: config.yml
```

Running make in debug mode explains why:

```
Considering target file `lint'.
 File `lint' does not exist.
  Considering target file `.venv/bin/python'.
    Considering target file `config.yml'.
     Finished prerequisites of target file `config.yml'.
    No need to remake target `config.yml'.
   Finished prerequisites of target file `.venv/bin/python'.
   Prerequisite `config.yml' is newer than target `.venv/bin/python'.
  Must remake target `.venv/bin/python'.
```

So if `config.yml` has timestamp later that `.venv/bin/python` (and it happens often), running any rule that depends on `config.yml` forces whole reinstall.

Instead I swap to order-only prerequisite for this rule: https://www.gnu.org/software/make/manual/make.html#Prerequisite-Types