### PR TITLE
prep for 9.0.0 release

### DIFF
--- a/.buildkite/publish/publish-common.sh
+++ b/.buildkite/publish/publish-common.sh
@@ -13,9 +13,6 @@ export SCRIPT_DIR="$CURDIR"
 export BUILDKITE_DIR=$(realpath "$(dirname "$SCRIPT_DIR")")
 export PROJECT_ROOT=$(realpath "$(dirname "$BUILDKITE_DIR")")
 
-# temporary hard-coded build qualifier, this should be removed once we've released 9.0
-export VERSION_QUALIFIER="${VERSION_QUALIFIER:-rc1}"
-
 source $SCRIPT_DIR/git-setup.sh
 
 VERSION_PATH="$PROJECT_ROOT/connectors/VERSION"

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -8879,7 +8879,7 @@ Apache Software License
 UNKNOWN
 
 tzdata
-2025.1
+2025.2
 Apache Software License
 Apache Software License 2.0
 


### PR DESCRIPTION
Removes the qualifier for rc1, as requested by mission control

## Checklists


#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
