### PR TITLE
Make Job Scheduling service emit debug log instead of info

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3896,8 +3896,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 frozenlist
-1.5.0
-Apache Software License
+1.6.0
+Apache-2.0
 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -4542,8 +4542,8 @@ SOFTWARE.
 
 
 greenlet
-3.1.1
-MIT License
+3.2.0
+MIT AND Python-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:
 
@@ -7695,7 +7695,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 rsa
-4.9
+4.9.1
 Apache Software License
 Copyright 2011 Sybren A. Stüvel <sybren@stuvel.eu>
 
@@ -9298,7 +9298,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.19.0
+1.20.0
 Apache Software License
 
                                  Apache License

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -117,7 +117,7 @@ class JobSchedulingService(BaseService):
             if connector.features.sync_rules_enabled():
                 await connector.validate_filtering(validator=data_source)
 
-            self.logger.info(
+            connector.log_debug(
                 "Connector is configured correctly and can reach the data source"
             )
             await connector.connected()


### PR DESCRIPTION
Minor fix: now with every loop of SchedulingService this log line is emitted making it look like this:

```
[FMWK][15:22:30][INFO] Running connector service version 8.17.3
[FMWK][15:22:30][INFO] Loading config from /Users/artemshelkovnikov-m2/git_tree/connectors-py/connectors/../config.yml
[FMWK][15:22:30][INFO] Running preflight checks
[FMWK][15:22:30][INFO] Waiting for Elasticsearch at https://a75ef4b880e04d68a4632538f7c2b3df.us-west2.gcp.elastic-cloud.com:443 (so far: 0 secs)
[FMWK][15:22:30][INFO] Elasticsearch 8.17.3 and Connectors 8.17.3 are compatible
[FMWK][15:22:30][INFO] Extraction service is not configured, skipping its preflight check.
[FMWK][15:22:31][INFO] [job_scheduling_service] Job Scheduling Service started, listening to events from https://a75ef4b880e04d68a4632538f7c2b3df.us-west2.gcp.elastic-cloud.com:443
[FMWK][15:22:31][INFO] [content_sync_job_execution_service] Content sync job execution service started, listening to events from https://a75ef4b880e04d68a4632538f7c2b3df.us-west2.gcp.elastic-cloud.com:443
[FMWK][15:22:31][INFO] [access_control_sync_job_execution_service] Access control sync job execution service started, listening to events from https://a75ef4b880e04d68a4632538f7c2b3df.us-west2.gcp.elastic-cloud.com:443
[FMWK][15:22:38][INFO] [job_scheduling_service] Connector is configured correctly and can reach the data source
[FMWK][15:23:08][INFO] [job_scheduling_service] Connector is configured correctly and can reach the data source
[FMWK][15:23:39][INFO] [job_scheduling_service] Connector is configured correctly and can reach the data source
[FMWK][15:24:09][INFO] [job_scheduling_service] Connector is configured correctly and can reach the data source
```
Changes are:
- Moved this log line to debug 
- Made this log line come from connector logger, mentioning connector ID instead

So, was:

```
[FMWK][15:24:09][INFO] [job_scheduling_service] Connector is configured correctly and can reach the data source
```

Is now:

```
[FMWK][15:24:40][DEBUG] [Connector id: g9Mj8ZUBkReHFeyYFhFY, index name: connector-github-8af9] Connector is configured correctly and can reach the data source
```