### PR TITLE
Improve pagination handling in Confluence API client

### DIFF
--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -259,23 +259,31 @@ class ConfluenceClient:
         Yields:
             response: JSON response.
         """
-        url = os.path.join(self.host_url, URLS[url_name].format(**url_kwargs))
+        base_url = os.path.join(self.host_url, URLS[url_name].format(**url_kwargs))
+        start = 0
+
         while True:
             try:
+                url = f"{base_url}&start={start}"
                 self._logger.debug(f"Starting pagination for API endpoint {url}")
                 response = await self.api_call(url=url)
                 json_response = await response.json()
+
                 links = json_response.get("_links")
                 yield json_response
-                if links.get("next") is None:
+                if links.get("next"):
+                    url = os.path.join(
+                        self.host_url,
+                        links.get("next")[1:],
+                    )
+                elif json_response.get("start") + json_response.get("size") < json_response.get("totalSize"):
+                    start = json_response.get("start") + json_response.get("size")
+                    url = f"{base_url}&start={start}"
+                else:
                     return
-                url = os.path.join(
-                    self.host_url,
-                    links.get("next")[1:],
-                )
             except Exception as exception:
                 self._logger.warning(
-                    f"Skipping data for type {url_name} from {url}. Exception: {exception}."
+                    f"Skipping data for type {url_name} from {base_url}. Exception: {exception}."
                 )
                 break
 
@@ -984,8 +992,9 @@ class ConfluenceDataSource(BaseDataSource):
             # entity can be space or content
             entity_details = entity.get(SPACE) or entity.get(CONTENT)
 
-            if (
-                entity_details.get("type", "") == "attachment"
+            if not entity_details:
+                continue
+            if (entity_details.get("type", "") == "attachment"
                 and entity_details.get("container", {}).get("title") is None
             ):
                 continue


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors-py/issues/3320

The code is here to enhance the pagination handling in case the /rest/content/search API is used since there is no next link in that api.
I would be happy if someone could check if my logic is somewhat acceptable.

## Checklists
#### Pre-Review Checklist
- [X] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [X] this PR has a meaningful title
- [X] this PR links to all relevant github issues that it fixes or partially addresses
- [X] if there is no GH issue, please create it. Each PR should have a link to an issue
- [X] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [X] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)
