### PR TITLE
[8.19] Rename 8.x to 8.19 (#3387)

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,7 +1,8 @@
 {
   "targetBranchChoices": [
     { "name": "main", "checked": true },
-    "8.x",
+    "9.0",
+    "8.19",
     "8.18",
     "8.17",
     "8.16",
@@ -10,8 +11,7 @@
   "fork": false,
   "targetPRLabels": ["backport"],
   "branchLabelMapping": {
-    "^v9.0.0$": "main",
-    "^v8.19.0$": "8.x",
+    "^v9.1.0$": "main",
     "^v(\\d+).(\\d+)(.\\d+)*$": "$1.$2"
   },
   "upstream": "elastic/connectors"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -567,7 +567,7 @@ steps:
   # ----
   - group: ":truck: Packaging and DRA"
     key: "mbp_dra_group"
-    if: "(build.branch == \"main\" || build.branch == \"8.x\" || build.branch == \"8.16\" || build.branch == \"8.17\" || build.branch == \"8.18\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
+    if: "(build.branch == \"main\" || build.branch == \"9.0\" || build.branch == \"8.19\" || build.branch == \"8.18\" || build.branch == \"8.17\" || build.pull_request.labels includes \"ci:packaging\")" # Add new maintenance branches here
     depends_on:
       - "lint"
       - "unit_tests"

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5369,7 +5369,7 @@ Apache Software License
 UNKNOWN
 
 h11
-0.14.0
+0.16.0
 MIT License
 The MIT License (MIT)
 
@@ -5396,7 +5396,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 httpcore
-1.0.8
+1.0.9
 BSD License
 Copyright © 2020, [Encode OSS Ltd](https://www.encode.io/).
 All rights reserved.

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -53,10 +53,14 @@ spec:
           branch: main
           cronline: '@daily'
           message: "Builds, tests, and pushes daily `main` DRA artifacts"
-        Daily 8.x:
-          branch: 8.x
+        Daily 9.0:
+          branch: "9.0"
           cronline: '@daily'
-          message: "Builds, tests, and pushes daily `8.x` DRA artifacts"
+          message: "Builds, tests, and pushes daily `9.0` DRA artifacts"
+        Daily 8.19:
+          branch: "8.19"
+          cronline: '@daily'
+          message: "Builds, tests, and pushes daily `8.19` DRA artifacts"
         Daily 8.18:
           branch: "8.18"
           cronline: '@daily'
@@ -125,10 +129,14 @@ spec:
           branch: '8.15'
           cronline: '@daily'
           message: "Runs daily `8.15` e2e test"
-        Daily 8_x:
-          branch: '8.x'
+        Daily 8_19:
+          branch: '8.19'
           cronline: '@daily'
-          message: "Runs daily `8.x` e2e test"
+          message: "Runs daily `8.19` e2e test"
+        Daily 9_0:
+          branch: '9.0'
+          cronline: '@daily'
+          message: "Runs daily `9.0` e2e test"
         Daily main:
           branch: main
           cronline: '@daily'
@@ -183,10 +191,14 @@ spec:
           branch: '8.15'
           cronline: '@daily'
           message: "Runs daily `8.15` e2e aarch64 test"
-        Daily 8_x:
-          branch: '8.x'
+        Daily 8_19:
+          branch: '8.19'
           cronline: '@daily'
-          message: "Runs daily `8.x` e2e aarch64 test"
+          message: "Runs daily `8.19` e2e aarch64 test"
+        Daily 9_0:
+          branch: '9.0'
+          cronline: '@daily'
+          message: "Runs daily `9.0` e2e aarch64 test"
         Daily main:
           branch: main
           cronline: '@daily'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Rename 8.x to 8.19 (#3387)](https://github.com/elastic/connectors/pull/3387)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)