### PR TITLE
agent-docker-build: add -y to "microdnf update" command

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -6,7 +6,7 @@ FROM docker.elastic.co/elastic-agent/elastic-agent:9.0.0-SNAPSHOT
 USER root
 
 # Install basic dependencies
-RUN microdnf update && microdnf install -y \
+RUN microdnf update -y && microdnf install -y \
   vim \
   wget \
   git \


### PR DESCRIPTION
currently it looks like:
```
❯ make agent-docker-build
...
 => [ 2/11] RUN microdnf update && microdnf install -y   vim   wget   git   make   python3.11   python3.11-pip   && microdnf clean all                                                          18.6s
 => => #  Reinstalling:      0 packages
 => => #  Upgrading:        37 packages
 => => #  Obsoleting:        0 packages
 => => #  Removing:          0 packages
 => => #  Downgrading:       0 packages
 => => # Is this ok [y/N]:
```
and now it's waiting for user input, but console is redirected, so any keyboard input is ignored.

So, looking that `install` command already has `-y`, I assumed that adding `-y` to `update` is also safe enough.

## Checklists

#### Pre-Review Checklist
- [ ] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [ ] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [ ] this PR has a thorough description
- [ ] Tested the changes locally