### PR TITLE
Make job_scheduling service run schedule in a task pool

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -6189,7 +6189,7 @@ MIT License
 
 
 multidict
-6.3.0
+6.2.0
 Apache Software License
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,3 +1,69 @@
+Jinja2
+3.1.6
+BSD License
+Copyright 2007 Pallets
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+MarkupSafe
+3.0.2
+BSD License
+Copyright 2010 Pallets
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
 PyJWT
 2.10.1
 MIT License
@@ -6123,7 +6189,7 @@ MIT License
 
 
 multidict
-6.2.0
+6.3.0
 Apache Software License
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 
@@ -7986,7 +8052,7 @@ SOFTWARE.
 
 
 stone
-3.3.8
+3.3.9
 MIT License
 Copyright (c) 2020 Dropbox Inc., http://www.dropbox.com/
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -201,6 +201,10 @@
 #service.max_concurrent_access_control_syncs: 1
 #
 #
+##  The maximum number of concurrent job scheduling tasks.
+#service.max_concurrent_scheduling_tasks: 4
+#
+#
 ##  The maximum size (in bytes) of files that the framework should be willing
 ##    to download and/or process.
 #service.max_file_download_size: 10485760

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -98,6 +98,7 @@ def _default_config():
             "max_errors_span": 600,
             "max_concurrent_content_syncs": 1,
             "max_concurrent_access_control_syncs": 1,
+            "max_concurrent_scheduling_tasks": 4,
             "max_file_download_size": DEFAULT_MAX_FILE_SIZE,
             "job_cleanup_interval": 300,
             "log_level": "INFO",

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -181,7 +181,7 @@ class JobSchedulingService(BaseService):
                             functools.partial(self._schedule, connector)
                         ):
                             connector.log_debug(
-                                f"{self.display_name.capitalize()} service is already running {self.max_concurrency} sync jobs and can't run more at this poinit. Increase '{self.max_concurrency_config}' in config if you want the service to run more sync jobs."  # pyright: ignore
+                                f"{self.display_name.capitalize()} service is already running {self.max_concurrency} concurrent sync jobs and can't run more at this point. Increase '{self.max_concurrency_config}' in config if you want the service to run more concurrent sync jobs."  # pyright: ignore
                             )
 
                 except Exception as e:

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -181,7 +181,7 @@ class JobSchedulingService(BaseService):
                             functools.partial(self._schedule, connector)
                         ):
                             connector.log_debug(
-                                f"{self.display_name.capitalize()} service is already running {self.max_concurrency} concurrent sync jobs and can't run more at this point. Increase '{self.max_concurrency_config}' in config if you want the service to run more concurrent sync jobs."  # pyright: ignore
+                                f"{self.display_name.capitalize()} service is already running {self.max_concurrency} concurrent scheduling jobs and can't run more at this point. Increase 'max_concurrent_scheduling_tasks' in config if you want the service to run more concurrent scheduling jobs."  # pyright: ignore
                             )
 
                 except Exception as e:

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -11,8 +11,8 @@ Event loop
 - mirrors an Elasticsearch index with a collection of documents
 """
 
-from datetime import datetime, timezone
 import functools
+from datetime import datetime, timezone
 
 from connectors.es.client import License, with_concurrency_control
 from connectors.es.index import DocumentNotFoundError
@@ -41,7 +41,9 @@ class JobSchedulingService(BaseService):
         self.source_list = config["sources"]
         self.first_run = True
         self.last_wake_up_time = datetime.now(timezone.utc)
-        self.max_concurrency = self.service_config.get("max_concurrent_scheduling_tasks")
+        self.max_concurrency = self.service_config.get(
+            "max_concurrent_scheduling_tasks"
+        )
         self.schedule_tasks_pool = ConcurrentTasks(max_concurrency=self.max_concurrency)
 
     def stop(self):
@@ -175,7 +177,9 @@ class JobSchedulingService(BaseService):
                         native_service_types=native_service_types,
                         connector_ids=connector_ids,
                     ):
-                        if not self.schedule_tasks_pool.try_put(functools.partial(self._schedule, connector)):
+                        if not self.schedule_tasks_pool.try_put(
+                            functools.partial(self._schedule, connector)
+                        ):
                             connector.log_debug(
                                 f"{self.display_name.capitalize()} service is already running {self.max_concurrency} sync jobs and can't run more at this poinit. Increase '{self.max_concurrency_config}' in config if you want the service to run more sync jobs."  # pyright: ignore
                             )

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -12,6 +12,7 @@ Event loop
 """
 
 from datetime import datetime, timezone
+import functools
 
 from connectors.es.client import License, with_concurrency_control
 from connectors.es.index import DocumentNotFoundError
@@ -27,6 +28,7 @@ from connectors.protocol import (
 )
 from connectors.services.base import BaseService
 from connectors.source import get_source_klass
+from connectors.utils import ConcurrentTasks
 
 
 class JobSchedulingService(BaseService):
@@ -39,6 +41,12 @@ class JobSchedulingService(BaseService):
         self.source_list = config["sources"]
         self.first_run = True
         self.last_wake_up_time = datetime.now(timezone.utc)
+        self.max_concurrency = self.service_config.get("max_concurrent_scheduling_tasks")
+        self.schedule_tasks_pool = ConcurrentTasks(max_concurrency=self.max_concurrency)
+
+    def stop(self):
+        super().stop()
+        self.schedule_tasks_pool.cancel()
 
     async def _schedule(self, connector):
         # To do some first-time stuff
@@ -167,13 +175,17 @@ class JobSchedulingService(BaseService):
                         native_service_types=native_service_types,
                         connector_ids=connector_ids,
                     ):
-                        await self._schedule(connector)
+                        if not self.schedule_tasks_pool.try_put(functools.partial(self._schedule, connector)):
+                            connector.log_debug(
+                                f"{self.display_name.capitalize()} service is already running {self.max_concurrency} sync jobs and can't run more at this poinit. Increase '{self.max_concurrency_config}' in config if you want the service to run more sync jobs."  # pyright: ignore
+                            )
 
                 except Exception as e:
                     self.logger.error(e, exc_info=True)
                     self.raise_if_spurious(e)
 
                 # Immediately break instead of sleeping
+                await self.schedule_tasks_pool.join()
                 if not self.running:
                     break
                 self.last_wake_up_time = datetime.now(timezone.utc)

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -508,9 +508,6 @@ async def test_initial_loop_run_heartbeat_only_once(
 async def test_run_when_validation_is_very_slow(
     get_source_klass_mock, connector_index_mock, set_env
 ):
-    error_message = "Something invalid is in config!"
-    actual_error = Exception(error_message)
-
     data_source_mock = Mock()
 
     def _source_klass(config):


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2878

This PR introduces concurrent task to job scheduling service. Before, `_schedule` function would be awaited - now they are added to concurrent task pool (default size = 4) and are all awaited in the end of scheduling loop.

Result of this is that it's possible to properly stop job scheduling service when it's in the middle of `_schedule` function. Before this change, slow validation of the connector could result in service hanging - while validation is happening, it was impossible to stop the connectors service.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
