### PR TITLE
[Makefile] Improvements to python selection and requirement changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install-agent: .venv/bin/elastic-ingest
 .venv/bin/elastic-ingest: .venv/bin/python requirements/framework.txt requirements/$(ARCH).txt requirements/agent.txt
 	.venv/bin/pip install -r requirements/$(ARCH).txt
 	.venv/bin/pip install -r requirements/agent.txt
-	.venv/bin/python setup.py developg
+	.venv/bin/python setup.py develop
 
 .venv/bin/ruff: .venv/bin/python
 	.venv/bin/pip install -r requirements/$(ARCH).txt


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3187

### Changes

#### 1. Fix Makefile target

Fix Makefile `elastic-ingest` target to force reinstall when requirements change. The `requirements/$(ARCH).txt` references  inside`requirements/framework.txt` the `framework.txt` was not listed as dependency of makefile target. Hence we were not reinstalling when framework-level dependency was updated.

#### 2. Fix python3 selection 

That was triggering me for a while. With every new python version update the global alias of python3 is bumped (on MacOS at least with homebrew python), e.g. now `python3` has version 3.13 for me. 

This caused running `make clean && make run` always fail as connectors are not compatible with python 3.12+. As requirements will fail to install.

In order to address this issue, I added logic to:
- use `PYTHON=python3` as before (backward compatible for CI setup)
  - check CI step that we use correct version 
- check python3 runtime version 
- if version > 3.11 try using `python3.11` or `3.10` alias (in that order)
- if those python versions are not available on the system fail with error
- print info which python version we are using
- works pretty well for me :) 

No backport required.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

