### PR TITLE
Fix SNAPSHOT workflow to not have VERSION_QUALIFIER

### DIFF
--- a/.buildkite/publish/dra/publish-daily-release-artifact.sh
+++ b/.buildkite/publish/dra/publish-daily-release-artifact.sh
@@ -55,6 +55,12 @@ if [[ "${WORKFLOW:-}" != "staging" && "${WORKFLOW:-}" != "snapshot" ]]; then
   exit 2
 fi
 
+# snapshot workflows do not use qualifiers
+if [[ "${WORKFLOW:-}" == "snapshot" ]]; then
+  echo "overriding any local VERSION_QUALIFIER for SNAPSHOT workflow"
+  VERSION_QUALIFIER=""
+fi
+
 # Version. This is pulled from config/product_version.
 if [[ "${VERSION:-}" == "" ]]; then
   echo "ERROR: VERSION required!"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -34,6 +34,8 @@ and add an Environment Variable for `VERSION_QUALIFIER` with the value of the pr
 
 For example, to release 9.0.0-BC1, you would set `VERSION_QUALIFIER=BC1` for this build.
 
+Note that the qualified artifacts will only show up in DRA "staging" but not "snapshot" reports.
+
 ### In-Between releases
 
 Sometimes, we need to release Connectors independently of the Elastic unified-release.


### PR DESCRIPTION
## part of https://github.com/elastic/search-team/issues/9111


https://github.com/elastic/connectors/pull/3119 didn't add the qualifier to the artifacts, but still did pass the qualifier to the `release-manager` command. This lead to errors like:

```
2025-01-17 12:04:45 CST | FAILURE: Build failed with an exception.
-- | --
  | 2025-01-17 12:04:45 CST |  
  | 2025-01-17 12:04:45 CST | * What went wrong:
  | 2025-01-17 12:04:45 CST | Some problems were found with the configuration of task ':checksumConnectorsSnapshotSHA512' (type 'DefaultTask').
  | 2025-01-17 12:04:45 CST | - Property '$1' specifies file '/artifacts/dra-artifacts/connectors-9.0.0-alpha1-SNAPSHOT.zip' which doesn't exist.
  | 2025-01-17 12:04:45 CST |  
  | 2025-01-17 12:04:45 CST | Reason: An input file was expected to be present but it doesn't exist.
```

This change should prevent `release-manager` from expecting an artifact for the snapshot flow that has the qualifier in its filename. 

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes

