### PR TITLE
[8.18] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to f56d29e (#3241)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:0bdec4b7b1e48fdf0e5fd06fec0f5d2d4e1033efb7ac872a1494483d2e50d9ee
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:f56d29ec7159b1a0294173f8df9c98e72b490a01506fb8c2c2abf93c5427517d
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:0bdec4b7b1e48fdf0e5fd06fec0f5d2d4e1033efb7ac872a1494483d2e50d9ee
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:f56d29ec7159b1a0294173f8df9c98e72b490a01506fb8c2c2abf93c5427517d
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -978,8 +978,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 aiohappyeyeballs
-2.4.3
-Other/Proprietary License; Python Software Foundation License
+2.4.8
+Python Software Foundation License
 A. HISTORY OF THE SOFTWARE
 ==========================
 
@@ -2927,7 +2927,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 cryptography
-43.0.3
+44.0.2
 Apache Software License; BSD License
 This software is made available under the terms of *either* of the licenses
 found in LICENSE.APACHE or LICENSE.BSD. Contributions to cryptography are made


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to f56d29e (#3241)](https://github.com/elastic/connectors/pull/3241)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)