### PR TITLE
Revert "DRA release pipeline, pass qualifier to release cli"

### DIFF
--- a/.buildkite/publish/dra/publish-daily-release-artifact.sh
+++ b/.buildkite/publish/dra/publish-daily-release-artifact.sh
@@ -87,5 +87,4 @@ docker run --rm \
       --commit "${REVISION}" \
       --workflow "${WORKFLOW}" \
       --version "${VERSION}" \
-      --qualifier "${VERSION_QUALIFIER}" \
       --artifact-set main


### PR DESCRIPTION
Reverts elastic/connectors#3101

We've determined this doesn't resolve https://github.com/elastic/search-team/issues/9111, and it's breaking CI, so let's just take it out until we can revist.