### PR TITLE
[Bugfix] Fix version check logic on startup

### DIFF
--- a/connectors/preflight_check.py
+++ b/connectors/preflight_check.py
@@ -5,6 +5,7 @@
 #
 
 import aiohttp
+import re
 
 from connectors.es.management_client import ESManagementClient
 from connectors.logger import logger
@@ -87,10 +88,11 @@ class PreflightCheck:
         Checks if the Connector and ES versions are compatible
         """
 
+        # Remove any version qualifier (e.g., -SNAPSHOT, -beta1, -rc1)
+        major_minor_patch_es_version = re.split(r"-", es_version)[0]
+
         # array legend: 0 - major, 1 - minor, 2 - patch
-        es_version_parts = list(
-            map(int, es_version.replace("-SNAPSHOT", "").split("."))
-        )
+        es_version_parts = list(map(int, major_minor_patch_es_version.split(".")))
         connector_version_parts = list(map(int, self.version.split("+")[0].split(".")))
 
         # major

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -234,6 +234,21 @@ async def test_warn_mismatched_version(
             "1.2.3",
             "Elasticsearch 1.2.3 and Connectors 1.2.3 are compatible",
         ),
+        (
+            "1.2.3-SNAPSHOT",
+            "1.2.3",
+            "Elasticsearch 1.2.3 and Connectors 1.2.3 are compatible",
+        ),
+        (
+            "1.2.3-beta1",
+            "1.2.3",
+            "Elasticsearch 1.2.3 and Connectors 1.2.3 are compatible",
+        ),
+        (
+            "1.2.3-rc1",
+            "1.2.3+build123",
+            "Elasticsearch 1.2.3 and Connectors 1.2.3 are compatible",
+        ),
     ],
 )
 async def test_pass_mismatched_version(


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3231

ES version like `9.0.0-beta1` would crash the preflight version check. Handle this case here. 

- added unit tests
- verified manually