### PR TITLE
Parse invalid OneDrive permissions without crashing

### DIFF
--- a/connectors/sources/onedrive.py
+++ b/connectors/sources/onedrive.py
@@ -661,7 +661,7 @@ class OneDriveDataSource(BaseDataSource):
                     permissions.append(_prefix_user_id(identity_id))
                 else:
                     log = f"No user id found for user {user_id} for file {file_id} in `grantedToV2`"
-                    logger.warning(log)
+                    self._logger.warning(log)
 
             if identities := permission.get("grantedToIdentitiesV2"):
                 for identity in identities:
@@ -674,9 +674,9 @@ class OneDriveDataSource(BaseDataSource):
                     if group_permission:
                         permissions.append(_prefix_group(group_permission))
 
-                    if not user_permission and group_permission:
+                    if not user_permission and not group_permission:
                         log = f"No group or user id found for {user_id} for file {file_id} in `grantedToIdentitiesV2`"
-                        logger.warning(log)
+                        self._logger.warning(log)
 
         return permissions
 

--- a/tests/sources/test_onedrive.py
+++ b/tests/sources/test_onedrive.py
@@ -347,9 +347,7 @@ RESPONSE_PERMISSION3 = {
     }
 }
 RESPONSE_PERMISSION_INVALID = {
-    "grantedToV2": {
-        "user": None
-    }
+    "grantedToV2": {}
 }
 
 EXPECTED_USER1_FILES_PERMISSION = [

--- a/tests/sources/test_onedrive.py
+++ b/tests/sources/test_onedrive.py
@@ -339,6 +339,19 @@ RESPONSE_PERMISSION2 = {
         }
     ],
 }
+RESPONSE_PERMISSION3 = {
+    "grantedToV2": {
+        "user": {
+            "id": "user_id_3",
+        }
+    }
+}
+RESPONSE_PERMISSION_INVALID = {
+    "grantedToV2": {
+        "user": None
+    }
+}
+
 EXPECTED_USER1_FILES_PERMISSION = [
     {
         "type": "folder",
@@ -815,6 +828,32 @@ async def test_list_permissions():
                 "user-1", "file-1"
             ):
                 assert permission == RESPONSE_PERMISSION1
+
+@pytest.mark.asyncio
+async def test_list_permissions_when_no_identities_field():
+    async with create_onedrive_source() as source:
+        with patch.object(
+            OneDriveClient,
+            "paginated_api_call",
+            return_value=AsyncIterator([[RESPONSE_PERMISSION3]]),
+        ):
+            async for permission in source.client.list_file_permission(
+                "user-1", "file-1"
+            ):
+                assert permission == RESPONSE_PERMISSION3
+
+@pytest.mark.asyncio
+async def test_list_permissions_when_id_missing():
+    async with create_onedrive_source() as source:
+        with patch.object(
+            OneDriveClient,
+            "paginated_api_call",
+            return_value=AsyncIterator([[RESPONSE_PERMISSION_INVALID]]),
+        ):
+            async for permission in source.client.list_file_permission(
+                "user-1", "file-1"
+            ):
+                assert permission == RESPONSE_PERMISSION_INVALID
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is in response to an SDH where Connectors were crashing because the user had a misconfigured permission in OneDrive. Ideally, the Connector shouldn't crash in this case and instead should log a useful warning about the permission missing.

- Handle cases where the user id from `grantedToV2` permissions API response is empty
- Add warning logs for when permissions are unexpectedly not present