### PR TITLE
Fix log line for when too many jobs are attempted to be scheduled

### DIFF
--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -181,7 +181,7 @@ class JobSchedulingService(BaseService):
                             functools.partial(self._schedule, connector)
                         ):
                             connector.log_debug(
-                                f"{self.display_name.capitalize()} service is already running {self.max_concurrency} concurrent scheduling jobs and can't run more at this point. Increase 'max_concurrent_scheduling_tasks' in config if you want the service to run more concurrent scheduling jobs."  # pyright: ignore
+                                f"Job Scheduling service is already running {self.max_concurrency} concurrent scheduling jobs and can't run more at this point. Increase 'max_concurrent_scheduling_tasks' in config if you want the service to run more concurrent scheduling jobs."  # pyright: ignore
                             )
 
                 except Exception as e:


### PR DESCRIPTION
Running 5 connectors locally can lead to the error in stdout:

```
[FMWK][15:07:12][ERROR] [job_scheduling_service] 'JobSchedulingService' object has no attribute 'display_name'
Traceback (most recent call last):
  File "/Users/artemshelkovnikov-m2/git_tree/connectors-py/connectors/services/job_scheduling.py", line 184, in _run
    f"Job Scheduling service is already running {self.max_concurrency} concurrent scheduling jobs and can't run more at this point. Increase 'max_concurrent_scheduling_tasks' in config if you want the service to run more concurrent scheduling jobs."  # pyright: ignore
       ^^^^^^^^^^^^^^^^^
AttributeError: 'JobSchedulingService' object has no attribute 'display_name'
```

Fixing it (code was copied wrongly from scheduling services)