### PR TITLE
Add support for default UUID type 4 serialization

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3703,7 +3703,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 frozenlist
-1.6.2
+1.7.0
 Apache-2.0
 Apache License
                            Version 2.0, January 2004
@@ -5977,7 +5977,7 @@ BSD
 UNKNOWN
 
 propcache
-0.3.1
+0.3.2
 Apache Software License
 
                                  Apache License
@@ -6907,7 +6907,7 @@ SOFTWARE.
 
 
 requests
-2.32.3
+2.32.4
 Apache Software License
 
                                  Apache License
@@ -8422,7 +8422,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 yarl
-1.20.0
+1.20.1
 Apache Software License
 
                                  Apache License

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -177,8 +177,6 @@ class MongoDataSource(BaseDataSource):
         try:
             client_params = {}
 
-            client_params["uuidRepresentation"] = "standard"
-
             if self.configuration["direct_connection"]:
                 client_params["directConnection"] = True
 

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -252,7 +252,7 @@ class MongoDataSource(BaseDataSource):
     async def get_docs(self, filtering=None):
         with self.get_client() as client:
             db = client[self.configuration["database"]]
-            self.collection = db[self.configuration["collection"]]
+            collection = db[self.configuration["collection"]]
 
             if filtering is not None and filtering.has_advanced_rules():
                 advanced_rules = filtering.get_advanced_rules()
@@ -260,19 +260,19 @@ class MongoDataSource(BaseDataSource):
                 if "find" in advanced_rules:
                     find_kwargs = advanced_rules.get("find", {})
 
-                    async for doc in self.collection.find(**find_kwargs):
+                    async for doc in collection.find(**find_kwargs):
                         yield self.do_serialize(doc), None
 
                 elif "aggregate" in advanced_rules:
                     aggregate_kwargs = deepcopy(advanced_rules.get("aggregate", {}))
                     pipeline = aggregate_kwargs.pop("pipeline", [])
 
-                    async for doc in self.collection.aggregate(
+                    async for doc in collection.aggregate(
                         pipeline=pipeline, **aggregate_kwargs
                     ):
                         yield self.do_serialize(doc), None
             else:
-                async for doc in self.collection.find():
+                async for doc in collection.find():
                     yield self.do_serialize(doc), None
 
     def check_conflicting_values(self, value):

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -241,7 +241,6 @@ class MongoDataSource(BaseDataSource):
             elif isinstance(value, DBRef):
                 value = _serialize(value.as_doc().to_dict())
             elif isinstance(value, Binary):
-                print(value.subtype)
                 if value.subtype == UUID_SUBTYPE:
                     value = value.as_uuid()
                 elif value.subtype == OLD_UUID_SUBTYPE:

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -217,7 +217,7 @@ class MongoDataSource(BaseDataSource):
             await client.admin.command("ping")
 
     # TODO: That's a lot of work. Find a better way
-    def do_serialize(self, doc):
+    def serialize(self, doc):
         def _serialize(value):
             if isinstance(value, ObjectId):
                 value = str(value)
@@ -261,7 +261,7 @@ class MongoDataSource(BaseDataSource):
                     find_kwargs = advanced_rules.get("find", {})
 
                     async for doc in collection.find(**find_kwargs):
-                        yield self.do_serialize(doc), None
+                        yield self.serialize(doc), None
 
                 elif "aggregate" in advanced_rules:
                     aggregate_kwargs = deepcopy(advanced_rules.get("aggregate", {}))
@@ -270,10 +270,10 @@ class MongoDataSource(BaseDataSource):
                     async for doc in collection.aggregate(
                         pipeline=pipeline, **aggregate_kwargs
                     ):
-                        yield self.do_serialize(doc), None
+                        yield self.serialize(doc), None
             else:
                 async for doc in collection.find():
-                    yield self.do_serialize(doc), None
+                    yield self.serialize(doc), None
 
     def check_conflicting_values(self, value):
         if value == "true":

--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -175,7 +175,9 @@ class MongoDataSource(BaseDataSource):
     def get_client(self):
         certfile = ""
         try:
-            client_params = {"uuidRepresentation": "standard"}
+            client_params = {}
+
+            client_params["uuidRepresentation"] = "standard"
 
             if self.configuration["direct_connection"]:
                 client_params["directConnection"] = True

--- a/tests/sources/fixtures/mongodb/fixture.py
+++ b/tests/sources/fixtures/mongodb/fixture.py
@@ -5,6 +5,7 @@
 #
 # ruff: noqa: T201
 import os
+from uuid import uuid4
 
 import bson
 from faker import Faker
@@ -15,7 +16,9 @@ _SIZES = {"small": 750, "medium": 1500, "large": 3000}
 NUMBER_OF_RECORDS_TO_DELETE = 50
 
 fake = Faker()
-client = MongoClient("mongodb://admin:justtesting@127.0.0.1:27021")
+client = MongoClient(
+    "mongodb://admin:justtesting@127.0.0.1:27021?uuidRepresentation=standard"
+)
 
 
 async def load():
@@ -27,6 +30,7 @@ async def load():
             "birthdate": fake.date(),
             "time": fake.time(),
             "comment": fake.sentence(),
+            "unique_id": uuid4(),
         }
 
     record_number = _SIZES[DATA_SIZE] + NUMBER_OF_RECORDS_TO_DELETE

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -435,7 +435,7 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise(
                     b'\xab\xdd\xda.\x96\xf9OQ\xa5\x12\xf1"[\x07\x17\xc0', 4
                 )
             },
-            {"some_uuid":  UUID('abddda2e-96f9-4f51-a512-f1225b0717c0')},
+            {"some_uuid": UUID("abddda2e-96f9-4f51-a512-f1225b0717c0")},
         ),
         (
             {
@@ -443,9 +443,7 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise(
                     b'\xab\xdd\xda.\x96\xf9OQ\xa5\x12\xf1"[\x07\x17\xc0', 3
                 )
             },
-            {
-                "some_uuid": None
-            },
+            {"some_uuid": None},
         ),
     ],
 )

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -8,9 +8,10 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
+from uuid import UUID
 
 import pytest
-from bson import DBRef, ObjectId
+from bson import Binary, DBRef, ObjectId
 from bson.decimal128 import Decimal128
 from pymongo.errors import OperationFailure
 
@@ -427,6 +428,24 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise(
         (
             {"id": ObjectId("507f1f77bcf86cd799439011")},
             {"id": "507f1f77bcf86cd799439011"},
+        ),
+        (
+            {
+                "some_uuid": Binary(
+                    b'\xab\xdd\xda.\x96\xf9OQ\xa5\x12\xf1"[\x07\x17\xc0', 4
+                )
+            },
+            {"some_uuid":  UUID('abddda2e-96f9-4f51-a512-f1225b0717c0')},
+        ),
+        (
+            {
+                "some_uuid": Binary(
+                    b'\xab\xdd\xda.\x96\xf9OQ\xa5\x12\xf1"[\x07\x17\xc0', 3
+                )
+            },
+            {
+                "some_uuid": None
+            },
         ),
     ],
 )

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -459,9 +459,9 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise(
         ),
     ],
 )
-async def test_do_serialize(raw, output):
+async def test_serialize(raw, output):
     async with create_mongo_source() as source:
-        assert source.do_serialize(raw) == output
+        assert source.serialize(raw) == output
 
 
 @pytest.mark.asyncio

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -272,7 +272,7 @@ async def test_mongo_data_source_get_docs_when_advanced_rules_aggregate_present(
                 client_mock.__getitem__.return_value = database_mock
 
                 collection_mock = MagicMock()
-                collection_mock.find = AsyncIterator(items=[{"_id": 1}])
+                collection_mock.aggregate = AsyncIterator(items=[{"_id": 1}])
                 database_mock.__getitem__.return_value = collection_mock
 
             async for _ in source.get_docs(filtering):

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -8,9 +8,10 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
+from uuid import UUID
 
 import pytest
-from bson import DBRef, ObjectId
+from bson import Binary, DBRef, ObjectId
 from bson.decimal128 import Decimal128
 from pymongo.errors import OperationFailure
 
@@ -427,6 +428,26 @@ async def test_validate_config_when_configuration_valid_then_does_not_raise(
         (
             {"id": ObjectId("507f1f77bcf86cd799439011")},
             {"id": "507f1f77bcf86cd799439011"},
+        ),
+        (
+            {"some_real_uuid": UUID("abddda2e-96f9-4f51-a512-f1225b0717c0")},
+            {"some_real_uuid": UUID("abddda2e-96f9-4f51-a512-f1225b0717c0")},
+        ),
+        (
+            {
+                "some_binary_uuid": Binary(
+                    b'\xab\xdd\xda.\x96\xf9OQ\xa5\x12\xf1"[\x07\x17\xc0', 4
+                )
+            },
+            {"some_binary_uuid": UUID("abddda2e-96f9-4f51-a512-f1225b0717c0")},
+        ),
+        (
+            {
+                "some_binary_uuid": Binary(
+                    b'\xab\xdd\xda.\x96\xf9OQ\xa5\x12\xf1"[\x07\x17\xc0', 3
+                )
+            },
+            {"some_binary_uuid": None},
         ),
     ],
 )

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -229,16 +229,13 @@ async def test_mongo_data_source_get_docs_when_advanced_rules_find_present():
         )
 
         with mock.patch.object(source, "get_client") as mock_client:
-            client_mock = MagicMock()
+            with mock_client() as client_mock:
+                database_mock = MagicMock()
+                client_mock.__getitem__.return_value = database_mock
 
-            mock_client.return_value.__enter__.return_value = client_mock
-
-            database_mock = MagicMock()
-            client_mock.__getitem__.return_value = database_mock
-
-            collection_mock = MagicMock()
-            collection_mock.find = AsyncIterator(items=[{"_id": 1}])
-            database_mock.__getitem__.return_value = collection_mock
+                collection_mock = MagicMock()
+                collection_mock.find = AsyncIterator(items=[{"_id": 1}])
+                database_mock.__getitem__.return_value = collection_mock
 
             async for _ in source.get_docs(filtering):
                 pass
@@ -270,16 +267,13 @@ async def test_mongo_data_source_get_docs_when_advanced_rules_aggregate_present(
         )
 
         with mock.patch.object(source, "get_client") as mock_client:
-            client_mock = MagicMock()
+            with mock_client() as client_mock:
+                database_mock = MagicMock()
+                client_mock.__getitem__.return_value = database_mock
 
-            mock_client.return_value.__enter__.return_value = client_mock
-
-            database_mock = MagicMock()
-            client_mock.__getitem__.return_value = database_mock
-
-            collection_mock = MagicMock()
-            collection_mock.aggregate = AsyncIterator(items=[{"_id": 1}])
-            database_mock.__getitem__.return_value = collection_mock
+                collection_mock = MagicMock()
+                collection_mock.find = AsyncIterator(items=[{"_id": 1}])
+                database_mock.__getitem__.return_value = collection_mock
 
             async for _ in source.get_docs(filtering):
                 pass


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3299

MongoDB is pretty special about UUID handling.

Before a certain version of MongoDB, there was UUID type 3 - driver-specific UUID. Here's example from docs:

```
An example GUID created and displayed in a C# application would be shown as follows:

00010203-0405-0607-0809-0A0B0C0D0E0F

The MongoDB C# driver (in the default configuration) will convert it to a Binary database representation and store it with the following byte order:

03 02 01 00 05 04 07 06 08 09 0A 0B 0C 0D 0E 0F

However, the Java driver used to access the same field will return and display the following:

06070405-0001-0203-0F0E-0D0C0B0A0908

The Python driver will display something different again:

03020100-0504-0706-0809-0A0B0C0D0E0F
```

At some point type 4 was introduced, which is serialized in the same way across all the drivers.

Now, second part is that it's possible to choose `uuidRepresentation` (see https://pymongo.readthedocs.io/en/stable/api/bson/binary.html#bson.binary.UuidRepresentation) when initalising the connection - for example through connection string: `mongodb://127.0.0.1:27021?uuidRepresentation=standard` - this will use the modern serialisation format that's cross-compatible.

If the application uses old Java client that writes legacy format, it can be done with `mongodb://127.0.0.1:27021?uuidRepresentation=javaLegacy`.

Without this `uuidRepresentation` field set the MongoDB client returns instances of Binary type - it has a value (UUID) + type (3 or 4 for UUID).

When `uuidRepresentation` is set, though, the driver decodes the field and returns regular python UUID objects that can be serialised without any addition.

Default `uuidRepresentation` is `unspecified` and by default MongoDB driver we use returns Binary instances.

What this PR does is: it parses Binary fields it receive with type=4 and treats them as UUID. If type=3 is received, a warning is emitted and field is skipped.

If a user still wants to sync MongoDB instance with type=3 UUIDs, they can modify their connection string to set `uuidRepresentation` with correct value and it will naturally make the connector work.

Additionally to the above, I've moved some stuff around and fixed minor problems.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

## Release Note

Better support for UUID serialisation - modern UUIDs are properly handled out of the box.