### PR TITLE
[8.19] fix: keep long syncs alive through ES refresh storm (#4345)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -74,7 +74,7 @@ SOFTWARE.
 
 
 Pygments
-2.20.0
+2.21.0
 BSD-2-Clause
 Copyright (c) 2006-2022 by the respective authors (see AUTHORS file).
 All rights reserved.
@@ -2781,7 +2781,7 @@ documentation is licensed as follows:
 
 
 charset-normalizer
-3.4.9
+3.5.1
 MIT
 MIT License
 
@@ -4517,7 +4517,7 @@ SOFTWARE.
 
 
 greenlet
-3.5.4
+3.5.5
 MIT AND PSF-2.0
 The following files are derived from Stackless Python and are subject to the
 same license as Stackless Python:

--- a/connectors/es/index.py
+++ b/connectors/es/index.py
@@ -173,11 +173,6 @@ class ESIndex(ESClient):
         return self._create_object(resp_body)
 
     async def fetch_response_by_id(self, doc_id):
-        if not self.serverless:
-            await self._retrier.execute_with_retry(
-                partial(self.client.indices.refresh, index=self.index_name)
-            )
-
         try:
             resp = await self._retrier.execute_with_retry(
                 partial(self.client.get, index=self.index_name, id=doc_id)
@@ -241,11 +236,6 @@ class ESIndex(ESClient):
         Returns:
             Iterator
         """
-        if not self.serverless:
-            await self._retrier.execute_with_retry(
-                partial(self.client.indices.refresh, index=self.index_name)
-            )
-
         if query is None:
             query = {"match_all": {}}
 

--- a/connectors/sync_job_runner.py
+++ b/connectors/sync_job_runner.py
@@ -7,6 +7,10 @@ import asyncio
 import time
 
 import elasticsearch
+from elastic_transport import ConnectionError as ElasticTransportConnectionError
+from elasticsearch import (
+    ApiError,
+)
 from elasticsearch import (
     AuthorizationException as ElasticAuthorizationException,
 )
@@ -31,6 +35,7 @@ from connectors.protocol.connectors import (
     DELETED_DOCUMENT_COUNT,
     INDEXED_DOCUMENT_COUNT,
     INDEXED_DOCUMENT_VOLUME,
+    ProtocolError,
 )
 from connectors.source import BaseDataSource
 from connectors.utils import truncate_id
@@ -38,8 +43,14 @@ from connectors.utils import truncate_id
 UTF_8 = "utf-8"
 
 JOB_REPORTING_INTERVAL = 10
-JOB_CHECK_INTERVAL = 1
+JOB_CHECK_INTERVAL = 5
 ES_ID_SIZE_LIMIT = 512
+
+_RETRIABLE_INGESTION_STATS_ERRORS = (
+    ApiError,
+    ElasticTransportConnectionError,
+    ProtocolError,
+)
 
 
 class SyncJobRunningError(Exception):
@@ -199,7 +210,20 @@ class SyncJobRunner:
             )
 
             while not self.sync_orchestrator.done():
-                await self.check_job()
+                try:
+                    await self.check_job()
+                except (
+                    ConnectorJobCanceledError,
+                    ConnectorJobNotRunningError,
+                    ConnectorNotFoundError,
+                    ConnectorJobNotFoundError,
+                ):
+                    raise
+                except _RETRIABLE_INGESTION_STATS_ERRORS as e:
+                    self.sync_job.log_warning(
+                        f"Failed to check job status; will retry. Error: {e}",
+                        exc_info=True,
+                    )
                 await asyncio.sleep(JOB_CHECK_INTERVAL)
             sync_error = self.sync_orchestrator.get_error()
             sync_status = JobStatus.COMPLETED if sync_error is None else JobStatus.ERROR
@@ -519,16 +543,22 @@ class SyncJobRunner:
         while True:
             await asyncio.sleep(interval)
 
-            if not await self.reload_sync_job():
-                break
+            try:
+                if not await self.reload_sync_job():
+                    break
 
-            result = self.sync_orchestrator.ingestion_stats()
-            ingestion_stats = {
-                INDEXED_DOCUMENT_COUNT: result.get(INDEXED_DOCUMENT_COUNT, 0),
-                INDEXED_DOCUMENT_VOLUME: result.get(INDEXED_DOCUMENT_VOLUME, 0),
-                DELETED_DOCUMENT_COUNT: result.get(DELETED_DOCUMENT_COUNT, 0),
-            }
-            await self.sync_job.update_metadata(ingestion_stats=ingestion_stats)
+                result = self.sync_orchestrator.ingestion_stats()
+                ingestion_stats = {
+                    INDEXED_DOCUMENT_COUNT: result.get(INDEXED_DOCUMENT_COUNT, 0),
+                    INDEXED_DOCUMENT_VOLUME: result.get(INDEXED_DOCUMENT_VOLUME, 0),
+                    DELETED_DOCUMENT_COUNT: result.get(DELETED_DOCUMENT_COUNT, 0),
+                }
+                await self.sync_job.update_metadata(ingestion_stats=ingestion_stats)
+            except _RETRIABLE_INGESTION_STATS_ERRORS as e:
+                self.sync_job.log_warning(
+                    f"Failed to update ingestion stats; will retry. Error: {e}",
+                    exc_info=True,
+                )
 
     async def check_job(self):
         if not await self.reload_connector():

--- a/tests/es/test_index.py
+++ b/tests/es/test_index.py
@@ -22,9 +22,6 @@ index_name = "fake_index"
 @pytest.mark.asyncio
 async def test_es_index_create_object_error(mock_responses):
     index = ESIndex(index_name, config)
-    mock_responses.post(
-        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
-    )
 
     mock_responses.post(
         f"http://nowhere.com:9200/{index_name}/_search?expand_wildcards=hidden",
@@ -52,9 +49,6 @@ class FakeIndex(ESIndex):
 async def test_fetch_by_id(mock_responses):
     doc_id = "1"
     index = FakeIndex(index_name, config)
-    mock_responses.post(
-        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
-    )
 
     mock_responses.get(
         f"http://nowhere.com:9200/{index_name}/_doc/{doc_id}",
@@ -80,9 +74,6 @@ async def test_fetch_response_by_id(mock_responses):
         "_primary_term": 1,
         "_source": {},
     }
-    mock_responses.post(
-        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
-    )
 
     mock_responses.get(
         f"http://nowhere.com:9200/{index_name}/_doc/{doc_id}",
@@ -101,9 +92,6 @@ async def test_fetch_response_by_id(mock_responses):
 async def test_fetch_response_by_id_not_found(mock_responses):
     doc_id = "1"
     index = FakeIndex(index_name, config)
-    mock_responses.post(
-        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
-    )
 
     mock_responses.get(
         f"http://nowhere.com:9200/{index_name}/_doc/{doc_id}",
@@ -121,9 +109,6 @@ async def test_fetch_response_by_id_not_found(mock_responses):
 async def test_fetch_response_by_id_api_error(mock_responses, patch_sleep):
     doc_id = "1"
     index = FakeIndex(index_name, config)
-    mock_responses.post(
-        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
-    )
 
     mock_responses.get(
         f"http://nowhere.com:9200/{index_name}/_doc/{doc_id}",
@@ -204,9 +189,6 @@ async def test_update_by_script():
 @pytest.mark.asyncio
 async def test_get_all_docs_with_error(mock_responses, patch_logger, patch_sleep):
     index = FakeIndex(index_name, config)
-    mock_responses.post(
-        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
-    )
 
     mock_responses.post(
         f"http://nowhere.com:9200/{index_name}/_search?expand_wildcards=hidden",
@@ -229,9 +211,6 @@ async def test_get_all_docs_with_error(mock_responses, patch_logger, patch_sleep
 async def test_get_all_docs(mock_responses):
     index = FakeIndex(index_name, config)
     total = 3
-    mock_responses.post(
-        f"http://nowhere.com:9200/{index_name}/_refresh", headers=headers, status=200
-    )
 
     mock_responses.post(
         f"http://nowhere.com:9200/{index_name}/_search?expand_wildcards=hidden",

--- a/tests/test_sync_job_runner.py
+++ b/tests/test_sync_job_runner.py
@@ -8,10 +8,11 @@ from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 from elasticsearch import (
-    AuthorizationException as ElasticAuthorizationException,
+    ApiError,
+    ConflictError,
 )
 from elasticsearch import (
-    ConflictError,
+    AuthorizationException as ElasticAuthorizationException,
 )
 from elasticsearch import (
     NotFoundError as ElasticNotFoundError,
@@ -679,6 +680,101 @@ async def test_sync_job_runner_reporting_metadata(
     sync_job_runner.connector.sync_done.assert_awaited_with(
         sync_job_runner.sync_job, cursor=sync_cursor
     )
+
+
+@pytest.mark.asyncio
+async def test_update_ingestion_stats_survives_transient_errors():
+    # Transient ES errors must not permanently stop last_seen updates.
+    sync_job_runner = create_runner()
+    sync_job_runner.sync_orchestrator = Mock()
+    sync_job_runner.sync_orchestrator.ingestion_stats.return_value = {
+        "indexed_document_count": 1,
+        "indexed_document_volume": 1,
+        "deleted_document_count": 0,
+    }
+    sync_job_runner.reload_sync_job = AsyncMock(return_value=True)
+    sync_job_runner.sync_job.update_metadata = AsyncMock(
+        side_effect=[
+            ProtocolError("connection timeout"),
+            None,
+            asyncio.CancelledError(),
+        ]
+    )
+    sync_job_runner.sync_job.log_warning = Mock()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sync_job_runner.update_ingestion_stats(interval=0)
+
+    assert sync_job_runner.sync_job.update_metadata.await_count == 3
+    sync_job_runner.sync_job.log_warning.assert_called()
+    _, kwargs = sync_job_runner.sync_job.log_warning.call_args
+    assert kwargs.get("exc_info") is True
+
+
+@pytest.mark.asyncio
+async def test_update_ingestion_stats_survives_reload_errors():
+    sync_job_runner = create_runner()
+    sync_job_runner.sync_orchestrator = Mock()
+    sync_job_runner.sync_orchestrator.ingestion_stats.return_value = {
+        "indexed_document_count": 1,
+        "indexed_document_volume": 1,
+        "deleted_document_count": 0,
+    }
+    sync_job_runner.reload_sync_job = AsyncMock(
+        side_effect=[
+            ApiError(503, meta=Mock(), body="error"),
+            True,
+        ]
+    )
+    sync_job_runner.sync_job.update_metadata = AsyncMock(
+        side_effect=asyncio.CancelledError()
+    )
+    sync_job_runner.sync_job.log_warning = Mock()
+
+    with pytest.raises(asyncio.CancelledError):
+        await sync_job_runner.update_ingestion_stats(interval=0)
+
+    assert sync_job_runner.reload_sync_job.await_count == 2
+    sync_job_runner.sync_job.update_metadata.assert_awaited_once()
+    sync_job_runner.sync_job.log_warning.assert_called_once()
+    _, kwargs = sync_job_runner.sync_job.log_warning.call_args
+    assert kwargs.get("exc_info") is True
+
+
+@pytest.mark.asyncio
+@patch("connectors.sync_job_runner.JOB_REPORTING_INTERVAL", 0)
+@patch("connectors.sync_job_runner.JOB_CHECK_INTERVAL", 0)
+async def test_sync_job_runner_survives_transient_check_job_errors(
+    sync_orchestrator_mock,
+):
+    ingestion_stats = {
+        "indexed_document_count": 1,
+        "indexed_document_volume": 1,
+        "deleted_document_count": 0,
+    }
+    sync_orchestrator_mock.ingestion_stats.return_value = ingestion_stats
+    sync_orchestrator_mock.done.side_effect = [False, False, True]
+    sync_job_runner = create_runner()
+    sync_job_runner.sync_job.log_warning = Mock()
+
+    check_job_calls = 0
+
+    async def check_job_side_effect():
+        nonlocal check_job_calls
+        check_job_calls += 1
+        if check_job_calls == 1:
+            raise ApiError(503, meta=Mock(), body="error")
+
+    sync_job_runner.check_job = check_job_side_effect
+
+    await sync_job_runner.execute()
+
+    assert check_job_calls == 2
+    sync_job_runner.sync_job.fail.assert_not_awaited()
+    sync_job_runner.sync_job.done.assert_awaited()
+    sync_job_runner.sync_job.log_warning.assert_called_once()
+    _, kwargs = sync_job_runner.sync_job.log_warning.call_args
+    assert kwargs.get("exc_info") is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix: keep long syncs alive through ES refresh storm (#4345)