### PR TITLE
Don’t auto-open PRs to update cgr.dev images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:d7d42af987333417272165a51dd7aed9cfd47067ac701ea927263364b12d64ad
+FROM cgr.dev/chainguard/wolfi-base:latest
 ARG python_version=3.11
 
 USER root

--- a/Dockerfile.ftest
+++ b/Dockerfile.ftest
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:d7d42af987333417272165a51dd7aed9cfd47067ac701ea927263364b12d64ad
+FROM cgr.dev/chainguard/wolfi-base:latest
 ARG python_version=3.11
 
 USER root

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,12 @@
   ],
   "packageRules": [
     {
+      "matchPackagePatterns": [
+        "^cgr.dev/"
+      ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": [
         "docker.elastic.co/wolfi/python"
       ],


### PR DESCRIPTION
As a follow-up to https://github.com/elastic/connectors/pull/3063, we want to unpin digest in Dockerfiles for external users, and un-manage those Dockerfiles in Renovate. We want to avoid PRs like https://github.com/elastic/connectors/pull/3151.