### PR TITLE
Add sandfly to nightly CI

### DIFF
--- a/.buildkite/nightly_steps.yml
+++ b/.buildkite/nightly_steps.yml
@@ -337,3 +337,15 @@ steps:
     matrix:
       - "3.10"
       - "3.11"
+  - label: "🔨 [Python {{ matrix }}] Sandfly"
+    <<: *retries
+    command: ".buildkite/run_functional_test.sh"
+    env:
+      PYTHON_VERSION: "{{ matrix }}"
+      CONNECTOR: "sandfly"
+      DATA_SIZE: "small"
+    artifact_paths:
+      - "perf8-report-*/**/*"
+    matrix:
+      - "3.10"
+      - "3.11"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -580,6 +580,25 @@ steps:
               artifact_paths:
                 - "perf8-report-*/**/*"
 
+          - path:
+            - "connectors/sources/sandfly.py"
+            - "tests/sources/fixtures/sandfly/**"
+            - "tests/sources/fixtures/fixture.py"
+            - "${DOCKERFILE_FTEST_PATH}"
+            - "requirements/**"
+            config:
+              label: "🔨 Sandfly"
+              <<: *test-agents
+              <<: *retries
+              env:
+                - PYTHON_VERSION=3.11
+                - DATA_SIZE=small
+                - CONNECTOR=sandfly
+              command:
+                - ".buildkite/run_functional_test.sh"
+              artifact_paths:
+                - "perf8-report-*/**/*"
+
   # ----
   # DRA publishing
   # ----

--- a/connectors/sources/sandfly.py
+++ b/connectors/sources/sandfly.py
@@ -5,6 +5,8 @@
 #
 """
 Sandfly Security source module to fetch documents from a Sandfly Security Server.
+
+Note: this connector is a community contribution, and is supported only under "best effort" from the community.
 """
 
 import json


### PR DESCRIPTION
When we added the Sandfly connector in https://github.com/elastic/connectors/issues/3510, we didn't add it to our CI. We should.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)

