### PR TITLE
[9.0] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 485e1ad (#3339)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:9a54cc75c3e42a3e8d4a4e52c02c3903e6e99a5f691ea321022070024ec7f072
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:485e1ad61685b04c8ee006d452768535a14c90a231e9f3c0742f946d7a77fe50
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:9a54cc75c3e42a3e8d4a4e52c02c3903e6e99a5f691ea321022070024ec7f072
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:485e1ad61685b04c8ee006d452768535a14c90a231e9f3c0742f946d7a77fe50
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2051,7 +2051,7 @@ Library.
 
 
 azure-core
-1.32.0
+1.33.0
 MIT License
 Copyright (c) Microsoft Corporation.
 
@@ -6189,7 +6189,7 @@ MIT License
 
 
 multidict
-6.2.0
+6.3.2
 Apache Software License
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 
@@ -8656,7 +8656,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 typing_extensions
-4.13.0
+4.13.1
 UNKNOWN
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -9298,7 +9298,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.18.3
+1.19.0
 Apache Software License
 
                                  Apache License


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 485e1ad (#3339)](https://github.com/elastic/connectors/pull/3339)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)