### PR TITLE
New configurable service.idle_jobs_threshold

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -217,6 +217,10 @@
 #service.log_level: INFO
 #
 #
+##  The threshold (in seconds) before a sync job is considered idle.
+#service.idle_jobs_threshold: 300
+#
+#
 ## ------------------------------- Extraction Service ----------------------------------
 #
 ##  Local extraction service-related configurations.

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -102,6 +102,7 @@ def _default_config():
             "max_file_download_size": DEFAULT_MAX_FILE_SIZE,
             "job_cleanup_interval": 300,
             "log_level": "INFO",
+            "idle_jobs_threshold": 300
         },
         "sources": {
             "azure_blob_storage": "connectors.sources.azure_blob_storage:AzureBlobStorageDataSource",

--- a/connectors/protocol/connectors.py
+++ b/connectors/protocol/connectors.py
@@ -65,7 +65,6 @@ __all__ = [
     "ServiceTypeNotConfiguredError",
     "ServiceTypeNotSupportedError",
     "Status",
-    "IDLE_JOBS_THRESHOLD",
     "JOB_NOT_FOUND_ERROR",
     "Connector",
     "Features",
@@ -1095,7 +1094,6 @@ class Connector(ESDocument):
         }
 
 
-IDLE_JOBS_THRESHOLD = 60 * 5  # 5 minutes
 
 
 class SyncJobIndex(ESIndex):
@@ -1203,7 +1201,7 @@ class SyncJobIndex(ESIndex):
         async for job in self.get_all_docs(query=query):
             yield job
 
-    async def idle_jobs(self, connector_ids):
+    async def idle_jobs(self, idle_jobs_threshold, connector_ids):
         query = {
             "bool": {
                 "filter": [
@@ -1216,7 +1214,7 @@ class SyncJobIndex(ESIndex):
                             ]
                         }
                     },
-                    {"range": {"last_seen": {"lte": f"now-{IDLE_JOBS_THRESHOLD}s"}}},
+                    {"range": {"last_seen": {"lte": f"now-{idle_jobs_threshold}s"}}},
                 ]
             }
         }

--- a/connectors/services/job_cleanup.py
+++ b/connectors/services/job_cleanup.py
@@ -21,6 +21,7 @@ class JobCleanUpService(BaseService):
     def __init__(self, config):
         super().__init__(config, "job_cleanup_service")
         self.idling = int(self.service_config.get("job_cleanup_interval", 60 * 5))
+        self.idle_jobs_threshold = self.service_config.get("idle_jobs_threshold", 60 * 5)
         self.native_service_types = self.config.get("native_service_types", []) or []
         self.connector_ids = list(self.connectors.keys())
 
@@ -90,7 +91,7 @@ class JobCleanUpService(BaseService):
             ]
 
             marked_count = total_count = 0
-            async for job in self.sync_job_index.idle_jobs(connector_ids=connector_ids):
+            async for job in self.sync_job_index.idle_jobs(self.idle_jobs_threshold, connector_ids=connector_ids):
                 job_id = job.id
                 try:
                     connector_id = job.connector_id

--- a/tests/protocol/test_connectors.py
+++ b/tests/protocol/test_connectors.py
@@ -20,7 +20,6 @@ from connectors.filtering.validation import (
     InvalidFilteringError,
 )
 from connectors.protocol import (
-    IDLE_JOBS_THRESHOLD,
     JOB_NOT_FOUND_ERROR,
     Connector,
     ConnectorIndex,
@@ -2246,6 +2245,7 @@ async def test_idle_jobs(get_all_docs, set_env):
     job = Mock()
     get_all_docs.return_value = AsyncIterator([job])
     config = load_config(CONFIG)
+    idle_jobs_threshold = config["service"]["idle_jobs_threshold"]
     connector_ids = [1, 2]
     expected_query = {
         "bool": {
@@ -2259,13 +2259,13 @@ async def test_idle_jobs(get_all_docs, set_env):
                         ]
                     }
                 },
-                {"range": {"last_seen": {"lte": f"now-{IDLE_JOBS_THRESHOLD}s"}}},
+                {"range": {"last_seen": {"lte": f"now-{idle_jobs_threshold}s"}}},
             ]
         }
     }
 
     sync_job_index = SyncJobIndex(elastic_config=config["elasticsearch"])
-    jobs = [job async for job in sync_job_index.idle_jobs(connector_ids=connector_ids)]
+    jobs = [job async for job in sync_job_index.idle_jobs(idle_jobs_threshold, connector_ids=connector_ids)]
 
     get_all_docs.assert_called_with(query=expected_query)
     assert len(jobs) == 1

--- a/tests/services/test_job_cleanup.py
+++ b/tests/services/test_job_cleanup.py
@@ -22,6 +22,7 @@ CONFIG = {
         "max_errors": 20,
         "max_errors_span": 600,
         "job_cleanup_interval": 1,
+        "idle_jobs_threshold": 300
     },
     "native_service_types": ["mongodb"],
 }


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2298

This PR creates a new configurable field

`service.idle_jobs_threshold`

which is the amount of time (in seconds) before a sync job is considered 'idle'.

We make this field configurable by grabbing it from the `service` configurations and passing the value to `SyncJobIndex::idle_jobs()` as an new argument - previously this was a hardcoded global variable.

**TODO**
- [ ] Setting this value to zero should disable 'idle' jobs fully (?)
- [ ] Possibly provide a log message as to why this timeout occurred

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference