### PR TITLE
[Framework] Correctly handle soft deleted connectors

### DIFF
--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -233,18 +233,20 @@ class ConnectorIndex(ESIndex):
 
         native_connectors_query = {
             "bool": {
+                "must_not": [{"term": {"deleted": True}}],
                 "filter": [
                     {"term": {"is_native": True}},
                     {"terms": {"service_type": native_service_types}},
-                ]
+                ],
             }
         }
 
         custom_connectors_query = {
             "bool": {
+                "must_not": [{"term": {"deleted": True}}],
                 "filter": [
                     {"terms": {"_id": connector_ids}},
-                ]
+                ],
             }
         }
         if len(native_service_types) > 0 and len(connector_ids) > 0:
@@ -1185,7 +1187,9 @@ class SyncJobIndex(ESIndex):
     async def orphaned_idle_jobs(self, connector_ids):
         query = {
             "bool": {
-                "must_not": {"terms": {"connector.id": connector_ids}},
+                "must_not": {
+                    "terms": {"connector.id": connector_ids},
+                },
                 "filter": [
                     {
                         "terms": {
@@ -1194,7 +1198,7 @@ class SyncJobIndex(ESIndex):
                                 JobStatus.CANCELING.value,
                             ]
                         }
-                    }
+                    },
                 ],
             }
         }
@@ -1215,7 +1219,7 @@ class SyncJobIndex(ESIndex):
                         }
                     },
                     {"range": {"last_seen": {"lte": f"now-{IDLE_JOBS_THRESHOLD}s"}}},
-                ]
+                ],
             }
         }
 

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -1187,9 +1187,7 @@ class SyncJobIndex(ESIndex):
     async def orphaned_idle_jobs(self, connector_ids):
         query = {
             "bool": {
-                "must_not": {
-                    "terms": {"connector.id": connector_ids},
-                },
+                "must_not": {"terms": {"connector.id": connector_ids}},
                 "filter": [
                     {
                         "terms": {
@@ -1198,7 +1196,7 @@ class SyncJobIndex(ESIndex):
                                 JobStatus.CANCELING.value,
                             ]
                         }
-                    },
+                    }
                 ],
             }
         }
@@ -1219,7 +1217,7 @@ class SyncJobIndex(ESIndex):
                         }
                     },
                     {"range": {"last_seen": {"lte": f"now-{IDLE_JOBS_THRESHOLD}s"}}},
-                ],
+                ]
             }
         }
 

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -241,19 +241,21 @@ async def test_supported_connectors(
     config = {"host": "http://nowhere.com:9200", "user": "tarek", "password": "blah"}
     native_connectors_query = {
         "bool": {
+            "must_not": [{"term": {"deleted": True}}],
             "filter": [
                 {"term": {"is_native": True}},
                 {"terms": {"service_type": native_service_types}},
-            ]
+            ],
         }
     }
 
     custom_connectors_query = {
         "bool": {
+            "must_not": [{"term": {"deleted": True}}],
             "filter": [
                 {"term": {"is_native": False}},
                 {"terms": {"_id": connector_ids}},
-            ]
+            ],
         }
     }
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3118

Since we introduced soft-deletes in 9.0, make sure framework respects deleted flag. 

### Changes

Exclude any connectors with `deleted: true` when fetching supported connectors in a query (note, I added this to native connectors query for conssitency but this code should be deleted anyway https://github.com/elastic/connectors/issues/2991)

This is in line with how API handles soft-deleted connectors https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java#L410C12-L410C119

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference


### Verification

Ran this locally with debug log enabled with ES 9.0. Soft-deleted connector, and that was resulting output of the framework:
```
[content_sync_job_execution_service] There's no supported connectors found with native service types [] or connector ids [Fq4v1pQBjAGa8X_ervuC]         
```
`Fq4v1pQBjAGa8X_ervuC` was soft deleted so behaviour is correct
