### PR TITLE
Update README.md for 9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Use connectors to sync data from popular data sources to Elasticsearch.
 
 These connectors are available to be self-managed on your own infrastructure.
 
+> [!NOTE]  
+> Managed connectors on Elastic Cloud Hosted are no longer available as of version 9.0.
+
 ℹ️ For an overview of the steps involved in deploying connectors refer to [**Self-managed connectors**](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-build-connector.html) in the official Elastic documentation.
 
 To get started quickly with self-managed connectors using Docker Compose, check out this [README file](./scripts/stack/README.md).

--- a/README.md
+++ b/README.md
@@ -8,30 +8,23 @@
 This repository contains the source code for all Elastic connectors, developed by the Search team at Elastic.
 Use connectors to sync data from popular data sources to Elasticsearch.
 
-These connectors are available as:
-- [**Self-managed connectors**](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-build-connector.html) to be self-managed on your own infrastructure
-- [**Elastic managed connectors**](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-native-connectors.html) using our fully managed service on Elastic Cloud
+These connectors are available to be self-managed on your own infrastructure.
 
-ℹ️ For an overview of the steps involved in deploying self-managed connectors refer to [**Self-managed connectors**](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-build-connector.html) in the official Elastic documentation.
+ℹ️ For an overview of the steps involved in deploying connectors refer to [**Self-managed connectors**](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-build-connector.html) in the official Elastic documentation.
 
 To get started quickly with self-managed connectors using Docker Compose, check out this [README file](./scripts/stack/README.md).
 
 ### Connector documentation
 
-The main documentation for using connectors lives in the Elasticsearch docs.
-Here are the main pages:
+The main documentation for using connectors lives in the [Elastic docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-connectors.html).
+You'll find the individual references for each connector there.
 
-- [Connectors overview](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-connectors.html)
-- [Self-managed connectors](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-build-connector.html)
-- [Elastic managed connectors](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-native-connectors.html)
-
-You'll also find the individual references for each connector there.
 For everything to do with _developing_ connectors, you'll find that here in this repo.
 
 #### API documentation
 
 Since 8.12.0, you can manage connectors and sync jobs programmatically using APIs.
-Refer to the [Connector API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/connector-apis.html) in the Elasticsearch docs.
+Refer to the [Connector API documentation](https://www.elastic.co/docs/api/doc/elasticsearch/v8/group/endpoint-connector).
 
 #### Command-line interface
 


### PR DESCRIPTION
- Removes mention of managed connectors
- Updates links accordingly, including the API docs 

> [!NOTE]
> URLs for the elasticsearch docs will be redirected when the new docs system goes live.