### PR TITLE
Fix to ESApi connector_sync_job_update_stats() to ensure undefined metadata passed as {} when undefined

### DIFF
--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -130,7 +130,7 @@ class ESApi(ESClient):
                 self.client.connector.sync_job_update_stats,
                 connector_sync_job_id=sync_job_id,
                 body=ingestion_stats,
-                metadata=metadata,
+                metadata=metadata if metadata else {},
             )
         )
 

--- a/tests/es/test_index.py
+++ b/tests/es/test_index.py
@@ -408,7 +408,7 @@ async def test_es_api_connector_sync_job_claim():
 async def test_es_api_connector_sync_job_update_stats():
     sync_job_id = "sync_job_id_test"
     ingestion_stats = {"ingestion": "stat"}
-    metadata = None # make sure metadata gets passed as '{}' if undefined
+    metadata = None  # make sure metadata gets passed as '{}' if undefined
 
     es_api = ESApi(elastic_config=config)
     es_api.client = AsyncMock()

--- a/tests/es/test_index.py
+++ b/tests/es/test_index.py
@@ -408,7 +408,7 @@ async def test_es_api_connector_sync_job_claim():
 async def test_es_api_connector_sync_job_update_stats():
     sync_job_id = "sync_job_id_test"
     ingestion_stats = {"ingestion": "stat"}
-    metadata = {"meta": "data"}
+    metadata = None # make sure metadata gets passed as '{}' if undefined
 
     es_api = ESApi(elastic_config=config)
     es_api.client = AsyncMock()
@@ -416,5 +416,5 @@ async def test_es_api_connector_sync_job_update_stats():
     await es_api.connector_sync_job_update_stats(sync_job_id, ingestion_stats, metadata)
 
     es_api.client.connector.sync_job_update_stats.assert_called_once_with(
-        connector_sync_job_id=sync_job_id, body=ingestion_stats, metadata=metadata
+        connector_sync_job_id=sync_job_id, body=ingestion_stats, metadata={}
     )

--- a/tests/es/test_index.py
+++ b/tests/es/test_index.py
@@ -419,6 +419,7 @@ async def test_es_api_connector_sync_job_update_stats_with_metadata():
         connector_sync_job_id=sync_job_id, body=ingestion_stats, metadata=metadata
     )
 
+
 @pytest.mark.asyncio
 async def test_es_api_connector_sync_job_update_stats_metadata_as_none():
     sync_job_id = "sync_job_id_test"

--- a/tests/es/test_index.py
+++ b/tests/es/test_index.py
@@ -405,6 +405,21 @@ async def test_es_api_connector_sync_job_claim():
 
 
 @pytest.mark.asyncio
+async def test_es_api_connector_sync_job_update_stats_with_metadata():
+    sync_job_id = "sync_job_id_test"
+    ingestion_stats = {"ingestion": "stat"}
+    metadata = {"meta": "data"}
+
+    es_api = ESApi(elastic_config=config)
+    es_api.client = AsyncMock()
+
+    await es_api.connector_sync_job_update_stats(sync_job_id, ingestion_stats, metadata)
+
+    es_api.client.connector.sync_job_update_stats.assert_called_once_with(
+        connector_sync_job_id=sync_job_id, body=ingestion_stats, metadata=metadata
+    )
+
+@pytest.mark.asyncio
 async def test_es_api_connector_sync_job_update_stats():
     sync_job_id = "sync_job_id_test"
     ingestion_stats = {"ingestion": "stat"}

--- a/tests/es/test_index.py
+++ b/tests/es/test_index.py
@@ -420,7 +420,7 @@ async def test_es_api_connector_sync_job_update_stats_with_metadata():
     )
 
 @pytest.mark.asyncio
-async def test_es_api_connector_sync_job_update_stats():
+async def test_es_api_connector_sync_job_update_stats_metadata_as_none():
     sync_job_id = "sync_job_id_test"
     ingestion_stats = {"ingestion": "stat"}
     metadata = None  # make sure metadata gets passed as '{}' if undefined


### PR DESCRIPTION
## Related to https://github.com/elastic/search-team/issues/9194


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Testes the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

## Related Pull Requests
https://github.com/elastic/connectors/pull/3110