### PR TITLE
[8.16] SharePoint Online Connector: Added credentials.close() call to _fetch_token() method (#3177)

### DIFF
--- a/connectors/sources/sharepoint_online.py
+++ b/connectors/sources/sharepoint_online.py
@@ -357,6 +357,8 @@ class EntraAPIToken(MicrosoftSecurityToken):
 
         token = await credentials.get_token(self._scope)
 
+        await credentials.close()
+
         return token.token, datetime.utcfromtimestamp(token.expires_on)
 
 

--- a/tests/sources/test_sharepoint_online.py
+++ b/tests/sources/test_sharepoint_online.py
@@ -534,12 +534,15 @@ class TestEntraAPIToken:
 
         certificate_credential_mock = AsyncMock()
         certificate_credential_mock.get_token = AsyncMock(return_value=entra_token)
+        certificate_credential_mock.close = AsyncMock()
 
         with patch(
             "connectors.sources.sharepoint_online.CertificateCredential",
             return_value=certificate_credential_mock,
         ):
             actual_token, actual_expires_at = await token._fetch_token()
+
+        certificate_credential_mock.close.assert_called_once()
 
         assert actual_token == bearer
         assert actual_expires_at == datetime.utcfromtimestamp(expires_at)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [SharePoint Online Connector: Added credentials.close() call to _fetch_token() method (#3177)](https://github.com/elastic/connectors/pull/3177)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)