### PR TITLE
[9.0] Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 61d6ceb (#3496)

### DIFF
--- a/Dockerfile.ftest.wolfi
+++ b/Dockerfile.ftest.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:8d25b874b8427ae635c237a5746518600e4177a1c07f82811de199dee19bcf0c
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:61d6ceb7e26e2af1040adf38913aa133615a8d98397c86ff30e85c3a73514e09
 USER root
 COPY . /connectors
 WORKDIR /connectors

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:8d25b874b8427ae635c237a5746518600e4177a1c07f82811de199dee19bcf0c
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:61d6ceb7e26e2af1040adf38913aa133615a8d98397c86ff30e85c3a73514e09
 USER root
 COPY . /app
 WORKDIR /app

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5655,8 +5655,8 @@ MIT License
 
 
 multidict
-6.6.0
-Apache Software License
+6.6.3
+Apache License 2.0
    Copyright 2016 Andrew Svetlov and aio-libs contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Update docker.elastic.co/wolfi/python:3.11-dev Docker digest to 61d6ceb (#3496)](https://github.com/elastic/connectors/pull/3496)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)