### PR TITLE
[9.1] Bump aiohttp to 3.12.14 (#3554)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1328,8 +1328,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 
 aiohttp
-3.11.10
-Apache Software License
+3.12.14
+Apache-2.0
    Copyright aio-libs contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/requirements/framework.txt
+++ b/requirements/framework.txt
@@ -1,4 +1,4 @@
-aiohttp==3.11.10
+aiohttp==3.12.14
 aiofiles==23.2.1
 aiomysql==0.1.1
 httpx==0.27.0


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Bump aiohttp to 3.12.14 (#3554)](https://github.com/elastic/connectors/pull/3554)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)