### PR TITLE
Add slack settings directly in pipelines

### DIFF
--- a/.buildkite/nightly_steps.yml
+++ b/.buildkite/nightly_steps.yml
@@ -12,6 +12,12 @@ definitions:
           signal_reason: none
           limit: 2
 
+notify:
+  - if: build.branch =~ /^((main)|([0-9]+\.[0-9]+))$/ && (build.state == "failed" || pipeline.started_passing)
+    slack:
+      channels:
+        - "#search-et-alerts"
+
 env:
   DOCKERFILE_FTEST_PATH: "Dockerfile.ftest.wolfi"
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,12 @@ definitions:
           signal_reason: none
           limit: 2
 
+notify:
+  - if: build.branch =~ /^((main)|([0-9]+\.[0-9]+))$/ && (build.state == "failed" || pipeline.started_passing)
+    slack:
+      channels:
+        - "#search-et-alerts"
+
 env:
   DOCKERFILE_FTEST_PATH: "Dockerfile.ftest.wolfi"
 

--- a/.buildkite/release-pipeline.yml
+++ b/.buildkite/release-pipeline.yml
@@ -1,5 +1,10 @@
 ## 🏠/.buildkite/pipeline-release.yml
 # Manual triggered pipeline to build and publish Docker images
+notify:
+  - if: build.branch =~ /^((main)|([0-9]+\.[0-9]+))$/ && (build.state == "failed" || pipeline.started_passing)
+    slack:
+      channels:
+        - "#search-et-alerts"
 
 env:
   MANUAL_RELEASE: true # unlike DRA, this pipeline should suffix its artifacts with a timestamp

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -49,10 +49,6 @@ spec:
       branch_configuration: "main"
       pipeline_file: ".buildkite/pipeline.yml"
       repository: "elastic/connectors"
-      env:
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true' # Must be in quotes to make it a string
-        SLACK_NOTIFICATIONS_CHANNEL: '#search-et-alerts'
-        SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       schedules:
         Daily main:
           branch: main
@@ -113,10 +109,6 @@ spec:
       provider_settings:
         trigger_mode: "none"
       repository: "elastic/connectors"
-      env:
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true' # Must be in quotes to make it a string
-        SLACK_NOTIFICATIONS_CHANNEL: '#search-et-alerts'
-        SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       schedules:
         Daily 8_18:
           branch: '8.18'
@@ -171,10 +163,6 @@ spec:
       provider_settings:
         trigger_mode: "none"
       repository: "elastic/connectors"
-      env:
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true' # Must be in quotes to make it a string
-        SLACK_NOTIFICATIONS_CHANNEL: '#search-et-alerts'
-        SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       schedules:
         Daily 8_18:
           branch: '8.18'
@@ -228,10 +216,6 @@ spec:
       pipeline_file: ".buildkite/release-pipeline.yml"
       provider_settings:
         trigger_mode: "none"
-      env:
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true' # Must be in quotes to make it a string
-        SLACK_NOTIFICATIONS_CHANNEL: '#search-et-alerts'
-        SLACK_NOTIFICATIONS_ON_SUCCESS: 'true'
       teams:
         search-extract-and-transform: {}
         search-productivity-team: {}


### PR DESCRIPTION
undoes https://github.com/elastic/connectors/pull/3425/files, and puts them instead directly into the pipeline definitions.

This should explicitly let us only notify on failure and first-pass.

Also uses a regex to keep us from needing to update the branches we care about. `catalog-info.yml` will still control which branches/pipelines run on a schedule. 