### PR TITLE
DRA release pipeline, pass qualifier to release cli

### DIFF
--- a/.buildkite/publish/dra/publish-daily-release-artifact.sh
+++ b/.buildkite/publish/dra/publish-daily-release-artifact.sh
@@ -87,4 +87,5 @@ docker run --rm \
       --commit "${REVISION}" \
       --workflow "${WORKFLOW}" \
       --version "${VERSION}" \
+      --qualifier "$VERSION_QUALIFIER" \
       --artifact-set main

--- a/.buildkite/publish/dra/publish-daily-release-artifact.sh
+++ b/.buildkite/publish/dra/publish-daily-release-artifact.sh
@@ -87,5 +87,5 @@ docker run --rm \
       --commit "${REVISION}" \
       --workflow "${WORKFLOW}" \
       --version "${VERSION}" \
-      --qualifier "$VERSION_QUALIFIER" \
+      --qualifier "${VERSION_QUALIFIER}" \
       --artifact-set main


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/9111

It seems like we need to pass `--qualifier` to the release pipeline. Reading the cli implementation, I understand this is an optional arg ([source](https://github.com/elastic/infra/blob/19bde2ec72bb79075755ade7b5a14e6e85fd9267/cd/release/release-manager/docker-entrypoint.sh#L254)) so skipping checks for undefined.

If I understand correctly, we only ever populate this via manual trigger of release pipeline. 