### PR TITLE
Add hardcoded qualifier

### DIFF
--- a/.buildkite/publish/publish-common.sh
+++ b/.buildkite/publish/publish-common.sh
@@ -13,6 +13,9 @@ export SCRIPT_DIR="$CURDIR"
 export BUILDKITE_DIR=$(realpath "$(dirname "$SCRIPT_DIR")")
 export PROJECT_ROOT=$(realpath "$(dirname "$BUILDKITE_DIR")")
 
+# temporary hard-coded build qualifier, this should be removed once we've released 9.0
+export VERSION_QUALIFIER="${VERSION_QUALIFIER:-beta1}"
+
 source $SCRIPT_DIR/git-setup.sh
 
 VERSION_PATH="$PROJECT_ROOT/connectors/VERSION"


### PR DESCRIPTION
Add hard-coded qualifier `beta1` so nightly builds have a qualifier. This will be removed when we release 9.0.