### PR TITLE
Add support for configurable maximum queue memory size

### DIFF
--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -1023,7 +1023,7 @@ class SyncOrchestrator:
 
         stream = MemQueue(
             maxsize=queue_size,
-            maxmemsize=queue_mem_size * 1024 * 1024,
+            maxmemsize=queue_mem_size,
             refresh_timeout=mem_queue_refresh_timeout,
             refresh_interval=mem_queue_refresh_interval,
         )

--- a/connectors/sources/box.py
+++ b/connectors/sources/box.py
@@ -475,7 +475,21 @@ class BoxDataSource(BaseDataSource):
             else:
                 yield item
 
-    async def get_docs(self, filtering=None):
+    def _update_queue_max_mem_size(self):
+        """
+        Helper function to update the queue's max memory size
+        if the configured value exceeds the constant defined in the data source
+        """
+        max_mem_size_from_config = self.framework_config.max_queue_mem_size
+
+        if max_mem_size_from_config > QUEUE_MEM_SIZE:
+            self.queue.update_maxmemsize(max_mem_size_from_config)
+            logger.debug(f"MemQueue max memory size updated from {QUEUE_MEM_SIZE} to {max_mem_size_from_config}")
+
+    async def get_docs(self, filtering=None): # type: ignore
+        # update queue max memory size if needed
+        self._update_queue_max_mem_size()
+
         seen_ids = set()
         root_folder = "0"
         if self.is_enterprise == BOX_ENTERPRISE:

--- a/connectors/sources/outlook.py
+++ b/connectors/sources/outlook.py
@@ -50,8 +50,6 @@ from connectors.utils import (
 RETRIES = 3
 RETRY_INTERVAL = 2
 
-QUEUE_MEM_SIZE = 5 * 1024 * 1024  # Size in Megabytes
-
 OUTLOOK_SERVER = "outlook_server"
 OUTLOOK_CLOUD = "outlook_cloud"
 API_SCOPE = "https://graph.microsoft.com/.default"
@@ -821,7 +819,7 @@ class OutlookDataSource(BaseDataSource):
 
         return self.configuration["use_document_level_security"]
 
-    async def get_access_control(self):
+    async def get_access_control(self): # type: ignore
         if not self._dls_enabled():
             self._logger.warning("DLS is not enabled. Skipping")
             return
@@ -1064,7 +1062,7 @@ class OutlookDataSource(BaseDataSource):
         await self.client.ping()
         self._logger.info("Successfully connected to Outlook")
 
-    async def get_docs(self, filtering=None):
+    async def get_docs(self, filtering=None): # type: ignore
         """Executes the logic to fetch outlook objects in async manner
 
         Args:

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -218,8 +218,13 @@ class SyncJobRunner:
                 await self.data_provider.close()
 
     def _data_source_framework_config(self):
-        builder = DataSourceFrameworkConfig.Builder().with_max_file_size(
+        builder = DataSourceFrameworkConfig.Builder()
+
+        builder.with_max_file_size(
             self.service_config.get("max_file_download_size")
+        )
+        builder.with_max_queue_memory_size(
+            self.service_config.get("queue_max_mem_size")
         )
         return builder.build()
 

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -36,10 +36,13 @@ ACCESS_CONTROL_INDEX_PREFIX = ".search-acl-filter-"
 DEFAULT_CHUNK_SIZE = 500
 DEFAULT_QUEUE_SIZE = 1024
 DEFAULT_DISPLAY_EVERY = 100
-DEFAULT_QUEUE_MEM_SIZE = 5
+DEFAULT_QUEUE_MEM_SIZE = 5242880 # 5 MB
 DEFAULT_CHUNK_MEM_SIZE = 25
 DEFAULT_MAX_CONCURRENCY = 5
 DEFAULT_CONCURRENT_DOWNLOADS = 10
+DEFAULT_MAX_FILE_SIZE = 10485760 # 10 MB
+DEFAULT_ELASTICSEARCH_MAX_RETRIES = 5
+DEFAULT_ELASTICSEARCH_RETRY_INTERVAL = 10
 
 # Regular expression pattern to match a basic email format (no whitespace, valid domain)
 EMAIL_REGEX_PATTERN = r"^\S+@\S+\.\S+$"
@@ -297,8 +300,15 @@ class MemQueue(asyncio.Queue):
         self._current_memsize = 0
         self.refresh_timeout = refresh_timeout
 
+        logger.debug(f"MemQueue created with maxsize={maxsize}, maxmemsize={maxmemsize}, "
+                     f"refresh_interval={refresh_interval}, refresh_timeout={refresh_timeout}")
+
     def qmemsize(self):
         return self._current_memsize
+
+    def update_maxmemsize(self, new_maxmemsize):
+        current_maxmemsize = self.maxmemsize
+        self.maxmemsize = new_maxmemsize
 
     def _get(self):
         item_size, item = self._queue.popleft()  # pyright: ignore


### PR DESCRIPTION
## Part of https://github.com/elastic/connectors/issues/3584

This PR allows the maximum size of the in-memory queue for data sources to be configurable.

Currently, the following data sources have their maximum queue sizes hardcoded:
- Confluence (25 MB)
- ServiceNow (25 MB)
- Box (5 MB)
- Jira (5 MB)
- Microsoft Teams (5 MB)

### Proposed changes
The user can add the following to their `config.yml`
```yaml
connectors:
-
  connector_id: "connector_id"
  service_type: "confluence"
  api_key: "..."
elasticsearch:
  host: "https://elasticsearch-host.com:443"
  api_key: "..."
service.queue_max_mem_size: 31_457_280 # new configurable value
```

If the configured queue size is _greater_ than what is specified inside the data source itself, the maximum memory queue size will be updated. This allows us to keep the current hardcoded values for backwards compatibility while enabling users to increase them if needed.

`service.queue_max_mem_size` has a default value of `5 MB`.

`config::DataSourceFrameworkConfig` is initialized at this default value. Upon the execution of a sync job, this configuration is updated and exposed to the data source via `self.framework_config` and is updated inside each relevant data source's `get_docs` method.

This PR also unifies how default values are set to be more consistent and maintainable.

### Why do it this way?
Reading the code, it's apparent that minimal exposure of framework-level config to the data sources was desired. We **could** refactor `BaseDataSource` to attempt to pick up framework-level configuration on startup, but this requires fundamentally changing its visibility on all framework-level configurations. Initializing framework configs with default values and reading the user-set values on sync appears to be the intended way of exposing these configs to the data sources.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] Considered corresponding documentation changes