### PR TITLE
[8.x] Attempt to retry 403 errors when they are actually secondary throttling limit (#3358)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -7934,11 +7934,11 @@ made under the terms of *both* these licenses.
 
 
 soupsieve
-2.6
+2.7
 MIT License
 MIT License
 
-Copyright (c) 2018 - 2024 Isaac Muse <isaacmuse@gmail.com>
+Copyright (c) 2018 - 2025 Isaac Muse <isaacmuse@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Attempt to retry 403 errors when they are actually secondary throttling limit (#3358)](https://github.com/elastic/connectors/pull/3358)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)