### PR TITLE
handling ELASTIC_PASSWORD when running run-stack.sh

### DIFF
--- a/scripts/stack/copy-config.sh
+++ b/scripts/stack/copy-config.sh
@@ -38,6 +38,7 @@ if [[ "$is_example_config" == true ]]; then
     $sed_cmd '/elasticsearch.password/s/^#//g' "$script_config"
 
     if [[ "${ELASTIC_PASSWORD:-}" != "" ]]; then
-        $sed_cmd "s/elasticsearch.password:\ changeme/elasticsearch.password:\ \"$ELASTIC_PASSWORD\"/g" "$script_config"
+        esc_pass=$(printf '%s' "$ELASTIC_PASSWORD" | sed 's/[&|\\]/\\&/g')
+        $sed_cmd "/^elasticsearch\.password:/s|:.*|: ${esc_pass}|" "$script_config";
     fi
 fi

--- a/scripts/stack/wait-for-elasticsearch.sh
+++ b/scripts/stack/wait-for-elasticsearch.sh
@@ -8,7 +8,7 @@ else
 fi
 
 echo "Connecting to Elasticsearch on $ELASTICSEARCH_URL"
-until curl -u elastic:changeme --silent --output /dev/null --max-time 1 "$@" ${ELASTICSEARCH_URL}; do
+until curl -u elastic:${ELASTIC_PASSWORD:-"changeme"} --silent --output /dev/null --max-time 1 "$@" ${ELASTICSEARCH_URL}; do
   echo 'Waiting for Elasticsearch to be running...'
   sleep 2
 done


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3368



## Checklists


#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue: https://github.com/elastic/connectors/issues/3368
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)


