### PR TITLE
[8.x] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to bad9ad1 (#3283)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:14cdfa7a772c9bfcb9349bdcb36f678359052e44443ba8c9df1f6f2434bd2a43
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:bad9ad1e25682565808233b9a06b24bece60091ba6541e4f17086a5dc973c91e
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:14cdfa7a772c9bfcb9349bdcb36f678359052e44443ba8c9df1f6f2434bd2a43
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:bad9ad1e25682565808233b9a06b24bece60091ba6541e4f17086a5dc973c91e
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to bad9ad1 (#3283)](https://github.com/elastic/connectors/pull/3283)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)