### PR TITLE
switch version qualifier to `rc1`

### DIFF
--- a/.buildkite/publish/publish-common.sh
+++ b/.buildkite/publish/publish-common.sh
@@ -14,7 +14,7 @@ export BUILDKITE_DIR=$(realpath "$(dirname "$SCRIPT_DIR")")
 export PROJECT_ROOT=$(realpath "$(dirname "$BUILDKITE_DIR")")
 
 # temporary hard-coded build qualifier, this should be removed once we've released 9.0
-export VERSION_QUALIFIER="${VERSION_QUALIFIER:-beta1}"
+export VERSION_QUALIFIER="${VERSION_QUALIFIER:-rc1}"
 
 source $SCRIPT_DIR/git-setup.sh
 


### PR DESCRIPTION
beta1 is out, so time to bump the qualifier, per the #mission-control thread