### PR TITLE
[8.16] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 8d32370 (#3203)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:ff16db30aa11d1734206e98c6a95350e6530de995a5e7c6c516e2c784d8ba811
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:8d32370ffc5117a7a88eed0a9c51f3507de1e15d08b13051a5c9383d25ebe8b3
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:ff16db30aa11d1734206e98c6a95350e6530de995a5e7c6c516e2c784d8ba811
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:8d32370ffc5117a7a88eed0a9c51f3507de1e15d08b13051a5c9383d25ebe8b3
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 8d32370 (#3203)](https://github.com/elastic/connectors/pull/3203)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)