### PR TITLE
version qualifier fixes

### DIFF
--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -49,6 +49,7 @@ export REVISION="${BUILDKITE_COMMIT}"
 export BRANCH_NAME="${BUILDKITE_BRANCH}"
 export PRODUCT_NAME="connectors"
 export GIT_REPO="connectors"
+export VERSION_QUALIFIER="${VERSION_QUALIFIER:-}"
 
 # set PUBLISH_SNAPSHOT and PUBLISH_STAGING based on the branch
 if [[ "${BUILDKITE_BRANCH:-}" =~ (main|8\.x|[0-9]\.[0-9x]*$) ]]; then

--- a/.buildkite/publish/dra/init_dra_publishing.sh
+++ b/.buildkite/publish/dra/init_dra_publishing.sh
@@ -49,7 +49,6 @@ export REVISION="${BUILDKITE_COMMIT}"
 export BRANCH_NAME="${BUILDKITE_BRANCH}"
 export PRODUCT_NAME="connectors"
 export GIT_REPO="connectors"
-export VERSION_QUALIFIER="${VERSION_QUALIFIER:-}"
 
 # set PUBLISH_SNAPSHOT and PUBLISH_STAGING based on the branch
 if [[ "${BUILDKITE_BRANCH:-}" =~ (main|8\.x|[0-9]\.[0-9x]*$) ]]; then

--- a/.buildkite/publish/dra/publish-daily-release-artifact.sh
+++ b/.buildkite/publish/dra/publish-daily-release-artifact.sh
@@ -57,7 +57,7 @@ fi
 
 # snapshot workflows do not use qualifiers
 if [[ "${WORKFLOW:-}" == "snapshot" ]]; then
-  echo "overriding any local VERSION_QUALIFIER for SNAPSHOT workflow"
+  echo "SNAPSHOT workflows ignore version qualifier"
   version_qualifier=""
 else
   version_qualifier="${VERSION_QUALIFIER:-}"

--- a/.buildkite/publish/dra/publish-daily-release-artifact.sh
+++ b/.buildkite/publish/dra/publish-daily-release-artifact.sh
@@ -58,7 +58,9 @@ fi
 # snapshot workflows do not use qualifiers
 if [[ "${WORKFLOW:-}" == "snapshot" ]]; then
   echo "overriding any local VERSION_QUALIFIER for SNAPSHOT workflow"
-  VERSION_QUALIFIER=""
+  version_qualifier=""
+else
+  version_qualifier="${VERSION_QUALIFIER:-}"
 fi
 
 # Version. This is pulled from config/product_version.
@@ -93,5 +95,5 @@ docker run --rm \
       --commit "${REVISION}" \
       --workflow "${WORKFLOW}" \
       --version "${VERSION}" \
-      --qualifier "${VERSION_QUALIFIER:-}" \
+      --qualifier "${version_qualifier:-}" \
       --artifact-set main


### PR DESCRIPTION
## Part of https://github.com/elastic/search-team/issues/9111

Turns out that when you `source somescript.sh` instead of `./somescript.sh`, overrides of exported variables propagate up, instead of staying local to their assignment. So https://github.com/elastic/connectors/pull/3123/files ended up overwriting `VERSION_QUALIFIER` for both snapshot AND staging workflows. 🤦 

This instead swithces `publish-daily-release-artifact.sh` to use it's own local variable of `version_qualifier`, rather than overwriting the provided value of `VERSION_QUALIFIER`. 

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
