### PR TITLE
Enable basic DRA qualifiers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -578,8 +578,7 @@ steps:
   # ----
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    # TODO: fix
-    if: "(build.branch == \"seanstory/9111-add-dra-qualifier\" || build.branch == \"main\" || build.branch == \"8.x\" || build.branch == \"8.16\" || build.branch == \"8.17\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"8.x\" || build.branch == \"8.16\" || build.branch == \"8.17\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -578,7 +578,8 @@ steps:
   # ----
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"8.x\" || build.branch == \"8.16\" || build.branch == \"8.17\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    # TODO: fix
+    if: "(build.branch == \"seanstory/9111-add-dra-qualifier\" || build.branch == \"main\" || build.branch == \"8.x\" || build.branch == \"8.16\" || build.branch == \"8.17\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -57,6 +57,10 @@ fi
 if [[ "${BUILDKITE_BRANCH:-}" =~ ([0-9]\.[0-9x]*$) ]]; then
   export PUBLISH_STAGING="true"
 fi
+if [ -n "${VERSION_QUALIFIER:-}" ]; then
+  # this is a special case where we will release a pre-release artifact, regardless of branch
+  export PUBLISH_STAGING="true"
+fi
 
 # Sanity check in the logs to list the downloaded artifacts
 chmod -R a+rw "${RELEASE_DIR}/dist"
@@ -149,12 +153,19 @@ fi
 
 # generate the dependency report and publish STAGING artifacts
 if [[ "${PUBLISH_STAGING:-}" == "true" ]]; then
-  dependencyReportName="dependencies-${VERSION}.csv";
+  if [ -n "${VERSION_QUALIFIER:-}" ]; then
+    dependencyReportName="dependencies-${VERSION}-${VERSION_QUALIFIER}.csv";
+    artifact_name="connectors-${VERSION}-${VERSION_QUALIFIER}.zip"
+  else
+    dependencyReportName="dependencies-${VERSION}.csv";
+    artifact_name="connectors-${VERSION}.zip"
+  fi
+
   echo "-------- Generating STAGING dependency report: ${dependencyReportName}"
   generateDependencyReport $DEPENDENCIES_REPORTS_DIR/$dependencyReportName
 
   echo "-------- Publishing STAGING DRA Artifacts"
-  cp $RELEASE_DIR/dist/elasticsearch_connectors-${VERSION}.zip $DRA_ARTIFACTS_DIR/connectors-${VERSION}.zip
+  cp $RELEASE_DIR/dist/elasticsearch_connectors-${VERSION}.zip $DRA_ARTIFACTS_DIR/${artifact_name}
   setDraVaultCredentials
   export WORKFLOW="staging"
 

--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -155,17 +155,19 @@ fi
 if [[ "${PUBLISH_STAGING:-}" == "true" ]]; then
   if [ -n "${VERSION_QUALIFIER:-}" ]; then
     dependencyReportName="dependencies-${VERSION}-${VERSION_QUALIFIER}.csv";
-    artifact_name="connectors-${VERSION}-${VERSION_QUALIFIER}.zip"
+    zip_artifact_name="connectors-${VERSION}-${VERSION_QUALIFIER}.zip"
+    cp $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-docker-image-linux-amd64.tar.gz $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-$VERSION_QUALIFIER-docker-image-linux-amd64.tar.gz
+    cp $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-docker-image-linux-arm64.tar.gz $DRA_ARTIFACTS_DIR/$PROJECT_NAME-$VERSION-$VERSION_QUALIFIER-docker-image-linux-arm64.tar.gz
   else
     dependencyReportName="dependencies-${VERSION}.csv";
-    artifact_name="connectors-${VERSION}.zip"
+    zip_artifact_name="connectors-${VERSION}.zip"
   fi
 
   echo "-------- Generating STAGING dependency report: ${dependencyReportName}"
   generateDependencyReport $DEPENDENCIES_REPORTS_DIR/$dependencyReportName
 
   echo "-------- Publishing STAGING DRA Artifacts"
-  cp $RELEASE_DIR/dist/elasticsearch_connectors-${VERSION}.zip $DRA_ARTIFACTS_DIR/${artifact_name}
+  cp $RELEASE_DIR/dist/elasticsearch_connectors-${VERSION}.zip $DRA_ARTIFACTS_DIR/${zip_artifact_name}
   setDraVaultCredentials
   export WORKFLOW="staging"
 

--- a/.buildkite/publish/dra/publish-daily-release-artifact.sh
+++ b/.buildkite/publish/dra/publish-daily-release-artifact.sh
@@ -74,22 +74,18 @@ ls -lah ${RELEASE_DIR}/dist
 echo "Contents of 'dra-artifacts' subdir"
 ls -lah $DRA_ARTIFACTS_DIR
 
-# TODO: put this back
-echo "We would now execute:
-
 docker run --rm \
   --name release-manager \
   -e VAULT_ADDR \
   -e VAULT_ROLE_ID \
   -e VAULT_SECRET_ID \
-  --mount type=bind,readonly=false,src=\"${RELEASE_DIR}/dist\",target=\"/artifacts\" \
+  --mount type=bind,readonly=false,src="${RELEASE_DIR}/dist",target="/artifacts" \
   docker.elastic.co/infra/release-manager:latest \
   cli collect \
-      --project \"${GIT_REPO}\" \
-      --branch \"${BRANCH_NAME}\" \
-      --commit \"${REVISION}\" \
-      --workflow \"${WORKFLOW}\" \
-      --version \"${VERSION}\" \
-      --qualifier \"${VERSION_QUALIFIER:-}\" \
+      --project "${GIT_REPO}" \
+      --branch "${BRANCH_NAME}" \
+      --commit "${REVISION}" \
+      --workflow "${WORKFLOW}" \
+      --version "${VERSION}" \
+      --qualifier "${VERSION_QUALIFIER:-}" \
       --artifact-set main
-"

--- a/.buildkite/publish/dra/publish-daily-release-artifact.sh
+++ b/.buildkite/publish/dra/publish-daily-release-artifact.sh
@@ -74,17 +74,22 @@ ls -lah ${RELEASE_DIR}/dist
 echo "Contents of 'dra-artifacts' subdir"
 ls -lah $DRA_ARTIFACTS_DIR
 
+# TODO: put this back
+echo "We would now execute:
+
 docker run --rm \
   --name release-manager \
   -e VAULT_ADDR \
   -e VAULT_ROLE_ID \
   -e VAULT_SECRET_ID \
-  --mount type=bind,readonly=false,src="${RELEASE_DIR}/dist",target="/artifacts" \
+  --mount type=bind,readonly=false,src=\"${RELEASE_DIR}/dist\",target=\"/artifacts\" \
   docker.elastic.co/infra/release-manager:latest \
   cli collect \
-      --project "${GIT_REPO}" \
-      --branch "${BRANCH_NAME}" \
-      --commit "${REVISION}" \
-      --workflow "${WORKFLOW}" \
-      --version "${VERSION}" \
+      --project \"${GIT_REPO}\" \
+      --branch \"${BRANCH_NAME}\" \
+      --commit \"${REVISION}\" \
+      --workflow \"${WORKFLOW}\" \
+      --version \"${VERSION}\" \
+      --qualifier \"${VERSION_QUALIFIER:-}\" \
       --artifact-set main
+"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -27,6 +27,13 @@ On the day of the release, `#mission-control` will notify the release manager th
 
 The Unified Release build will take care of producing git tags and official artifacts from our most recent DRA artifacts.
 
+### Pre-release artifacts
+
+If `#mission-control` asks for a pre-release artifact to be built, trigger the build pipeline from the relevant branch
+and add an Environment Variable for `VERSION_QUALIFIER` with the value of the pre-release.
+
+For example, to release 9.0.0-BC1, you would set `VERSION_QUALIFIER` to be `BC1` for this build.
+
 ### In-Between releases
 
 Sometimes, we need to release Connectors independently of the Elastic unified-release.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -32,7 +32,7 @@ The Unified Release build will take care of producing git tags and official arti
 If `#mission-control` asks for a pre-release artifact to be built, trigger the build pipeline from the relevant branch
 and add an Environment Variable for `VERSION_QUALIFIER` with the value of the pre-release.
 
-For example, to release 9.0.0-BC1, you would set `VERSION_QUALIFIER` to be `BC1` for this build.
+For example, to release 9.0.0-BC1, you would set `VERSION_QUALIFIER=BC1` for this build.
 
 ### In-Between releases
 


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/9111

This gives us the ability to specify a `VERSION_QUALIFIER` env var for a buildkite pipeline, and have that qualifier be picked up when producing staging artifacts. 

After this PR is merged, we will trigger a build on `main` with `VERSION_QUALIFIER=alpha1` to produce a 9.0.0-alpha1 pre-release for internal testing.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes

