### PR TITLE
Auto-backport Renovate PRs

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -11,7 +11,7 @@
   "branchLabelMapping": {
     "^v9.0.0$": "main",
     "^v8.18.0$": "8.x",
-    "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
+    "^v(\\d+).(\\d+)(.\\d+)*$": "$1.$2"
   },
   "upstream": "elastic/connectors"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,13 @@
     "local>elastic/renovate-config",
     "github>elastic/renovate-config:only-chainguard"
   ],
+  "labels": [
+    "renovate",
+    "auto-backport",
+    "v8.16",
+    "v8.17",
+    "v9.0.0"
+  ],
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
This PR enables auto-backport of Renovate PRs (when merged to `main`) to branches corresponding to currently open minor versions.