### PR TITLE
[8.18] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to cfb2947 (#3414)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:e47343f24b3fd7929333c655bb60910a967113dbc557783d0ce9dc87551123bc
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:cfb2947815aa0ffd32ebfe6fbbb2f915d2754ccc5cb46860b73f58f811818a3a
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:e47343f24b3fd7929333c655bb60910a967113dbc557783d0ce9dc87551123bc
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:cfb2947815aa0ffd32ebfe6fbbb2f915d2754ccc5cb46860b73f58f811818a3a
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3521,7 +3521,7 @@ Apache Software License
 
 
 elasticsearch-connectors
-8.18.0
+8.18.2
 Apache Software License
 Elastic License 2.0
 
@@ -4115,7 +4115,7 @@ Apache Software License
 
 
 google-auth
-2.38.0
+2.40.1
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004
@@ -4349,8 +4349,8 @@ SOFTWARE.
 
 
 greenlet
-3.1.1
-MIT License
+3.2.2
+MIT AND Python-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:
 
@@ -5004,7 +5004,7 @@ Apache Software License
 UNKNOWN
 
 h11
-0.14.0
+0.16.0
 MIT License
 The MIT License (MIT)
 
@@ -5031,7 +5031,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 httpcore
-1.0.8
+1.0.9
 BSD License
 Copyright © 2020, [Encode OSS Ltd](https://www.encode.io/).
 All rights reserved.
@@ -7127,7 +7127,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 rsa
-4.9
+4.9.1
 Apache Software License
 Copyright 2011 Sybren A. Stüvel <sybren@stuvel.eu>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to cfb2947 (#3414)](https://github.com/elastic/connectors/pull/3414)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)