### PR TITLE
Handle KeyError in the ES sink.py

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -307,11 +307,11 @@ class Sink:
             for op, data in item.items():
                 # "result" is only present in successful operations
                 if "result" not in data:
-                    try:
+                    if data["_id"] in stats[op]:
                         del stats[op][data["_id"]]
-                    except KeyError:
-                        self._logger.info(
-                            f"KeyError in _populate_stats: {op}, {data['_id']}"
+                    else:
+                        self._logger.debug(
+                            f"Document {data['_id']} not in stats for operation: {op}"
                         )
 
         self.counters.increment(

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -307,7 +307,10 @@ class Sink:
             for op, data in item.items():
                 # "result" is only present in successful operations
                 if "result" not in data:
-                    del stats[op][data["_id"]]
+                    try:
+                        del stats[op][data["_id"]]
+                    except KeyError:
+                        self._logger.info(f"KeyError in _populate_stats: {op}, {data['_id']}")
 
         self.counters.increment(
             INDEXED_DOCUMENT_COUNT, len(stats[OP_INDEX]) + len(stats[OP_UPDATE])
@@ -367,6 +370,7 @@ class Sink:
             while True:
                 batch_num += 1
                 doc_size, doc = await self.fetch_doc()
+                print(f"Sink: fetched doc {doc}")
                 if doc in (END_DOCS, EXTRACTOR_ERROR):
                     break
                 operation = doc["_op_type"]

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -370,7 +370,6 @@ class Sink:
             while True:
                 batch_num += 1
                 doc_size, doc = await self.fetch_doc()
-                print(f"Sink: fetched doc {doc}")
                 if doc in (END_DOCS, EXTRACTOR_ERROR):
                     break
                 operation = doc["_op_type"]

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -310,7 +310,9 @@ class Sink:
                     try:
                         del stats[op][data["_id"]]
                     except KeyError:
-                        self._logger.info(f"KeyError in _populate_stats: {op}, {data['_id']}")
+                        self._logger.info(
+                            f"KeyError in _populate_stats: {op}, {data['_id']}"
+                        )
 
         self.counters.increment(
             INDEXED_DOCUMENT_COUNT, len(stats[OP_INDEX]) + len(stats[OP_UPDATE])


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3628

This PR adds a `try/except` block around a dictionary access in the `_populate_stats` method in `es/sink.py`.

While rare, this method can occasionally raise a `KeyError` when the sink hits a lot of indexing errors - this will gracefully catch and log the exception at the DEBUG log level.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases