### PR TITLE
[9.0] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 0863e59 (#3350)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:485e1ad61685b04c8ee006d452768535a14c90a231e9f3c0742f946d7a77fe50
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:0863e59b639952fd396dc2026cdc329d7415079e6949cfd7f42e59e2ac6dbc14
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:485e1ad61685b04c8ee006d452768535a14c90a231e9f3c0742f946d7a77fe50
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:0863e59b639952fd396dc2026cdc329d7415079e6949cfd7f42e59e2ac6dbc14
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5224,7 +5224,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 httpcore
-1.0.7
+1.0.8
 BSD License
 Copyright © 2020, [Encode OSS Ltd](https://www.encode.io/).
 All rights reserved.
@@ -6189,7 +6189,7 @@ MIT License
 
 
 multidict
-6.3.2
+6.4.3
 Apache Software License
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 
@@ -8656,7 +8656,7 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 typing_extensions
-4.13.1
+4.13.2
 UNKNOWN
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -8997,8 +8997,8 @@ made under the terms of *both* these licenses.
 
 
 urllib3
-2.3.0
-MIT License
+2.4.0
+UNKNOWN
 MIT License
 
 Copyright (c) 2008-2020 Andrey Petrov and contributors.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 0863e59 (#3350)](https://github.com/elastic/connectors/pull/3350)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)