### PR TITLE
Refactor MongoDB connector `get_client` method to not produce unexpected side-effects

### DIFF
--- a/connectors/sources/mongo.py
+++ b/connectors/sources/mongo.py
@@ -253,7 +253,7 @@ class MongoDataSource(BaseDataSource):
             db = client[self.configuration["database"]]
             collection = db[self.configuration["collection"]]
 
-            if filtering is not None and filtering.has_advanced_rules():
+            if filtering and filtering.has_advanced_rules():
                 advanced_rules = filtering.get_advanced_rules()
 
                 if "find" in advanced_rules:

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -7,10 +7,11 @@ import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime
 from unittest import mock
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
+from uuid import UUID
 
 import pytest
-from bson import DBRef, ObjectId
+from bson import Binary, DBRef, ObjectId
 from bson.decimal128 import Decimal128
 from pymongo.errors import OperationFailure
 
@@ -20,12 +21,15 @@ from connectors.sources.mongo import MongoAdvancedRulesValidator, MongoDataSourc
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
+DEFAULT_DATABASE = "db"
+DEFAULT_COLLECTION = "col"
+
 
 @asynccontextmanager
 async def create_mongo_source(
     host="mongodb://127.0.0.1:27021",
-    database="db",
-    collection="col",
+    database=DEFAULT_DATABASE,
+    collection=DEFAULT_COLLECTION,
     ssl_enabled=False,
     ssl_ca="",
     tls_insecure=False,
@@ -202,10 +206,6 @@ async def test_ping_when_called_then_does_not_raise(*args):
 @pytest.mark.asyncio
 async def test_mongo_data_source_get_docs_when_advanced_rules_find_present():
     async with create_mongo_source() as source:
-        collection_mock = Mock()
-        collection_mock.find = AsyncIterator(items=[{"_id": 1}])
-        source.collection = collection_mock
-
         filtering = Filter(
             {
                 "advanced_snippet": {
@@ -229,7 +229,13 @@ async def test_mongo_data_source_get_docs_when_advanced_rules_find_present():
         )
 
         with mock.patch.object(source, "get_client") as mock_client:
-            mock_client.__enter__.return_value = Mock()
+            with mock_client() as client_mock:
+                database_mock = MagicMock()
+                client_mock.__getitem__.return_value = database_mock
+
+                collection_mock = MagicMock()
+                collection_mock.find = AsyncIterator(items=[{"_id": 1}])
+                database_mock.__getitem__.return_value = collection_mock
 
             async for _ in source.get_docs(filtering):
                 pass
@@ -241,10 +247,6 @@ async def test_mongo_data_source_get_docs_when_advanced_rules_find_present():
 @pytest.mark.asyncio
 async def test_mongo_data_source_get_docs_when_advanced_rules_aggregate_present():
     async with create_mongo_source() as source:
-        collection_mock = Mock()
-        collection_mock.aggregate = AsyncIterator(items=[{"_id": 1}])
-        source.collection = collection_mock
-
         filtering = Filter(
             {
                 "advanced_snippet": {
@@ -265,7 +267,14 @@ async def test_mongo_data_source_get_docs_when_advanced_rules_aggregate_present(
         )
 
         with mock.patch.object(source, "get_client") as mock_client:
-            mock_client.__enter__.return_value = Mock()
+            with mock_client() as client_mock:
+                database_mock = MagicMock()
+                client_mock.__getitem__.return_value = database_mock
+
+                collection_mock = MagicMock()
+                collection_mock.aggregate = AsyncIterator(items=[{"_id": 1}])
+                database_mock.__getitem__.return_value = collection_mock
+
             async for _ in source.get_docs(filtering):
                 pass
 

--- a/tests/sources/test_mongo.py
+++ b/tests/sources/test_mongo.py
@@ -8,10 +8,9 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock, Mock
-from uuid import UUID
 
 import pytest
-from bson import Binary, DBRef, ObjectId
+from bson import DBRef, ObjectId
 from bson.decimal128 import Decimal128
 from pymongo.errors import OperationFailure
 


### PR DESCRIPTION
A bunch of MongoDB connector simplifications:

- Remove `remote_temp_file` method as it's pure + not really reusable
- Changed `get_client` to just yield client and stop populating `self.collection` - really problematic 
  - Adjusted `get_docs` to init client in the beginning of the method
  - Adjusted tests

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)
