### PR TITLE
[8.x] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 0863e59 (#3350)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:485e1ad61685b04c8ee006d452768535a14c90a231e9f3c0742f946d7a77fe50
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:0863e59b639952fd396dc2026cdc329d7415079e6949cfd7f42e59e2ac6dbc14
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:485e1ad61685b04c8ee006d452768535a14c90a231e9f3c0742f946d7a77fe50
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:0863e59b639952fd396dc2026cdc329d7415079e6949cfd7f42e59e2ac6dbc14
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,3 +1,69 @@
+Jinja2
+3.1.6
+BSD License
+Copyright 2007 Pallets
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+MarkupSafe
+3.0.2
+BSD License
+Copyright 2010 Pallets
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1.  Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
 PyJWT
 2.10.1
 MIT License
@@ -1985,7 +2051,7 @@ Library.
 
 
 azure-core
-1.32.0
+1.33.0
 MIT License
 Copyright (c) Microsoft Corporation.
 
@@ -5158,7 +5224,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 httpcore
-1.0.7
+1.0.8
 BSD License
 Copyright © 2020, [Encode OSS Ltd](https://www.encode.io/).
 All rights reserved.
@@ -6123,7 +6189,7 @@ MIT License
 
 
 multidict
-6.2.0
+6.4.3
 Apache Software License
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 
@@ -6479,7 +6545,7 @@ BSD
 UNKNOWN
 
 propcache
-0.3.0
+0.3.1
 Apache Software License
 
                                  Apache License
@@ -7986,7 +8052,7 @@ SOFTWARE.
 
 
 stone
-3.3.8
+3.3.9
 MIT License
 Copyright (c) 2020 Dropbox Inc., http://www.dropbox.com/
 
@@ -8353,8 +8419,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 typing_extensions
-4.12.2
-Python Software Foundation License
+4.13.2
+UNKNOWN
 A. HISTORY OF THE SOFTWARE
 ==========================
 
@@ -8694,8 +8760,8 @@ made under the terms of *both* these licenses.
 
 
 urllib3
-2.3.0
-MIT License
+2.4.0
+UNKNOWN
 MIT License
 
 Copyright (c) 2008-2020 Andrey Petrov and contributors.
@@ -8995,7 +9061,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.18.3
+1.19.0
 Apache Software License
 
                                  Apache License


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 0863e59 (#3350)](https://github.com/elastic/connectors/pull/3350)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)