### PR TITLE
SharePoint Online Connector: Added credentials.close() call to _fetch_token() method

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -357,6 +357,8 @@ class EntraAPIToken(MicrosoftSecurityToken):
 
         token = await credentials.get_token(self._scope)
 
+        await credentials.close()
+
         return token.token, datetime.utcfromtimestamp(token.expires_on)
 
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -534,12 +534,15 @@ class TestEntraAPIToken:
 
         certificate_credential_mock = AsyncMock()
         certificate_credential_mock.get_token = AsyncMock(return_value=entra_token)
+        certificate_credential_mock.close = AsyncMock()
 
         with patch(
             "connectors.sources.sharepoint_online.CertificateCredential",
             return_value=certificate_credential_mock,
         ):
             actual_token, actual_expires_at = await token._fetch_token()
+
+        certificate_credential_mock.close.assert_called_once()
 
         assert actual_token == bearer
         assert actual_expires_at == datetime.utcfromtimestamp(expires_at)


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/9195
This fixes an issue where `Unclosed client session` and `Unclosed connector` messages were appearing in logs.

RCA:
aiohttp does not close its sessions, so when we create an Azure CertificateCredential, we need to manually call `.close()` on it, otherwise the client sessions will remain open.

See [this](https://github.com/Azure/azure-sdk-for-python/issues/13242#issuecomment-677857681) Azure Python SDK thread for details.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)