### PR TITLE
Remove MySQLQueries class and inline its methods

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1880,7 +1880,7 @@ SOFTWARE.
 
 
 azure-core
-1.34.0
+1.35.0
 MIT License
 Copyright (c) Microsoft Corporation.
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5655,7 +5655,7 @@ MIT License
 
 
 multidict
-6.6.1
+6.6.3
 Apache License 2.0
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 


### PR DESCRIPTION
Small cleanup:

Before all SQL connectors were using absolutely same logic that was later split up.

The split did not clean up everything, so this PR just cleans up one thing - unnecessary `MySQLQueries` class.

This PR removes it and inlines queries into the places that use these queries - all queries are used exactly once (or even never).