### PR TITLE
Use http1.1 when downloading ES tarball image for Ftests

### DIFF
--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -65,7 +65,7 @@ function download_docker_tarball {
   MAX_RETRIES=3
 
   echo "Downloading Docker image tarball from $TAR_URL..."
-  curl --retry $MAX_RETRIES --retry-connrefused -O "$TAR_URL"
+  curl --http1.1 --retry $MAX_RETRIES --retry-connrefused -O "$TAR_URL"
 
   if [ ! -f "$TAR_FILE" ]; then
     echo "Error: Download failed. File $TAR_FILE not found."


### PR DESCRIPTION
We've noticed some periodic ftest failures like:
```
+ echo 'Downloading Docker image tarball from https://artifacts-snapshot.elastic.co/elasticsearch/9.1.3-177feadd/downloads/elasticsearch/elasticsearch-9.1.3-SNAPSHOT-docker-image-amd64.tar.gz...'
--
  | Downloading Docker image tarball from https://artifacts-snapshot.elastic.co/elasticsearch/9.1.3-177feadd/downloads/elasticsearch/elasticsearch-9.1.3-SNAPSHOT-docker-image-amd64.tar.gz...
  | + curl --retry 3 --retry-connrefused -O https://artifacts-snapshot.elastic.co/elasticsearch/9.1.3-177feadd/downloads/elasticsearch/elasticsearch-9.1.3-SNAPSHOT-docker-image-amd64.tar.gz
  | % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
  | Dload  Upload   Total   Spent    Left  Speed
  | 60  674M   60  411M    0     0  29.4M      0  0:00:22  0:00:13  0:00:09 22.5M
  | curl: (92) HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR (err 2)
```

The suggestion from the platform eng prod team was to try with `--http1.1`. Giving it a go.

## Checklists


#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
