### PR TITLE
Run renovate only on weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
     "local>elastic/renovate-config",
     "github>elastic/renovate-config:only-chainguard"
   ],
+  "schedule": [
+    "* * * * 0,6"
+  ],
   "labels": [
     "renovate",
     "auto-backport",


### PR DESCRIPTION
See https://elastic.slack.com/archives/C01795T48LQ/p1743165270846379:

Renovate sending updates every day makes the routine harder to handle. I feel it's great to batch it during weekends, and then resolve all on Monday/Tuesday.