### PR TITLE
Fix Confluence connector swallowing all errors

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4349,7 +4349,7 @@ SOFTWARE.
 
 
 greenlet
-3.2.0
+3.2.1
 MIT AND Python-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -108,6 +108,9 @@ class NotFound(Exception):
     pass
 
 
+class BadRequest(Exception):
+    pass
+
 class Unauthorized(Exception):
     pass
 
@@ -214,18 +217,21 @@ class ConfluenceClient:
 
             await self._sleeps.sleep(retry_seconds)
             raise ThrottledError
+        elif exception.status == 400:
+            self._logger.error(f"Received Bad Request error for URL: {url}")
+            raise BadRequest from exception
         elif exception.status == 401:
             self._logger.error(f"Received Unauthorized error for URL: {url}")
-            raise Unauthorized
+            raise Unauthorized from exception
         elif exception.status == 403:
             self._logger.error(f"Received Forbidden error for URL: {url}")
-            raise Forbidden
+            raise Forbidden from exception
         elif exception.status == 404:
             self._logger.error(f"Received Not Found error for URL: {url}")
-            raise NotFound
+            raise NotFound from exception
         elif exception.status == 500:
             self._logger.error(f"Internal Server Error occurred for URL: {url}")
-            raise InternalServerError
+            raise InternalServerError from exception
         else:
             self._logger.error(
                 f"Error while making a GET call for URL: {url}. Error details: {exception}"

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -274,6 +274,7 @@ class ConfluenceClient:
                     links.get("next")[1:],
                 )
             except Exception as exception:
+                # update this to catch specific errors/exceptions and re-raise exceptions for things we cannot handle
                 self._logger.warning(
                     f"Skipping data for type {url_name} from {url}. Exception: {exception}."
                 )
@@ -320,7 +321,7 @@ class ConfluenceClient:
                 start=0,
             )
         else:
-            search_documents = self.paginated_api_call(
+            search_documents = self.paginated_api_call( # can return a 200, 400 or 403. This is Search content, not Search user
                 url_name=SEARCH,
                 query=f"{query}&{SEARCH_QUERY}",
             )
@@ -329,7 +330,7 @@ class ConfluenceClient:
                 yield entity
 
     async def fetch_spaces(self):
-        async for response in self.paginated_api_call(
+        async for response in self.paginated_api_call( # can return a 200, 400 or 401m, This is Space > Get Spaces endpoint (not Get Space singular)
             url_name=SPACE,
             api_query=SPACE_QUERY,
         ):
@@ -350,7 +351,7 @@ class ConfluenceClient:
             return {}
 
     async def fetch_page_blog_documents(self, api_query):
-        async for response in self.paginated_api_call(
+        async for response in self.paginated_api_call( # can return 200, 400 or 401. This is Content > Search content by CQL endpoint
             url_name=CONTENT,
             api_query=api_query,
         ):
@@ -368,7 +369,7 @@ class ConfluenceClient:
                 yield document, attachment_count
 
     async def fetch_attachments(self, content_id):
-        async for response in self.paginated_api_call(
+        async for response in self.paginated_api_call( # can return 200 or 404. This is Content - attachments > Get attachments
             url_name=ATTACHMENT,
             api_query=ATTACHMENT_QUERY,
             id=content_id,

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -275,8 +275,6 @@ class ConfluenceClient:
         while True:
             try:
                 self._logger.debug(f"Starting pagination for API endpoint {url}")
-                # Should re-raise ServerDisconnectedError, InternalServerError
-                # Maybe handle NotFound, ThrottledError, regular Exception by not crashing out entirely?
                 response = await self.api_call(url=url)
                 json_response = await response.json()
                 links = json_response.get("_links")
@@ -287,6 +285,7 @@ class ConfluenceClient:
                     self.host_url,
                     links.get("next")[1:],
                 )
+            # re-raise on specific exceptions
             except ServerDisconnectedError:
                 self._logger.error(
                     f"Server was disconnected during paginated GET request to API endpoint {url}."
@@ -297,7 +296,6 @@ class ConfluenceClient:
                     f"Internal Server Error occurred during paginated GET request to API endpoint {url}"
                 )
                 raise
-
             except Exception as exception:
                 self._logger.warning(
                     f"Skipping data for type {url_name} from {url}. Exception: {exception}."

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -263,6 +263,7 @@ class ConfluenceClient:
         while True:
             try:
                 self._logger.debug(f"Starting pagination for API endpoint {url}")
+                # can raise ServerDisconnectedError, InternalServerError, NotFound error, ThrottledError, regular Exception
                 response = await self.api_call(url=url)
                 json_response = await response.json()
                 links = json_response.get("_links")

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -343,7 +343,7 @@ class ConfluenceClient:
                 start=0,
             )
         else:
-            search_documents = self.paginated_api_call( # can return a 200, 400 or 403. This is Search content, not Search user
+            search_documents = self.paginated_api_call(
                 url_name=SEARCH,
                 query=f"{query}&{SEARCH_QUERY}",
             )
@@ -352,7 +352,7 @@ class ConfluenceClient:
                 yield entity
 
     async def fetch_spaces(self):
-        async for response in self.paginated_api_call( # can return a 200, 400 or 401, This is Space > Get Spaces endpoint (not Get Space singular)
+        async for response in self.paginated_api_call(
             url_name=SPACE,
             api_query=SPACE_QUERY,
         ):
@@ -373,7 +373,7 @@ class ConfluenceClient:
             return {}
 
     async def fetch_page_blog_documents(self, api_query):
-        async for response in self.paginated_api_call( # can return 200, 400 or 401. This is Content > Search content by CQL endpoint
+        async for response in self.paginated_api_call(
             url_name=CONTENT,
             api_query=api_query,
         ):
@@ -391,7 +391,7 @@ class ConfluenceClient:
                 yield document, attachment_count
 
     async def fetch_attachments(self, content_id):
-        async for response in self.paginated_api_call( # can return 200 or 404. This is Content - attachments > Get attachments
+        async for response in self.paginated_api_call(
             url_name=ATTACHMENT,
             api_query=ATTACHMENT_QUERY,
             id=content_id,

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -107,8 +107,10 @@ class InternalServerError(Exception):
 class NotFound(Exception):
     pass
 
+
 class Unauthorized(Exception):
     pass
+
 
 class Forbidden(Exception):
     pass

--- a/connectors/sources/confluence.py
+++ b/connectors/sources/confluence.py
@@ -111,6 +111,7 @@ class NotFound(Exception):
 class BadRequest(Exception):
     pass
 
+
 class Unauthorized(Exception):
     pass
 

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -24,6 +24,7 @@ from connectors.sources.confluence import (
     CONFLUENCE_CLOUD,
     CONFLUENCE_DATA_CENTER,
     CONFLUENCE_SERVER,
+    BadRequest,
     ConfluenceClient,
     ConfluenceDataSource,
     Forbidden,
@@ -31,7 +32,6 @@ from connectors.sources.confluence import (
     InvalidConfluenceDataSourceTypeError,
     NotFound,
     Unauthorized,
-    BadRequest
 )
 from connectors.utils import ssl_context
 from tests.commons import AsyncIterator
@@ -869,6 +869,7 @@ async def test_get_with_400_status():
                     url="http://localhost:1000/err"
                 )
                 await response.json()
+
 
 @pytest.mark.asyncio
 @patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -853,6 +853,7 @@ async def test_get_with_429_status_without_retry_after_header():
 
 
 @pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
 async def test_get_with_401_status():
     error = ClientResponseError(None, None)
     error.status = 401
@@ -870,6 +871,7 @@ async def test_get_with_401_status():
 
 
 @pytest.mark.asyncio
+@patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
 async def test_get_with_403_status():
     error = ClientResponseError(None, None)
     error.status = 403

--- a/tests/sources/test_confluence.py
+++ b/tests/sources/test_confluence.py
@@ -26,11 +26,11 @@ from connectors.sources.confluence import (
     CONFLUENCE_SERVER,
     ConfluenceClient,
     ConfluenceDataSource,
+    Forbidden,
     InternalServerError,
     InvalidConfluenceDataSourceTypeError,
     NotFound,
-    Forbidden,
-    Unauthorized
+    Unauthorized,
 )
 from connectors.utils import ssl_context
 from tests.commons import AsyncIterator
@@ -851,6 +851,7 @@ async def test_get_with_429_status_without_retry_after_header():
 
     assert result == payload
 
+
 @pytest.mark.asyncio
 async def test_get_with_401_status():
     error = ClientResponseError(None, None)
@@ -867,6 +868,7 @@ async def test_get_with_401_status():
                 )
                 await response.json()
 
+
 @pytest.mark.asyncio
 async def test_get_with_403_status():
     error = ClientResponseError(None, None)
@@ -882,6 +884,7 @@ async def test_get_with_403_status():
                     url="http://localhost:1000/err"
                 )
                 await response.json()
+
 
 @pytest.mark.asyncio
 async def test_get_with_404_status():


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/2394

The goal of this PR is to update the following `paginated_api_call` function to re-raise and/or handle specific Exceptions instead of blanket-swallowing any Exceptions that arise.

Current exception-handling code:
https://github.com/elastic/connectors/blob/8c8d4a3f7775c6edbb598a81a2b67348a7244f3a/connectors/sources/confluence.py#L194-L198

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)