### PR TITLE
[9.0] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to cfb2947 (#3414)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:effbe01646f8bb4cec592a68cd0774ca499cb6d821bd7a54f861c53e9464c990
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:cfb2947815aa0ffd32ebfe6fbbb2f915d2754ccc5cb46860b73f58f811818a3a
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:effbe01646f8bb4cec592a68cd0774ca499cb6d821bd7a54f861c53e9464c990
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:cfb2947815aa0ffd32ebfe6fbbb2f915d2754ccc5cb46860b73f58f811818a3a
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4115,7 +4115,7 @@ Apache Software License
 
 
 google-auth
-2.40.0
+2.40.1
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -4349,7 +4349,7 @@ SOFTWARE.
 
 
 greenlet
-3.2.1
+3.2.2
 MIT AND Python-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to cfb2947 (#3414)](https://github.com/elastic/connectors/pull/3414)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)