### PR TITLE
[8.16] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 3135203 (#3319)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:1dd35dad5a23838e3981380f94a51fab73b45f95f293e3b7e0414dded985cfda
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:31352039d9a20441a2fcd7a2bb6ac6f236e646311f573aad0d476760e1b55693
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:1dd35dad5a23838e3981380f94a51fab73b45f95f293e3b7e0414dded985cfda
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:31352039d9a20441a2fcd7a2bb6ac6f236e646311f573aad0d476760e1b55693
 USER root
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.16`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 3135203 (#3319)](https://github.com/elastic/connectors/pull/3319)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)