### PR TITLE
[8.18] Make job_scheduling service run schedule in a task pool (#3335)

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -201,6 +201,10 @@
 #service.max_concurrent_access_control_syncs: 1
 #
 #
+##  The maximum number of concurrent job scheduling tasks.
+#service.max_concurrent_scheduling_tasks: 4
+#
+#
 ##  The maximum size (in bytes) of files that the framework should be willing
 ##    to download and/or process.
 #service.max_file_download_size: 10485760

--- a/connectors/config.py
+++ b/connectors/config.py
@@ -98,6 +98,7 @@ def _default_config():
             "max_errors_span": 600,
             "max_concurrent_content_syncs": 1,
             "max_concurrent_access_control_syncs": 1,
+            "max_concurrent_scheduling_tasks": 4,
             "max_file_download_size": DEFAULT_MAX_FILE_SIZE,
             "job_cleanup_interval": 300,
             "log_level": "INFO",

--- a/connectors/services/job_scheduling.py
+++ b/connectors/services/job_scheduling.py
@@ -11,6 +11,7 @@ Event loop
 - mirrors an Elasticsearch index with a collection of documents
 """
 
+import functools
 from datetime import datetime, timezone
 
 from connectors.es.client import License, with_concurrency_control
@@ -27,6 +28,7 @@ from connectors.protocol import (
 )
 from connectors.services.base import BaseService
 from connectors.source import get_source_klass
+from connectors.utils import ConcurrentTasks
 
 
 class JobSchedulingService(BaseService):
@@ -38,6 +40,14 @@ class JobSchedulingService(BaseService):
         self.heartbeat_interval = self.service_config["heartbeat"]
         self.source_list = config["sources"]
         self.last_wake_up_time = datetime.now(timezone.utc)
+        self.max_concurrency = self.service_config.get(
+            "max_concurrent_scheduling_tasks"
+        )
+        self.schedule_tasks_pool = ConcurrentTasks(max_concurrency=self.max_concurrency)
+
+    def stop(self):
+        super().stop()
+        self.schedule_tasks_pool.cancel()
 
     async def _schedule(self, connector):
         if self.running is False:
@@ -162,13 +172,19 @@ class JobSchedulingService(BaseService):
                         native_service_types=native_service_types,
                         connector_ids=connector_ids,
                     ):
-                        await self._schedule(connector)
+                        if not self.schedule_tasks_pool.try_put(
+                            functools.partial(self._schedule, connector)
+                        ):
+                            connector.log_debug(
+                                f"{self.display_name.capitalize()} service is already running {self.max_concurrency} concurrent scheduling jobs and can't run more at this point. Increase 'max_concurrent_scheduling_tasks' in config if you want the service to run more concurrent scheduling jobs."  # pyright: ignore
+                            )
 
                 except Exception as e:
                     self.logger.critical(e, exc_info=True)
                     self.raise_if_spurious(e)
 
                 # Immediately break instead of sleeping
+                await self.schedule_tasks_pool.join()
                 if not self.running:
                     break
                 self.last_wake_up_time = datetime.now(timezone.utc)

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -3,6 +3,7 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -478,3 +479,32 @@ async def test_run_when_connector_validate_config_fails(
     data_source_mock.close.assert_awaited_once()
 
     connector.error.assert_awaited_with(error)
+
+@pytest.mark.asyncio
+@patch("connectors.services.job_scheduling.get_source_klass")
+async def test_run_when_validation_is_very_slow(
+    get_source_klass_mock, connector_index_mock, set_env
+):
+    data_source_mock = Mock()
+
+    def _source_klass(config):
+        return data_source_mock
+
+    async def _remote_validation():
+        await asyncio.sleep(999)
+
+    get_source_klass_mock.return_value = _source_klass
+
+    data_source_mock.validate_config_fields = Mock()
+    data_source_mock.validate_config = AsyncMock(side_effect=_remote_validation)
+    data_source_mock.ping = AsyncMock()
+    data_source_mock.close = AsyncMock()
+
+    connector = mock_connector(next_sync=datetime.now(timezone.utc))
+    connector_index_mock.supported_connectors.return_value = AsyncIterator([connector])
+    await create_and_run_service(JobSchedulingService, stop_after=0.15)
+
+    data_source_mock.validate_config_fields.assert_called()
+    data_source_mock.validate_config.assert_awaited_once()
+    data_source_mock.ping.assert_not_awaited()
+    data_source_mock.close.assert_awaited_once()

--- a/tests/services/test_job_scheduling.py
+++ b/tests/services/test_job_scheduling.py
@@ -480,6 +480,7 @@ async def test_run_when_connector_validate_config_fails(
 
     connector.error.assert_awaited_with(error)
 
+
 @pytest.mark.asyncio
 @patch("connectors.services.job_scheduling.get_source_klass")
 async def test_run_when_validation_is_very_slow(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Make job_scheduling service run schedule in a task pool (#3335)](https://github.com/elastic/connectors/pull/3335)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)