### PR TITLE
[9.2] Fix bash bug causing ES image download fallback logic to fail (#3740)

### DIFF
--- a/tests/ftest.sh
+++ b/tests/ftest.sh
@@ -215,7 +215,8 @@ function fetch_elasticsearch_image {
       continue
     fi
 
-    local tarball_url=$(get_docker_tarball_url "$manifest_url" "$tarball_name")
+    local tarball_url
+    tarball_url=$(get_docker_tarball_url "$manifest_url" "$tarball_name")
     if [ $? -ne 0 ]; then
       echo "Failed to get tarball URL for version $version, trying next..." >&2
       continue


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.2`:
 - [Fix bash bug causing ES image download fallback logic to fail (#3740)](https://github.com/elastic/connectors/pull/3740)

<!--- Backport version: 10.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)