### PR TITLE
[8.18] 8.18 Release Activities for DRA / Backport (#3166)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,6 +2,7 @@
   "targetBranchChoices": [
     { "name": "main", "checked": true },
     "8.x",
+    "8.18",
     "8.17",
     "8.16",
     "8.15"
@@ -10,8 +11,8 @@
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
     "^v9.0.0$": "main",
-    "^v8.18.0$": "8.x",
-    "^v(\\d+).(\\d+)(.\\d+)+$": "$1.$2"
+    "^v8.19.0$": "8.x",
+    "^v(\\d+).(\\d+)(.\\d+)*$": "$1.$2"
   },
   "upstream": "elastic/connectors"
 }

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -57,6 +57,18 @@ spec:
           branch: 8.x
           cronline: '@daily'
           message: "Builds, tests, and pushes daily `8.x` DRA artifacts"
+        Daily 8.18:
+          branch: "8.18"
+          cronline: '@daily'
+          message: "Builds, tests, and pushes daily `8.18` DRA artifacts"
+        Daily 8.17:
+          branch: "8.17"
+          cronline: '@daily'
+          message: "Builds, tests, and pushes daily `8.17` DRA artifacts"
+        Daily 8.16:
+          branch: "8.16"
+          cronline: '@daily'
+          message: "Builds, tests, and pushes daily `8.16` DRA artifacts"
       provider_settings:
         skip_pull_request_builds_for_existing_commits: false
         build_pull_request_labels_changed: true
@@ -97,6 +109,14 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
+        Daily 8_18:
+          branch: '8.18'
+          cronline: '@daily'
+          message: "Runs daily `8.18` e2e test"
+        Daily 8_17:
+          branch: '8.17'
+          cronline: '@daily'
+          message: "Runs daily `8.17` e2e test"
         Daily 8_16:
           branch: '8.16'
           cronline: '@daily'
@@ -147,6 +167,14 @@ spec:
         trigger_mode: "none"
       repository: "elastic/connectors"
       schedules:
+        Daily 8_18:
+          branch: '8.18'
+          cronline: '@daily'
+          message: "Runs daily `8.18` e2e aarch64 test"
+        Daily 8_17:
+          branch: '8.17'
+          cronline: '@daily'
+          message: "Runs daily `8.17` e2e aarch64 test"
         Daily 8_16:
           branch: '8.16'
           cronline: '@daily'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [8.18 Release Activities for DRA / Backport (#3166)](https://github.com/elastic/connectors/pull/3166)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)