### PR TITLE
Adding warning filter to suppress GA warning from ES Python client

### DIFF
--- a/connectors/es/__init__.py
+++ b/connectors/es/__init__.py
@@ -5,11 +5,11 @@
 #
 import warnings
 
+from elasticsearch.exceptions import GeneralAvailabilityWarning
+
 from connectors.es.client import ESClient  # NOQA
 from connectors.es.document import ESDocument, InvalidDocumentSourceError  # NOQA
 from connectors.es.index import ESIndex  # NOQA
-
-from elasticsearch.exceptions import GeneralAvailabilityWarning
 
 warnings.filterwarnings("ignore", category=GeneralAvailabilityWarning)
 

--- a/connectors/es/__init__.py
+++ b/connectors/es/__init__.py
@@ -3,9 +3,15 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import warnings
+
 from connectors.es.client import ESClient  # NOQA
 from connectors.es.document import ESDocument, InvalidDocumentSourceError  # NOQA
 from connectors.es.index import ESIndex  # NOQA
+
+from elasticsearch.exceptions import GeneralAvailabilityWarning
+
+warnings.filterwarnings("ignore", category=GeneralAvailabilityWarning)
 
 TIMESTAMP_FIELD = "_timestamp"
 DEFAULT_LANGUAGE = "en"


### PR DESCRIPTION
## Closes https://github.com/elastic/search-team/issues/9234
This PR adds a warning filter to suppress the following warning from output:

`
GeneralAvailabilityWarning: This API is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features. result = await func()`

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)