### PR TITLE
Update renovate labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,9 @@
   "labels": [
     "renovate",
     "auto-backport",
-    "v8.16",
-    "v8.17",
+    "v8.16.0",
+    "v8.17.0",
+    "v8.18.0",
     "v9.0.0"
   ],
   "packageRules": [


### PR DESCRIPTION
Our correct backport labels contain patch versions.

Additionally adding v8.18.0 to backport to `8.x` branch too.