### PR TITLE
[8.x] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to ff16db3 (#3194)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:bc0568ba8b807b776c9696070fe23525c237374f87dec415ae6ea15b4b22e472
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:ff16db30aa11d1734206e98c6a95350e6530de995a5e7c6c516e2c784d8ba811
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:bc0568ba8b807b776c9696070fe23525c237374f87dec415ae6ea15b4b22e472
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:ff16db30aa11d1734206e98c6a95350e6530de995a5e7c6c516e2c784d8ba811
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to ff16db3 (#3194)](https://github.com/elastic/connectors/pull/3194)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)