### PR TITLE
[8.18] Adding warning filter to suppress GA warning from ES Python client (#3189)

### DIFF
--- a/connectors/es/__init__.py
+++ b/connectors/es/__init__.py
@@ -13,6 +13,3 @@ from connectors.es.index import ESIndex  # NOQA
 from connectors.es.settings import DEFAULT_LANGUAGE, Mappings  # NOQA
 
 warnings.filterwarnings("ignore", category=GeneralAvailabilityWarning)
-
-TIMESTAMP_FIELD = "_timestamp"
-DEFAULT_LANGUAGE = "en"

--- a/connectors/es/__init__.py
+++ b/connectors/es/__init__.py
@@ -3,7 +3,16 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import warnings
+
+from elasticsearch.exceptions import GeneralAvailabilityWarning
+
 from connectors.es.client import ESClient  # NOQA
 from connectors.es.document import ESDocument, InvalidDocumentSourceError  # NOQA
 from connectors.es.index import ESIndex  # NOQA
 from connectors.es.settings import DEFAULT_LANGUAGE, Mappings  # NOQA
+
+warnings.filterwarnings("ignore", category=GeneralAvailabilityWarning)
+
+TIMESTAMP_FIELD = "_timestamp"
+DEFAULT_LANGUAGE = "en"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Adding warning filter to suppress GA warning from ES Python client (#3189)](https://github.com/elastic/connectors/pull/3189)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)