### PR TITLE
Speed up column name fetching

### DIFF
--- a/connectors/sources/mysql.py
+++ b/connectors/sources/mysql.py
@@ -184,7 +184,7 @@ class MySQLClient:
     )
     async def get_column_names_for_query(self, query):
         async with self.connection.cursor(aiomysql.cursors.SSCursor) as cursor:
-            await cursor.execute(query)
+            await cursor.execute(f"SELECT q.* FROM ({query}) as q LIMIT 0")
 
             return [f"{column[0]}" for column in cursor.description]
 


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1125

Instead of running a query to get column names returned, we run same query wrapping it into (`SELECT * from ({query}) LIMIT 0`) to save some time.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)