### PR TITLE
Fix ABS concurrent download configuration

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1536,7 +1536,7 @@ Apache License
 
 
 anyio
-4.8.0
+4.9.0
 MIT License
 The MIT License (MIT)
 
@@ -1788,7 +1788,7 @@ Copyright (C) 2016-present the asyncpg authors and contributors.
 
 
 attrs
-25.2.0
+25.3.0
 UNKNOWN
 The MIT License (MIT)
 
@@ -6097,7 +6097,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 msal-extensions
-1.2.0
+1.3.1
 MIT License
     MIT License
 
@@ -6477,22 +6477,6 @@ ply
 3.11
 BSD
 UNKNOWN
-
-portalocker
-2.10.1
-BSD License
-Copyright 2022 Rick van Hattem
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 
 propcache
 0.3.0

--- a/connectors/sources/azure_blob_storage.py
+++ b/connectors/sources/azure_blob_storage.py
@@ -230,7 +230,7 @@ class AzureBlobStorageDataSource(BaseDataSource):
                 blob=blob_name,
                 offset=offset,
                 length=length,
-                max_concurrency=MAX_CONCURRENT_DOWNLOADS,
+                max_concurrency=self.concurrent_downloads,
             )
             content = await data.read()
             length = data.size


### PR DESCRIPTION
The Azure Blob Storage configuration for max concurrent downloads wasn't applying the configured option.