### PR TITLE
[8.17] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to cd77168 (#3262)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:f56d29ec7159b1a0294173f8df9c98e72b490a01506fb8c2c2abf93c5427517d
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:cd77168d1119849e827e268c3bb71acb55ca61405a0a630a4995d010779f692d
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:f56d29ec7159b1a0294173f8df9c98e72b490a01506fb8c2c2abf93c5427517d
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:cd77168d1119849e827e268c3bb71acb55ca61405a0a630a4995d010779f692d
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to cd77168 (#3262)](https://github.com/elastic/connectors/pull/3262)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)