### PR TITLE
Don't run CI github actions that commit/push on forks

### DIFF
--- a/.buildkite/run_linter.sh
+++ b/.buildkite/run_linter.sh
@@ -8,7 +8,7 @@ source .buildkite/publish/git-setup.sh
 
 init_python
 
-if is_pr; then
+if is_pr && ! is_fork; then
   echo "We're on PR, running autoformat"
   if ! make autoformat ; then
     echo "make autoformat ran with errors, exiting"

--- a/.buildkite/run_linter.sh
+++ b/.buildkite/run_linter.sh
@@ -30,10 +30,9 @@ if is_pr && ! is_fork; then
     exit 1
   fi
 else
-  echo "We're not on PR, running only linter"
+  echo "We're not on PR or running against fork, running only linter"
   # On non-PR branches the bot has no permissions to open PRs.
   # Theoretically this would never fail because we always ask
   # linter to succeed to merge. It can fail intermittently?
   make lint
-  return
 fi

--- a/.buildkite/run_notice_check.sh
+++ b/.buildkite/run_notice_check.sh
@@ -14,7 +14,7 @@ if [ -z "$(git status --porcelain | grep NOTICE.txt)" ]; then
   exit 0
 else 
   git --no-pager diff
-  if is_pr; then
+  if is_pr && ! is_fork; then
     export GH_TOKEN="$VAULT_GITHUB_TOKEN"
 
     git add NOTICE.txt

--- a/.buildkite/shared.sh
+++ b/.buildkite/shared.sh
@@ -34,3 +34,11 @@ is_pr() {
     return 0 # true
   fi
 }
+
+is_fork() {
+  if [ "BUILDKITE_PULL_REQUEST_REPO" = "https://github.com/elastic/connectors.git"]; then
+    return 1 # false
+  else
+    return 0 # true
+  fi
+}


### PR DESCRIPTION
Subj:

Our machine might not have access to forks, so let's not do git commands on it and just fail steps if notice/autoformat fails.