### PR TITLE
[9.3] chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to d9af5b8 (#4361)

### DIFF
--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:e4f78293eeb316b237fb25b024a78106ac6dc7c9dc16c48752c44a4cd2d0d21e
+FROM docker.elastic.co/wolfi/python:3.11-dev@sha256:d9af5b8fae25f3bf8c305beb9fe92f1a74cc7ff969501e3ccfc5f7971d3561b7
 USER root
 COPY . /app
 WORKDIR /app

--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -74,7 +74,7 @@ SOFTWARE.
 
 
 Pygments
-2.20.0
+2.21.0
 BSD-2-Clause
 Copyright (c) 2006-2022 by the respective authors (see AUTHORS file).
 All rights reserved.
@@ -2832,7 +2832,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.9
+3.5.1
 MIT
 MIT License
 
@@ -4475,7 +4475,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.4
+3.5.5
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:


### PR DESCRIPTION
Backports the following commits to 9.3:
 - chore(deps): update docker.elastic.co/wolfi/python:3.11-dev docker digest to d9af5b8 (#4361)