### PR TITLE
Avoid git commands when running against a fork

### DIFF
--- a/.buildkite/run_linter.sh
+++ b/.buildkite/run_linter.sh
@@ -30,10 +30,9 @@ if is_pr && ! is_fork; then
     exit 1
   fi
 else
-  echo "We're not on PR, running only linter"
+  echo "We're not on PR or running against a fork, running only linter"
   # On non-PR branches the bot has no permissions to open PRs.
   # Theoretically this would never fail because we always ask
   # linter to succeed to merge. It can fail intermittently?
   make lint
-  return
 fi

--- a/.buildkite/run_linter.sh
+++ b/.buildkite/run_linter.sh
@@ -8,7 +8,7 @@ source .buildkite/publish/git-setup.sh
 
 init_python
 
-if is_pr; then
+if is_pr && ! is_fork; then
   echo "We're on PR, running autoformat"
   if ! make autoformat ; then
     echo "make autoformat ran with errors, exiting"

--- a/.buildkite/run_linter.sh
+++ b/.buildkite/run_linter.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 source .buildkite/shared.sh
-source .buildkite/publish/git-setup.sh
 
 init_python
 
@@ -19,6 +18,7 @@ if is_pr && ! is_fork; then
     echo "Nothing to be fixed by autoformat"
     exit 0
   else
+    source .buildkite/publish/git-setup.sh
     git --no-pager diff
     echo "linting errors are fixed, pushing the diff"
     export GH_TOKEN="$VAULT_GITHUB_TOKEN"

--- a/.buildkite/run_notice_check.sh
+++ b/.buildkite/run_notice_check.sh
@@ -14,7 +14,7 @@ if [ -z "$(git status --porcelain | grep NOTICE.txt)" ]; then
   exit 0
 else 
   git --no-pager diff
-  if is_pr; then
+  if is_pr && ! is_fork; then
     export GH_TOKEN="$VAULT_GITHUB_TOKEN"
 
     git add NOTICE.txt

--- a/.buildkite/run_notice_check.sh
+++ b/.buildkite/run_notice_check.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 source .buildkite/shared.sh
-source .buildkite/publish/git-setup.sh
 
 init_python
 
@@ -15,6 +14,7 @@ if [ -z "$(git status --porcelain | grep NOTICE.txt)" ]; then
 else 
   git --no-pager diff
   if is_pr && ! is_fork; then
+    source .buildkite/publish/git-setup.sh
     export GH_TOKEN="$VAULT_GITHUB_TOKEN"
 
     git add NOTICE.txt

--- a/.buildkite/shared.sh
+++ b/.buildkite/shared.sh
@@ -34,3 +34,11 @@ is_pr() {
     return 0 # true
   fi
 }
+
+is_fork() {
+  if [ "BUILDKITE_PULL_REQUEST_REPO" = "https://github.com/elastic/connectors.git"]; then
+    return 1 # false
+  else
+    return 0 # true
+  fi
+}


### PR DESCRIPTION
See failure of CI in PR https://github.com/elastic/connectors/pull/3090: https://buildkite.com/elastic/connectors/builds/15589#01945040-19d0-4239-915a-173479f8aee8

```
++ git switch -
--
  | Warning: you are leaving 2 commits behind, not connected to
  | any of your branches:
  |  
  | 824f57b6 use rstrip for lists to remove whitespace
  | cf502ec0 remove '' as a space with trailing comma
  |  
  | If you want to keep them by creating a new branch, this may be a good time
  | to do so with:
  |  
  | git branch <new-branch-name> 824f57b6
  |  
  | Switched to branch 'main'
  | Your branch is up to date with 'origin/main'.
  | ++ git checkout meghanmurphy1:confluence-trailing-comma
  | error: pathspec 'meghanmurphy1:confluence-trailing-comma' did not match any file(s) known to git
  | 🚨 Error: The command exited with status 1
  | user command error: exit status 1
```

I happens because forks are not known to Buildkite agent. Forks will not by default give permissions to Elasitc agents, so we cannot really push anything into them. This PR just makes forks treated same way we treat `main` branch: just report failures, don't try to fix them.