### PR TITLE
[9.0] [Salesforce] optimize field validation to reduce API calls (#3668)

### DIFF
--- a/connectors/sources/salesforce.py
+++ b/connectors/sources/salesforce.py
@@ -457,7 +457,13 @@ class SalesforceClient:
         relevant_sobject_fields,
     ):
         """Cached async property"""
-        for sobject in relevant_objects:
+        objects_to_query = [
+            obj for obj in relevant_objects if obj not in self._queryable_sobject_fields
+        ]
+        if not objects_to_query:
+            return self._queryable_sobject_fields
+
+        for sobject in objects_to_query:
             endpoint = DESCRIBE_SOBJECT_ENDPOINT.replace("<sobject>", sobject)
             response = await self._get_json(f"{self.base_url}{endpoint}")
 

--- a/tests/sources/test_salesforce.py
+++ b/tests/sources/test_salesforce.py
@@ -2078,3 +2078,130 @@ async def test_get_docs_with_dls_enabled(mock_responses):
 
         async for record, _ in source.get_docs():
             assert len(record["_allow_access_control"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_get_docs_with_configured_list_of_sobjects(mock_responses):
+    async with create_salesforce_source() as source:
+        source.salesforce_client.standard_objects_to_sync = ["Account", "Contact"]
+        source.salesforce_client.sync_custom_objects = False
+        source.salesforce_client._custom_objects = AsyncMock(
+            return_value=["CustomObject"]
+        )
+
+        source._parse_content_documents = MagicMock(return_value=[])
+
+        mock_responses.get(
+            TEST_FILE_DOWNLOAD_URL,
+            status=200,
+            body=b"chunk1",
+        )
+        mock_responses.get(
+            TEST_QUERY_MATCH_URL, repeat=True, callback=salesforce_query_callback
+        )
+
+        async for record, _ in source.get_docs():
+            assert record["attributes"]["type"] in ["Account", "Contact"]
+
+
+@pytest.mark.asyncio
+async def test_get_docs_sync_custom_objects(mock_responses):
+    async with create_salesforce_source() as source:
+        source.salesforce_client._custom_objects = AsyncMock(
+            return_value=["CustomObject", "Connector__c"]
+        )
+        source.salesforce_client.custom_objects_to_sync = ["CustomObject"]
+        source.salesforce_client.standard_objects_to_sync = []
+
+        source.salesforce_client.sync_custom_objects = True
+        source._parse_content_documents = MagicMock(return_value=[])
+
+        mock_responses.get(
+            TEST_FILE_DOWNLOAD_URL,
+            status=200,
+            body=b"chunk1",
+        )
+        mock_responses.get(
+            TEST_QUERY_MATCH_URL, repeat=True, callback=salesforce_query_callback
+        )
+
+        async for record, _ in source.get_docs():
+            assert record["attributes"]["type"] == "CustomObject"
+
+
+@pytest.mark.asyncio
+async def test_queryable_sobject_fields_performance_optimization(mock_responses):
+    """
+    Test the performance optimization that reduces API calls from O(n*14) to O(14)
+
+    This test demonstrates the specific performance improvement:
+    - Before: 6 objects × 14 RELEVANT_SOBJECTS = 84 total calls
+    - After: 14 API calls total (one per object, cached thereafter)
+    - Performance improvement: ~85% reduction in API calls
+    """
+    async with create_salesforce_source(mock_queryables=False) as source:
+        from connectors.sources.salesforce import RELEVANT_SOBJECTS
+
+        # Mock responses for all RELEVANT_SOBJECTS
+        mock_fields = [{"name": "Id"}, {"name": "Name"}, {"name": "Description"}]
+        for sobject in RELEVANT_SOBJECTS:
+            mock_responses.get(
+                f"{TEST_BASE_URL}/services/data/{API_VERSION}/sobjects/{sobject}/describe",
+                status=200,
+                payload={"fields": mock_fields},
+            )
+
+        # Track API calls
+        api_call_count = 0
+        original_get_json = source.salesforce_client._get_json
+
+        async def mock_get_json(url, **kwargs):
+            nonlocal api_call_count
+            api_call_count += 1
+            return await original_get_json(url, **kwargs)
+
+        source.salesforce_client._get_json = mock_get_json
+
+        # Simulate the scenario: 6 objects being synced, each calling _select_queryable_fields
+        # This represents a typical sync operation
+        objects_to_sync = [
+            "Account",
+            "Contact",
+            "Lead",
+            "Opportunity",
+            "Campaign",
+            "Case",
+        ]
+
+        # Test the OPTIMIZED behavior (current implementation)
+        for obj in objects_to_sync:
+            if obj in RELEVANT_SOBJECTS:
+                # This simulates _select_queryable_fields calling queryable_sobject_fields
+                # With optimization: only queries uncached objects
+                await source.salesforce_client.queryable_sobject_fields(
+                    relevant_objects=RELEVANT_SOBJECTS, relevant_sobject_fields=None
+                )
+
+        optimized_calls = api_call_count
+
+        # Verify the optimization worked
+        expected_optimized_calls = len(RELEVANT_SOBJECTS)  # O(14)
+        assert (
+            optimized_calls == expected_optimized_calls
+        ), f"Expected {expected_optimized_calls} API calls (O(14)), got {optimized_calls}"
+
+        # Calculate performance improvement
+        old_behavior_calls = len(objects_to_sync) * len(RELEVANT_SOBJECTS)  # O(n*14)
+        improvement_percentage = (
+            (old_behavior_calls - optimized_calls) / old_behavior_calls
+        ) * 100
+
+        # Verify the improvement is substantial (should be ~85% as mentioned)
+        assert (
+            improvement_percentage >= 80
+        ), f"Expected at least 80% improvement, got {improvement_percentage:.1f}%"
+
+        # Verify cache is properly populated
+        assert len(source.salesforce_client._queryable_sobject_fields) == len(
+            RELEVANT_SOBJECTS
+        ), f"Expected cache to contain {len(RELEVANT_SOBJECTS)} objects"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[Salesforce] optimize field validation to reduce API calls (#3668)](https://github.com/elastic/connectors/pull/3668)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)