### PR TITLE
[8.16] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 4ce83a8 (#3108)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:bed0cbfaaf9595e238b0ddaeb0e05a966ffe7d5bc992fc72142779861367a349
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:4ce83a86c3e27c6f4c308f477024d85b62edcf236f209b6ec64556f87f3e5ae5
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:bed0cbfaaf9595e238b0ddaeb0e05a966ffe7d5bc992fc72142779861367a349
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:4ce83a86c3e27c6f4c308f477024d85b62edcf236f209b6ec64556f87f3e5ae5
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 4ce83a8 (#3108)](https://github.com/elastic/connectors/pull/3108)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)