### PR TITLE
Pin Oracle DB version for ftest to 23.8.0.0

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1880,7 +1880,7 @@ SOFTWARE.
 
 
 azure-core
-1.35.0
+1.35.1
 MIT License
 Copyright (c) Microsoft Corporation.
 
@@ -6486,7 +6486,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 pycparser
-2.22
+2.23
 BSD License
 pycparser -- A C parser in Python
 
@@ -8410,7 +8410,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 xmltodict
-0.15.0
+1.0.0
 MIT License
 Copyright (C) 2012 Martin Blech and individual contributors.
 

--- a/tests/sources/fixtures/oracle/docker-compose.yml
+++ b/tests/sources/fixtures/oracle/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - esnet
 
   oracle:
-    image: container-registry.oracle.com/database/free:latest
+    image: container-registry.oracle.com/database/free:23.8.0.0
     ports:
       - 1521:1521
     environment:


### PR DESCRIPTION
This PR pins the OracleDB Docker container version to 23.8.0.0, as `:latest` tag seemed to be causing issues. This change will hopefully unblock CI for now 🤞 