### PR TITLE
Use actual PyPi version of elastic-agent-client

### DIFF
--- a/requirements/agent.txt
+++ b/requirements/agent.txt
@@ -1,1 +1,1 @@
-elastic-agent-client@git+https://github.com/elastic/python-elastic-agent-client@main
+elastic-agent-client==0.0.1.dev1


### PR DESCRIPTION
Noticed a NOTICE.txt update in https://github.com/elastic/connectors/pull/3085 that should not have been there.

Happens because we use `python-elastic-agent-client` from `main` of the repo, not from PyPi, fixing this.