### PR TITLE
fix(sharepoint_online): recover from expired drive delta links (410 Gone)

### DIFF
--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
@@ -35,7 +35,6 @@ from connectors.sources.sharepoint.sharepoint_online.constants import (
 from connectors.sources.sharepoint.sharepoint_online.utils import (
     DeltaLinkExpired,
     _is_excluded_sharepoint_url,
-    graph_site_page_to_document,
 )
 from connectors.utils import (
     CacheWithTimeout,
@@ -861,19 +860,19 @@ class SharepointOnlineClient:
             if items or delta_link:
                 yield DriveItemsPage(items, delta_link)
 
-    async def drive_items(self, drive_id, url=None):
+    async def drive_items(self, drive_id, url=None, on_delta_reset=None):
         fresh_url = (
             f"{GRAPH_API_URL}/drives/{drive_id}/root/delta?$select={DRIVE_ITEMS_FIELDS}"
         )
         effective_url = fresh_url if not url else url
 
         async for page in self._drive_items_with_delta_recovery(
-            drive_id, effective_url, fresh_url
+            drive_id, effective_url, fresh_url, on_delta_reset=on_delta_reset
         ):
             yield page
 
     async def _drive_items_with_delta_recovery(
-        self, drive_id, url, fresh_url, *, allow_restart=True
+        self, drive_id, url, fresh_url, *, allow_restart=True, on_delta_reset=None
     ):
         current_url = url
         while True:
@@ -889,6 +888,8 @@ class SharepointOnlineClient:
                     f"Drive delta link expired for drive '{drive_id}'; "
                     "restarting enumeration from root/delta"
                 )
+                if on_delta_reset is not None:
+                    on_delta_reset(drive_id)
                 current_url = fresh_url
                 allow_restart = False
 
@@ -1000,37 +1001,6 @@ class SharepointOnlineClient:
             for site_list in page:
                 yield site_list
 
-    async def graph_site_list_item_attachments(self, site_id, list_id, list_item_id):
-        url = (
-            f"{GRAPH_API_URL}/sites/{site_id}/lists/{list_id}/items/"
-            f"{list_item_id}/attachments"
-        )
-
-        try:
-            async for page in self._graph_api_client.scroll(url):
-                for attachment in page:
-                    attachment_id = attachment.get("id")
-                    stable_id = f"{list_id}-{list_item_id}-attachment-{attachment_id}"
-                    yield {
-                        "odata.id": stable_id,
-                        "FileName": attachment.get("name"),
-                        "graph_site_id": site_id,
-                        "graph_list_id": list_id,
-                        "graph_list_item_id": list_item_id,
-                        "graph_attachment_id": attachment_id,
-                    }
-        except NotFound:
-            return
-
-    async def graph_download_attachment(
-        self, site_id, list_id, list_item_id, attachment_id, async_buffer
-    ):
-        url = (
-            f"{GRAPH_API_URL}/sites/{site_id}/lists/{list_id}/items/"
-            f"{list_item_id}/attachments/{attachment_id}/content"
-        )
-        await self._graph_api_client.pipe(url, async_buffer)
-
     async def site_list_item_attachments(self, site_web_url, list_title, list_item_id):
         self._validate_sharepoint_rest_url(site_web_url)
 
@@ -1052,32 +1022,6 @@ class SharepointOnlineClient:
         await self._rest_api_client.pipe(
             f"{attachment_absolute_path}/$value", async_buffer
         )
-
-    async def graph_site_pages(self, site_id):
-        list_select = (
-            "id,name,title,webUrl,description,createdDateTime,lastModifiedDateTime"
-        )
-        detail_select = "id,description,canvasLayout,sharepointIds"
-
-        try:
-            async for page in self._graph_api_client.scroll(
-                f"{GRAPH_API_URL}/sites/{site_id}/pages?$select={list_select}"
-            ):
-                for graph_page in page:
-                    page_id = graph_page.get("id")
-                    if page_id:
-                        try:
-                            detail = await self._graph_api_client.fetch(
-                                f"{GRAPH_API_URL}/sites/{site_id}/pages/{page_id}"
-                                f"?$select={detail_select}"
-                            )
-                            graph_page = {**graph_page, **detail}
-                        except NotFound:
-                            pass
-
-                    yield graph_site_page_to_document(graph_page)
-        except NotFound:
-            return
 
     async def site_pages(self, site_web_url):
         self._validate_sharepoint_rest_url(site_web_url)

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
@@ -33,7 +33,9 @@ from connectors.sources.sharepoint.sharepoint_online.constants import (
     WILDCARD,
 )
 from connectors.sources.sharepoint.sharepoint_online.utils import (
+    DeltaLinkExpired,
     _is_excluded_sharepoint_url,
+    graph_site_page_to_document,
 )
 from connectors.utils import (
     CacheWithTimeout,
@@ -296,7 +298,7 @@ def retryable_aiohttp_call(retries):
                     async for item in func(*args, **kwargs, retry_count=retry):
                         yield item
                     break
-                except (NotFound, BadRequestError):
+                except (NotFound, BadRequestError, DeltaLinkExpired):
                     raise
                 except Exception:
                     if retry >= retries:
@@ -476,6 +478,9 @@ class MicrosoftAPISession:
             raise PermissionsMissing(msg) from e
         elif e.status == 404:
             raise NotFound from e  # We wanna catch it in the code that uses this and ignore in some cases
+        elif e.status == 410:
+            msg = f"Delta link expired for {absolute_url}"
+            raise DeltaLinkExpired(msg) from e
         elif e.status == 500:
             raise InternalServerError from e
         elif e.status == 400:
@@ -852,20 +857,28 @@ class SharepointOnlineClient:
             delta_link = (
                 response[DELTA_LINK_KEY] if DELTA_LINK_KEY in response else None
             )
-            if "value" in response and len(response["value"]) > 0:
-                yield DriveItemsPage(response["value"], delta_link)
+            items = response.get("value", [])
+            if items or delta_link:
+                yield DriveItemsPage(items, delta_link)
 
     async def drive_items(self, drive_id, url=None):
-        url = (
-            (
-                f"{GRAPH_API_URL}/drives/{drive_id}/root/delta?$select={DRIVE_ITEMS_FIELDS}"
-            )
-            if not url
-            else url
+        fresh_url = (
+            f"{GRAPH_API_URL}/drives/{drive_id}/root/delta?$select={DRIVE_ITEMS_FIELDS}"
         )
+        effective_url = fresh_url if not url else url
 
-        async for page in self.drive_items_delta(url):
-            yield page
+        try:
+            async for page in self.drive_items_delta(effective_url):
+                yield page
+        except DeltaLinkExpired:
+            if not url:
+                raise
+
+            self._logger.warning(
+                f"Drive delta link expired for drive '{drive_id}'; restarting from root/delta"
+            )
+            async for page in self.drive_items_delta(fresh_url):
+                yield page
 
     async def drive_items_permissions_batch(self, drive_id, drive_item_ids):
         requests = []
@@ -975,6 +988,36 @@ class SharepointOnlineClient:
             for site_list in page:
                 yield site_list
 
+    async def graph_site_list_item_attachments(self, site_id, list_id, list_item_id):
+        url = (
+            f"{GRAPH_API_URL}/sites/{site_id}/lists/{list_id}/items/"
+            f"{list_item_id}/attachments"
+        )
+
+        try:
+            async for page in self._graph_api_client.scroll(url):
+                for attachment in page:
+                    attachment_id = attachment.get("id")
+                    yield {
+                        "odata.id": attachment_id,
+                        "FileName": attachment.get("name"),
+                        "graph_site_id": site_id,
+                        "graph_list_id": list_id,
+                        "graph_list_item_id": list_item_id,
+                        "graph_attachment_id": attachment_id,
+                    }
+        except NotFound:
+            return
+
+    async def graph_download_attachment(
+        self, site_id, list_id, list_item_id, attachment_id, async_buffer
+    ):
+        url = (
+            f"{GRAPH_API_URL}/sites/{site_id}/lists/{list_id}/items/"
+            f"{list_item_id}/attachments/{attachment_id}/content"
+        )
+        await self._graph_api_client.pipe(url, async_buffer)
+
     async def site_list_item_attachments(self, site_web_url, list_title, list_item_id):
         self._validate_sharepoint_rest_url(site_web_url)
 
@@ -996,6 +1039,18 @@ class SharepointOnlineClient:
         await self._rest_api_client.pipe(
             f"{attachment_absolute_path}/$value", async_buffer
         )
+
+    async def graph_site_pages(self, site_id):
+        select = "id,name,title,webUrl,description,createdDateTime,lastModifiedDateTime"
+
+        try:
+            async for page in self._graph_api_client.scroll(
+                f"{GRAPH_API_URL}/sites/{site_id}/pages?$select={select}"
+            ):
+                for graph_page in page:
+                    yield graph_site_page_to_document(graph_page)
+        except NotFound:
+            return
 
     async def site_pages(self, site_web_url):
         self._validate_sharepoint_rest_url(site_web_url)

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
@@ -71,6 +71,12 @@ class InternalServerError(Exception):
     pass
 
 
+class GoneError(Exception):
+    """Raised when the API returns HTTP 410 Gone."""
+
+    pass
+
+
 class ThrottledError(Exception):
     """Internal exception class to indicate that request was throttled by the API"""
 
@@ -297,7 +303,7 @@ def retryable_aiohttp_call(retries):
                     async for item in func(*args, **kwargs, retry_count=retry):
                         yield item
                     break
-                except (NotFound, BadRequestError, DeltaLinkExpired):
+                except (NotFound, BadRequestError, GoneError):
                     raise
                 except Exception:
                     if retry >= retries:
@@ -478,8 +484,7 @@ class MicrosoftAPISession:
         elif e.status == 404:
             raise NotFound from e  # We wanna catch it in the code that uses this and ignore in some cases
         elif e.status == 410:
-            msg = f"Delta link expired for {absolute_url}"
-            raise DeltaLinkExpired(msg) from e
+            raise GoneError from e
         elif e.status == 500:
             raise InternalServerError from e
         elif e.status == 400:
@@ -852,13 +857,17 @@ class SharepointOnlineClient:
                 yield site_drive
 
     async def drive_items_delta(self, url):
-        async for response in self._graph_api_client.scroll_delta_url(url):
-            delta_link = (
-                response[DELTA_LINK_KEY] if DELTA_LINK_KEY in response else None
-            )
-            items = response.get("value", [])
-            if items or delta_link:
-                yield DriveItemsPage(items, delta_link)
+        try:
+            async for response in self._graph_api_client.scroll_delta_url(url):
+                delta_link = (
+                    response[DELTA_LINK_KEY] if DELTA_LINK_KEY in response else None
+                )
+                items = response.get("value", [])
+                if items or delta_link:
+                    yield DriveItemsPage(items, delta_link)
+        except GoneError as e:
+            msg = f"Delta link expired for {url}"
+            raise DeltaLinkExpired(msg) from e
 
     async def drive_items(self, drive_id, url=None, on_delta_reset=None):
         fresh_url = (

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
@@ -873,24 +873,15 @@ class SharepointOnlineClient:
         fresh_url = (
             f"{GRAPH_API_URL}/drives/{drive_id}/root/delta?$select={DRIVE_ITEMS_FIELDS}"
         )
-        effective_url = fresh_url if not url else url
+        current_url = url or fresh_url
 
-        async for page in self._drive_items_with_delta_recovery(
-            drive_id, effective_url, fresh_url, on_delta_reset=on_delta_reset
-        ):
-            yield page
-
-    async def _drive_items_with_delta_recovery(
-        self, drive_id, url, fresh_url, *, allow_restart=True, on_delta_reset=None
-    ):
-        current_url = url
-        while True:
+        for attempt in (0, 1):
             try:
                 async for page in self.drive_items_delta(current_url):
                     yield page
                 return
             except DeltaLinkExpired:
-                if not allow_restart:
+                if attempt == 1:
                     raise
 
                 self._logger.warning(
@@ -900,7 +891,6 @@ class SharepointOnlineClient:
                 if on_delta_reset is not None:
                     on_delta_reset(drive_id)
                 current_url = fresh_url
-                allow_restart = False
 
     async def drive_items_permissions_batch(self, drive_id, drive_item_ids):
         requests = []

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/client.py
@@ -867,18 +867,30 @@ class SharepointOnlineClient:
         )
         effective_url = fresh_url if not url else url
 
-        try:
-            async for page in self.drive_items_delta(effective_url):
-                yield page
-        except DeltaLinkExpired:
-            if not url:
-                raise
+        async for page in self._drive_items_with_delta_recovery(
+            drive_id, effective_url, fresh_url
+        ):
+            yield page
 
-            self._logger.warning(
-                f"Drive delta link expired for drive '{drive_id}'; restarting from root/delta"
-            )
-            async for page in self.drive_items_delta(fresh_url):
-                yield page
+    async def _drive_items_with_delta_recovery(
+        self, drive_id, url, fresh_url, *, allow_restart=True
+    ):
+        current_url = url
+        while True:
+            try:
+                async for page in self.drive_items_delta(current_url):
+                    yield page
+                return
+            except DeltaLinkExpired:
+                if not allow_restart:
+                    raise
+
+                self._logger.warning(
+                    f"Drive delta link expired for drive '{drive_id}'; "
+                    "restarting enumeration from root/delta"
+                )
+                current_url = fresh_url
+                allow_restart = False
 
     async def drive_items_permissions_batch(self, drive_id, drive_item_ids):
         requests = []
@@ -998,8 +1010,9 @@ class SharepointOnlineClient:
             async for page in self._graph_api_client.scroll(url):
                 for attachment in page:
                     attachment_id = attachment.get("id")
+                    stable_id = f"{list_id}-{list_item_id}-attachment-{attachment_id}"
                     yield {
-                        "odata.id": attachment_id,
+                        "odata.id": stable_id,
                         "FileName": attachment.get("name"),
                         "graph_site_id": site_id,
                         "graph_list_id": list_id,
@@ -1041,13 +1054,27 @@ class SharepointOnlineClient:
         )
 
     async def graph_site_pages(self, site_id):
-        select = "id,name,title,webUrl,description,createdDateTime,lastModifiedDateTime"
+        list_select = (
+            "id,name,title,webUrl,description,createdDateTime,lastModifiedDateTime"
+        )
+        detail_select = "id,description,canvasLayout,sharepointIds"
 
         try:
             async for page in self._graph_api_client.scroll(
-                f"{GRAPH_API_URL}/sites/{site_id}/pages?$select={select}"
+                f"{GRAPH_API_URL}/sites/{site_id}/pages?$select={list_select}"
             ):
                 for graph_page in page:
+                    page_id = graph_page.get("id")
+                    if page_id:
+                        try:
+                            detail = await self._graph_api_client.fetch(
+                                f"{GRAPH_API_URL}/sites/{site_id}/pages/{page_id}"
+                                f"?$select={detail_select}"
+                            )
+                            graph_page = {**graph_page, **detail}
+                        except NotFound:
+                            pass
+
                     yield graph_site_page_to_document(graph_page)
         except NotFound:
             return

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
@@ -41,6 +41,7 @@ from connectors.sources.sharepoint.sharepoint_online.constants import (
     WILDCARD,
 )
 from connectors.sources.sharepoint.sharepoint_online.utils import (
+    DeltaLinkExpired,
     SyncCursorEmpty,
     _get_login_name,
     _parse_created_date_time,
@@ -279,14 +280,6 @@ class SharepointOnlineDataSource(BaseDataSource):
         if missing:
             msg = f"The specified SharePoint sites [{', '.join(missing)}] could not be retrieved during sync. Examples of sites available on the tenant:[{', '.join(retrieved_sites[:5])}]."
             raise Exception(msg)
-
-        if self.configuration["auth_method"] == "secret" and self._dls_enabled():
-            self._logger.warning(
-                "Document Level Security is enabled with client-secret authentication. "
-                "SharePoint REST permission calls may fail on some tenants. "
-                "Certificate authentication with SharePoint application permissions is "
-                "recommended for reliable DLS."
-            )
 
     def _site_path_from_web_url(self, web_url):
         url_parts = web_url.split("/sites/")
@@ -627,7 +620,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                         None,
                     )
 
-                    async for page in self.client.drive_items(site_drive["id"]):
+                    async for page in self._sync_drive_items(site_drive["id"]):
                         for drive_items_batch in iterable_batches_generator(
                             page.items, SPO_API_MAX_BATCH_SIZE
                         ):
@@ -735,11 +728,7 @@ class SharepointOnlineDataSource(BaseDataSource):
                         OP_INDEX,
                     )
 
-                    delta_link = self.get_drive_delta_link(site_drive["id"])
-
-                    async for page in self.client.drive_items(
-                        drive_id=site_drive["id"], url=delta_link
-                    ):
+                    async for page in self._sync_drive_items(site_drive["id"]):
                         for drive_items_batch in iterable_batches_generator(
                             page.items, SPO_API_MAX_BATCH_SIZE
                         ):
@@ -1038,8 +1027,8 @@ class SharepointOnlineDataSource(BaseDataSource):
                 if "Attachments" in list_item["fields"]:
                     async for (
                         list_item_attachment
-                    ) in self.client.graph_site_list_item_attachments(
-                        site_id, site_list_id, list_item_natural_id
+                    ) in self.client.site_list_item_attachments(
+                        site_web_url, site_list_name, list_item_natural_id
                     ):
                         list_item_attachment["_id"] = list_item_attachment["odata.id"]
                         list_item_attachment["object_type"] = "list_item_attachment"
@@ -1203,7 +1192,7 @@ class SharepointOnlineDataSource(BaseDataSource):
     async def site_pages(self, site, site_access_control, check_timestamp=False):
         site_id = site["id"]
         url = site["webUrl"]
-        async for site_page in self.client.graph_site_pages(site_id):
+        async for site_page in self.client.site_pages(url):
             if not check_timestamp or (
                 check_timestamp and site_page["Modified"] >= self.last_sync_time()
             ):
@@ -1287,6 +1276,22 @@ class SharepointOnlineDataSource(BaseDataSource):
         site_drives = self._sync_cursor.get(CURSOR_SITE_DRIVE_KEY)
         if site_drives and drive_id in site_drives:
             del site_drives[drive_id]
+
+    async def _sync_drive_items(self, drive_id):
+        try:
+            async for page in self.client.drive_items(
+                drive_id,
+                url=self.get_drive_delta_link(drive_id),
+                on_delta_reset=self.clear_drive_delta_link,
+            ):
+                yield page
+        except DeltaLinkExpired as e:
+            self.clear_drive_delta_link(drive_id)
+            msg = (
+                f"Drive delta sync failed for drive '{drive_id}' after 410 Gone "
+                "recovery attempt. Run a full sync after the issue is resolved."
+            )
+            raise DeltaLinkExpired(msg) from e
 
     def get_drive_delta_link(self, drive_id):
         return nested_get_from_dict(
@@ -1385,21 +1390,8 @@ class SharepointOnlineDataSource(BaseDataSource):
             "_timestamp": new_timestamp,
         }
 
-        if attachment.get("graph_attachment_id"):
-            download_func = partial(
-                self.client.graph_download_attachment,
-                attachment["graph_site_id"],
-                attachment["graph_list_id"],
-                attachment["graph_list_item_id"],
-                attachment["graph_attachment_id"],
-            )
-        else:
-            download_func = partial(
-                self.client.download_attachment, attachment["odata.id"]
-            )
-
         attached_file, body = await self._download_content(
-            download_func,
+            partial(self.client.download_attachment, attachment["odata.id"]),
             attachment["_original_filename"],
         )
 

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
@@ -1283,6 +1283,11 @@ class SharepointOnlineDataSource(BaseDataSource):
 
         self._sync_cursor[CURSOR_SITE_DRIVE_KEY][drive_id] = link
 
+    def clear_drive_delta_link(self, drive_id):
+        site_drives = self._sync_cursor.get(CURSOR_SITE_DRIVE_KEY)
+        if site_drives and drive_id in site_drives:
+            del site_drives[drive_id]
+
     def get_drive_delta_link(self, drive_id):
         return nested_get_from_dict(
             self._sync_cursor, [CURSOR_SITE_DRIVE_KEY, drive_id]

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
@@ -280,6 +280,14 @@ class SharepointOnlineDataSource(BaseDataSource):
             msg = f"The specified SharePoint sites [{', '.join(missing)}] could not be retrieved during sync. Examples of sites available on the tenant:[{', '.join(retrieved_sites[:5])}]."
             raise Exception(msg)
 
+        if self.configuration["auth_method"] == "secret" and self._dls_enabled():
+            self._logger.warning(
+                "Document Level Security is enabled with client-secret authentication. "
+                "SharePoint REST permission calls may fail on some tenants. "
+                "Certificate authentication with SharePoint application permissions is "
+                "recommended for reliable DLS."
+            )
+
     def _site_path_from_web_url(self, web_url):
         url_parts = web_url.split("/sites/")
         site_path_parts = url_parts[1:]
@@ -1030,8 +1038,8 @@ class SharepointOnlineDataSource(BaseDataSource):
                 if "Attachments" in list_item["fields"]:
                     async for (
                         list_item_attachment
-                    ) in self.client.site_list_item_attachments(
-                        site_web_url, site_list_name, list_item_natural_id
+                    ) in self.client.graph_site_list_item_attachments(
+                        site_id, site_list_id, list_item_natural_id
                     ):
                         list_item_attachment["_id"] = list_item_attachment["odata.id"]
                         list_item_attachment["object_type"] = "list_item_attachment"
@@ -1195,7 +1203,7 @@ class SharepointOnlineDataSource(BaseDataSource):
     async def site_pages(self, site, site_access_control, check_timestamp=False):
         site_id = site["id"]
         url = site["webUrl"]
-        async for site_page in self.client.site_pages(url):
+        async for site_page in self.client.graph_site_pages(site_id):
             if not check_timestamp or (
                 check_timestamp and site_page["Modified"] >= self.last_sync_time()
             ):
@@ -1372,8 +1380,21 @@ class SharepointOnlineDataSource(BaseDataSource):
             "_timestamp": new_timestamp,
         }
 
+        if attachment.get("graph_attachment_id"):
+            download_func = partial(
+                self.client.graph_download_attachment,
+                attachment["graph_site_id"],
+                attachment["graph_list_id"],
+                attachment["graph_list_item_id"],
+                attachment["graph_attachment_id"],
+            )
+        else:
+            download_func = partial(
+                self.client.download_attachment, attachment["odata.id"]
+            )
+
         attached_file, body = await self._download_content(
-            partial(self.client.download_attachment, attachment["odata.id"]),
+            download_func,
             attachment["_original_filename"],
         )
 

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/datasource.py
@@ -1280,9 +1280,7 @@ class SharepointOnlineDataSource(BaseDataSource):
     async def _sync_drive_items(self, drive_id):
         try:
             async for page in self.client.drive_items(
-                drive_id,
-                url=self.get_drive_delta_link(drive_id),
-                on_delta_reset=self.clear_drive_delta_link,
+                drive_id, url=self.get_drive_delta_link(drive_id)
             ):
                 yield page
         except DeltaLinkExpired as e:

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/utils.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/utils.py
@@ -21,6 +21,34 @@ class SyncCursorEmpty(Exception):
     pass
 
 
+class DeltaLinkExpired(Exception):
+    """Raised when Microsoft Graph returns 410 Gone for a delta link."""
+
+    pass
+
+
+def graph_site_page_to_document(graph_page):
+    """Map a Microsoft Graph sitePage resource to the connector document shape."""
+    page_id = graph_page.get("id")
+    description = graph_page.get("description") or ""
+
+    return {
+        "Id": page_id,
+        "Title": graph_page.get("title") or graph_page.get("name"),
+        "webUrl": graph_page.get("webUrl"),
+        "LayoutWebpartsContent": graph_page.get("layoutWebpartsContent"),
+        "CanvasContent1": graph_page.get("canvasContent1") or description,
+        "WikiField": graph_page.get("wikiField") or description,
+        "Description": description,
+        "Created": graph_page.get("createdDateTime"),
+        "Modified": graph_page.get("lastModifiedDateTime"),
+        "AuthorId": graph_page.get("authorId"),
+        "EditorId": graph_page.get("editorId"),
+        "odata.id": page_id,
+        "OData__UIVersionString": graph_page.get("uiVersionString"),
+    }
+
+
 def _prefix_group(group):
     return prefix_identity("group", group)
 

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/utils.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/utils.py
@@ -4,6 +4,7 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
+import json
 from datetime import datetime
 
 from connectors.access_control import prefix_identity
@@ -27,24 +28,49 @@ class DeltaLinkExpired(Exception):
     pass
 
 
+def _sharepoint_list_item_id(graph_page):
+    sharepoint_ids = (
+        graph_page.get("sharePointIds") or graph_page.get("sharepointIds") or {}
+    )
+    return sharepoint_ids.get("listItemId") or graph_page.get("id")
+
+
+def _graph_page_body_content(graph_page):
+    description = graph_page.get("description") or ""
+    canvas_layout = graph_page.get("canvasLayout")
+
+    if canvas_layout is None:
+        return description
+
+    if isinstance(canvas_layout, str):
+        return canvas_layout or description
+
+    try:
+        return json.dumps(canvas_layout)
+    except (TypeError, ValueError):
+        return description
+
+
 def graph_site_page_to_document(graph_page):
     """Map a Microsoft Graph sitePage resource to the connector document shape."""
     page_id = graph_page.get("id")
-    description = graph_page.get("description") or ""
+    list_item_id = _sharepoint_list_item_id(graph_page)
+    body_content = _graph_page_body_content(graph_page)
 
     return {
-        "Id": page_id,
+        "Id": list_item_id,
+        "graph_page_id": page_id,
         "Title": graph_page.get("title") or graph_page.get("name"),
         "webUrl": graph_page.get("webUrl"),
         "LayoutWebpartsContent": graph_page.get("layoutWebpartsContent"),
-        "CanvasContent1": graph_page.get("canvasContent1") or description,
-        "WikiField": graph_page.get("wikiField") or description,
-        "Description": description,
+        "CanvasContent1": body_content,
+        "WikiField": body_content,
+        "Description": graph_page.get("description") or "",
         "Created": graph_page.get("createdDateTime"),
         "Modified": graph_page.get("lastModifiedDateTime"),
         "AuthorId": graph_page.get("authorId"),
         "EditorId": graph_page.get("editorId"),
-        "odata.id": page_id,
+        "odata.id": list_item_id,
         "OData__UIVersionString": graph_page.get("uiVersionString"),
     }
 

--- a/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/utils.py
+++ b/app/connectors_service/connectors/sources/sharepoint/sharepoint_online/utils.py
@@ -4,7 +4,6 @@
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
 
-import json
 from datetime import datetime
 
 from connectors.access_control import prefix_identity
@@ -26,53 +25,6 @@ class DeltaLinkExpired(Exception):
     """Raised when Microsoft Graph returns 410 Gone for a delta link."""
 
     pass
-
-
-def _sharepoint_list_item_id(graph_page):
-    sharepoint_ids = (
-        graph_page.get("sharePointIds") or graph_page.get("sharepointIds") or {}
-    )
-    return sharepoint_ids.get("listItemId") or graph_page.get("id")
-
-
-def _graph_page_body_content(graph_page):
-    description = graph_page.get("description") or ""
-    canvas_layout = graph_page.get("canvasLayout")
-
-    if canvas_layout is None:
-        return description
-
-    if isinstance(canvas_layout, str):
-        return canvas_layout or description
-
-    try:
-        return json.dumps(canvas_layout)
-    except (TypeError, ValueError):
-        return description
-
-
-def graph_site_page_to_document(graph_page):
-    """Map a Microsoft Graph sitePage resource to the connector document shape."""
-    page_id = graph_page.get("id")
-    list_item_id = _sharepoint_list_item_id(graph_page)
-    body_content = _graph_page_body_content(graph_page)
-
-    return {
-        "Id": list_item_id,
-        "graph_page_id": page_id,
-        "Title": graph_page.get("title") or graph_page.get("name"),
-        "webUrl": graph_page.get("webUrl"),
-        "LayoutWebpartsContent": graph_page.get("layoutWebpartsContent"),
-        "CanvasContent1": body_content,
-        "WikiField": body_content,
-        "Description": graph_page.get("description") or "",
-        "Created": graph_page.get("createdDateTime"),
-        "Modified": graph_page.get("lastModifiedDateTime"),
-        "AuthorId": graph_page.get("authorId"),
-        "EditorId": graph_page.get("editorId"),
-        "odata.id": list_item_id,
-        "OData__UIVersionString": graph_page.get("uiVersionString"),
-    }
 
 
 def _prefix_group(group):

--- a/app/connectors_service/tests/sources/test_sharepoint_online.py
+++ b/app/connectors_service/tests/sources/test_sharepoint_online.py
@@ -49,12 +49,14 @@ from connectors.sources.sharepoint.sharepoint_online.constants import (
     WILDCARD,
 )
 from connectors.sources.sharepoint.sharepoint_online.utils import (
+    DeltaLinkExpired,
     SyncCursorEmpty,
     _get_login_name,
     _prefix_email,
     _prefix_group,
     _prefix_user,
     _prefix_user_id,
+    graph_site_page_to_document,
 )
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
@@ -1005,6 +1007,26 @@ class TestMicrosoftAPISession:
 
         assert e.match(error_message)
 
+    @pytest.mark.asyncio
+    async def test_call_api_with_410(
+        self,
+        microsoft_api_session,
+        mock_responses,
+        patch_sleep,
+        patch_cancellable_sleeps,
+    ):
+        url = "http://localhost:1234/delta-link"
+
+        gone_error = ClientResponseError(MagicMock(), MagicMock())
+        gone_error.status = 410
+        gone_error.message = "Gone"
+
+        mock_responses.get(url, exception=gone_error)
+
+        with pytest.raises(DeltaLinkExpired):
+            async with microsoft_api_session._get(url) as _:
+                pass
+
 
 class TestSharepointOnlineClient:
     @property
@@ -1339,6 +1361,47 @@ class TestSharepointOnlineClient:
         assert returned_drive_items == items_page_1 + items_page_2
 
     @pytest.mark.asyncio
+    async def test_drive_items_delta_yields_empty_page_with_delta_link(
+        self, client, patch_scroll_delta_url
+    ):
+        delta_url = "https://sharepoint.com/delta-link"
+        next_delta_url = "https://sharepoint.com/delta-link/next"
+
+        patch_scroll_delta_url.return_value = AsyncIterator(
+            [{"@odata.deltaLink": next_delta_url, "value": []}]
+        )
+
+        returned_pages = []
+        async for page in client.drive_items_delta(delta_url):
+            returned_pages.append(page)
+
+        assert len(returned_pages) == 1
+        assert list(returned_pages[0]) == []
+        assert returned_pages[0].delta_link() == next_delta_url
+
+    @pytest.mark.asyncio
+    async def test_drive_items_recovers_from_expired_delta_link(self, client):
+        drive_id = "drive-1"
+        stored_delta_url = "https://sharepoint.com/stale-delta"
+        fresh_items = ["item-1"]
+
+        async def drive_items_delta_mock(url):
+            if url == stored_delta_url:
+                msg = "expired"
+                raise DeltaLinkExpired(msg)
+            yield DriveItemsPage(fresh_items, "https://sharepoint.com/fresh-delta")
+
+        with patch.object(
+            client, "drive_items_delta", side_effect=drive_items_delta_mock
+        ):
+            returned_items = []
+            async for page in client.drive_items(drive_id, url=stored_delta_url):
+                for item in page:
+                    returned_items.append(item)
+
+        assert returned_items == fresh_items
+
+    @pytest.mark.asyncio
     async def test_drive_items(self, client, patch_fetch):
         drive_id = "12345"
         delta_url_next_sync = "https://sharepoint.com/delta-link-lalal/page-2"
@@ -1436,6 +1499,84 @@ class TestSharepointOnlineClient:
             returned_items.append(attachment)
 
         assert len(returned_items) == 0
+
+    @pytest.mark.asyncio
+    async def test_graph_site_list_item_attachments(self, client, patch_scroll):
+        site_id = "site-1"
+        list_id = "list-1"
+        list_item_id = "item-1"
+        actual_attachments = [
+            {"id": "attachment-1", "name": "notes.txt"},
+            {"id": "attachment-2", "name": "image.png"},
+        ]
+
+        returned_items = await self._execute_scrolling_method(
+            partial(
+                client.graph_site_list_item_attachments,
+                site_id,
+                list_id,
+                list_item_id,
+            ),
+            patch_scroll,
+            actual_attachments,
+        )
+
+        assert len(returned_items) == len(actual_attachments)
+        assert returned_items[0]["FileName"] == "notes.txt"
+        assert returned_items[0]["graph_attachment_id"] == "attachment-1"
+
+    @pytest.mark.asyncio
+    async def test_graph_site_list_item_attachments_not_found(
+        self, client, patch_scroll
+    ):
+        patch_scroll.side_effect = NotFound()
+
+        returned_items = []
+        async for attachment in client.graph_site_list_item_attachments(
+            "site-1", "list-1", "item-1"
+        ):
+            returned_items.append(attachment)
+
+        assert returned_items == []
+
+    @pytest.mark.asyncio
+    async def test_graph_site_pages(self, client, patch_scroll):
+        site_id = "site-1"
+        actual_items = [
+            {
+                "id": "page-1",
+                "title": "Home",
+                "webUrl": "https://example.sharepoint.com/sitepages/home.aspx",
+                "description": "Welcome",
+                "createdDateTime": "2024-01-01T00:00:00Z",
+                "lastModifiedDateTime": "2024-01-02T00:00:00Z",
+            }
+        ]
+
+        returned_items = await self._execute_scrolling_method(
+            partial(client.graph_site_pages, site_id), patch_scroll, actual_items
+        )
+
+        assert len(returned_items) == 1
+        assert returned_items[0]["Title"] == "Home"
+        assert returned_items[0]["Modified"] == "2024-01-02T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_graph_site_page_to_document(self):
+        graph_page = {
+            "id": "page-1",
+            "title": "Home",
+            "webUrl": "https://example.sharepoint.com/sitepages/home.aspx",
+            "description": "Welcome",
+            "createdDateTime": "2024-01-01T00:00:00Z",
+            "lastModifiedDateTime": "2024-01-02T00:00:00Z",
+        }
+
+        document = graph_site_page_to_document(graph_page)
+
+        assert document["Id"] == "page-1"
+        assert document["CanvasContent1"] == "Welcome"
+        assert document["Modified"] == "2024-01-02T00:00:00Z"
 
     @pytest.mark.asyncio
     async def test_site_list_item_attachments_wrong_tenant(self, client):
@@ -2131,8 +2272,22 @@ class TestSharepointOnlineDataSource:
     @property
     def site_list_item_attachments(self):
         return [
-            {"odata.id": "9", "name": "attachment 1.txt"},
-            {"odata.id": "10", "name": "attachment 2.txt"},
+            {
+                "odata.id": "9",
+                "FileName": "attachment 1.txt",
+                "graph_site_id": "site-1",
+                "graph_list_id": SITE_LIST_ONE_ID,
+                "graph_list_item_id": "1",
+                "graph_attachment_id": "9",
+            },
+            {
+                "odata.id": "10",
+                "FileName": "attachment 2.txt",
+                "graph_site_id": "site-1",
+                "graph_list_id": SITE_LIST_ONE_ID,
+                "graph_list_item_id": "1",
+                "graph_attachment_id": "10",
+            },
         ]
 
     @property
@@ -2340,10 +2495,10 @@ class TestSharepointOnlineDataSource:
                 return_value=self.site_list_has_unique_role_assignments
             )
             client.site_list_items = AsyncIterator(self.site_list_items)
-            client.site_list_item_attachments = AsyncIterator(
+            client.graph_site_list_item_attachments = AsyncIterator(
                 self.site_list_item_attachments
             )
-            client.site_pages = AsyncIterator(self.site_pages)
+            client.graph_site_pages = AsyncIterator(self.site_pages)
 
             client.graph_api_token = AsyncMock()
             client.graph_api_token.get.return_value = self.graph_api_token
@@ -2691,14 +2846,14 @@ class TestSharepointOnlineDataSource:
                 },
             ]
         )
-        attachment_list_titles = []
+        attachment_list_ids = []
 
-        async def attachments_spy(site_web_url, list_title, list_item_id):
-            attachment_list_titles.append(list_title)
+        async def attachments_spy(site_id, list_id, list_item_id):
+            attachment_list_ids.append(list_id)
             for attachment in self.site_list_item_attachments:
                 yield attachment
 
-        patch_sharepoint_client.site_list_item_attachments = attachments_spy
+        patch_sharepoint_client.graph_site_list_item_attachments = attachments_spy
 
         async with create_spo_source() as source:
             source._dls_enabled = Mock(return_value=False)
@@ -2711,8 +2866,8 @@ class TestSharepointOnlineDataSource:
                 doc["name"] for doc in results if doc.get("object_type") == "site_list"
             ]
             assert site_list_names == [SITE_LIST_ONE_NAME]
-            assert SHAREPOINT_HOME_CACHE_LIST_NAME not in attachment_list_titles
-            assert SITE_LIST_ONE_NAME in attachment_list_titles
+            assert SHAREPOINT_HOME_CACHE_LIST_ID not in attachment_list_ids
+            assert SITE_LIST_ONE_ID in attachment_list_ids
             # Same document set as sync without the excluded system list
             assert len(results) == 11
 

--- a/app/connectors_service/tests/sources/test_sharepoint_online.py
+++ b/app/connectors_service/tests/sources/test_sharepoint_online.py
@@ -56,7 +56,6 @@ from connectors.sources.sharepoint.sharepoint_online.utils import (
     _prefix_group,
     _prefix_user,
     _prefix_user_id,
-    graph_site_page_to_document,
 )
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
@@ -1443,6 +1442,34 @@ class TestSharepointOnlineClient:
                     pass
 
     @pytest.mark.asyncio
+    async def test_drive_items_calls_on_delta_reset(self, client):
+        drive_id = "drive-1"
+        stored_delta_url = "https://sharepoint.com/stale-delta"
+        fresh_items = ["item-1"]
+        reset_calls = []
+
+        async def drive_items_delta_mock(url):
+            if url == stored_delta_url:
+                msg = "expired"
+                raise DeltaLinkExpired(msg)
+            yield DriveItemsPage(fresh_items, "https://sharepoint.com/fresh-delta")
+
+        with patch.object(
+            client, "drive_items_delta", side_effect=drive_items_delta_mock
+        ):
+            returned_items = []
+            async for page in client.drive_items(
+                drive_id,
+                url=stored_delta_url,
+                on_delta_reset=reset_calls.append,
+            ):
+                for item in page:
+                    returned_items.append(item)
+
+        assert returned_items == fresh_items
+        assert reset_calls == [drive_id]
+
+    @pytest.mark.asyncio
     async def test_drive_items(self, client, patch_fetch):
         drive_id = "12345"
         delta_url_next_sync = "https://sharepoint.com/delta-link-lalal/page-2"
@@ -1540,97 +1567,6 @@ class TestSharepointOnlineClient:
             returned_items.append(attachment)
 
         assert len(returned_items) == 0
-
-    @pytest.mark.asyncio
-    async def test_graph_site_list_item_attachments(self, client, patch_scroll):
-        site_id = "site-1"
-        list_id = "list-1"
-        list_item_id = "item-1"
-        actual_attachments = [
-            {"id": "attachment-1", "name": "notes.txt"},
-            {"id": "attachment-2", "name": "image.png"},
-        ]
-
-        returned_items = await self._execute_scrolling_method(
-            partial(
-                client.graph_site_list_item_attachments,
-                site_id,
-                list_id,
-                list_item_id,
-            ),
-            patch_scroll,
-            actual_attachments,
-        )
-
-        assert len(returned_items) == len(actual_attachments)
-        assert returned_items[0]["FileName"] == "notes.txt"
-        assert returned_items[0]["graph_attachment_id"] == "attachment-1"
-        assert returned_items[0]["odata.id"] == "list-1-item-1-attachment-attachment-1"
-
-    @pytest.mark.asyncio
-    async def test_graph_site_list_item_attachments_not_found(
-        self, client, patch_scroll
-    ):
-        patch_scroll.side_effect = NotFound()
-
-        returned_items = []
-        async for attachment in client.graph_site_list_item_attachments(
-            "site-1", "list-1", "item-1"
-        ):
-            returned_items.append(attachment)
-
-        assert returned_items == []
-
-    @pytest.mark.asyncio
-    async def test_graph_site_pages(self, client, patch_scroll, patch_fetch):
-        site_id = "site-1"
-        actual_items = [
-            {
-                "id": "page-1",
-                "title": "Home",
-                "webUrl": "https://example.sharepoint.com/sitepages/home.aspx",
-                "description": "Welcome",
-                "createdDateTime": "2024-01-01T00:00:00Z",
-                "lastModifiedDateTime": "2024-01-02T00:00:00Z",
-            }
-        ]
-        patch_fetch.return_value = {
-            "id": "page-1",
-            "description": "Welcome detail",
-            "canvasLayout": {"horizontalSections": []},
-            "sharepointIds": {"listItemId": "4"},
-        }
-
-        returned_items = await self._execute_scrolling_method(
-            partial(client.graph_site_pages, site_id), patch_scroll, actual_items
-        )
-
-        assert len(returned_items) == 1
-        assert returned_items[0]["Title"] == "Home"
-        assert returned_items[0]["Modified"] == "2024-01-02T00:00:00Z"
-        assert returned_items[0]["Id"] == "4"
-        assert returned_items[0]["graph_page_id"] == "page-1"
-        patch_fetch.assert_awaited()
-
-    @pytest.mark.asyncio
-    async def test_graph_site_page_to_document(self):
-        graph_page = {
-            "id": "page-1",
-            "title": "Home",
-            "webUrl": "https://example.sharepoint.com/sitepages/home.aspx",
-            "description": "Welcome",
-            "createdDateTime": "2024-01-01T00:00:00Z",
-            "lastModifiedDateTime": "2024-01-02T00:00:00Z",
-            "sharepointIds": {"listItemId": "4"},
-            "canvasLayout": {"sections": [{"text": "Hello"}]},
-        }
-
-        document = graph_site_page_to_document(graph_page)
-
-        assert document["Id"] == "4"
-        assert document["graph_page_id"] == "page-1"
-        assert "sections" in document["CanvasContent1"]
-        assert document["Modified"] == "2024-01-02T00:00:00Z"
 
     @pytest.mark.asyncio
     async def test_site_list_item_attachments_wrong_tenant(self, client):
@@ -2326,22 +2262,8 @@ class TestSharepointOnlineDataSource:
     @property
     def site_list_item_attachments(self):
         return [
-            {
-                "odata.id": f"{SITE_LIST_ONE_ID}-1-attachment-9",
-                "FileName": "attachment 1.txt",
-                "graph_site_id": "site-1",
-                "graph_list_id": SITE_LIST_ONE_ID,
-                "graph_list_item_id": "1",
-                "graph_attachment_id": "9",
-            },
-            {
-                "odata.id": f"{SITE_LIST_ONE_ID}-1-attachment-10",
-                "FileName": "attachment 2.txt",
-                "graph_site_id": "site-1",
-                "graph_list_id": SITE_LIST_ONE_ID,
-                "graph_list_item_id": "1",
-                "graph_attachment_id": "10",
-            },
+            {"odata.id": "9", "name": "attachment 1.txt"},
+            {"odata.id": "10", "name": "attachment 2.txt"},
         ]
 
     @property
@@ -2349,11 +2271,9 @@ class TestSharepointOnlineDataSource:
         return [
             {
                 "Id": "4",
-                "graph_page_id": "page-graph-id",
-                "odata.id": "4",
+                "odata.id": "11",
                 "GUID": "thats-not-a-guid",
                 "Modified": self.day_ago,
-                "CanvasContent1": "page content",
             }
         ]
 
@@ -2551,10 +2471,10 @@ class TestSharepointOnlineDataSource:
                 return_value=self.site_list_has_unique_role_assignments
             )
             client.site_list_items = AsyncIterator(self.site_list_items)
-            client.graph_site_list_item_attachments = AsyncIterator(
+            client.site_list_item_attachments = AsyncIterator(
                 self.site_list_item_attachments
             )
-            client.graph_site_pages = AsyncIterator(self.site_pages)
+            client.site_pages = AsyncIterator(self.site_pages)
 
             client.graph_api_token = AsyncMock()
             client.graph_api_token.get.return_value = self.graph_api_token
@@ -2566,7 +2486,7 @@ class TestSharepointOnlineDataSource:
 
             yield client
 
-    def drive_items_func(self, drive_id, url=None):
+    def drive_items_func(self, drive_id, url=None, on_delta_reset=None):
         if not url:
             return AsyncIterator(self.drive_items)
         else:
@@ -2902,14 +2822,14 @@ class TestSharepointOnlineDataSource:
                 },
             ]
         )
-        attachment_list_ids = []
+        attachment_list_titles = []
 
-        async def attachments_spy(site_id, list_id, list_item_id):
-            attachment_list_ids.append(list_id)
+        async def attachments_spy(site_web_url, list_title, list_item_id):
+            attachment_list_titles.append(list_title)
             for attachment in self.site_list_item_attachments:
                 yield attachment
 
-        patch_sharepoint_client.graph_site_list_item_attachments = attachments_spy
+        patch_sharepoint_client.site_list_item_attachments = attachments_spy
 
         async with create_spo_source() as source:
             source._dls_enabled = Mock(return_value=False)
@@ -2922,10 +2842,37 @@ class TestSharepointOnlineDataSource:
                 doc["name"] for doc in results if doc.get("object_type") == "site_list"
             ]
             assert site_list_names == [SITE_LIST_ONE_NAME]
-            assert SHAREPOINT_HOME_CACHE_LIST_ID not in attachment_list_ids
-            assert SITE_LIST_ONE_ID in attachment_list_ids
+            assert SHAREPOINT_HOME_CACHE_LIST_NAME not in attachment_list_titles
+            assert SITE_LIST_ONE_NAME in attachment_list_titles
             # Same document set as sync without the excluded system list
             assert len(results) == 11
+
+    @pytest.mark.asyncio
+    async def test_sync_drive_items_clears_cursor_on_failure(
+        self, patch_sharepoint_client
+    ):
+        drive_id = "drive-to-fail"
+
+        async def failing_drive_items(drive_id, url=None, on_delta_reset=None):
+            msg = "still expired after reset"
+            raise DeltaLinkExpired(msg)
+            yield  # pragma: no cover
+
+        patch_sharepoint_client.drive_items = failing_drive_items
+
+        async with create_spo_source() as source:
+            source.init_sync_cursor()
+            source.update_drive_delta_link(
+                drive_id, "https://sharepoint.com/stale-delta"
+            )
+
+            with pytest.raises(DeltaLinkExpired) as exc_info:
+                async for _page in source._sync_drive_items(drive_id):
+                    pass
+
+            assert drive_id in str(exc_info.value)
+            assert "410 Gone" in str(exc_info.value)
+            assert source.get_drive_delta_link(drive_id) is None
 
     @pytest.mark.asyncio
     async def test_site_lists_with_unique_role_assignments(

--- a/app/connectors_service/tests/sources/test_sharepoint_online.py
+++ b/app/connectors_service/tests/sources/test_sharepoint_online.py
@@ -1402,6 +1402,47 @@ class TestSharepointOnlineClient:
         assert returned_items == fresh_items
 
     @pytest.mark.asyncio
+    async def test_drive_items_recovers_from_410_on_full_sync(self, client):
+        drive_id = "drive-1"
+        fresh_items = ["item-1"]
+        call_count = 0
+
+        async def drive_items_delta_mock(url):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                msg = "expired"
+                raise DeltaLinkExpired(msg)
+            yield DriveItemsPage(fresh_items, "https://sharepoint.com/fresh-delta")
+
+        with patch.object(
+            client, "drive_items_delta", side_effect=drive_items_delta_mock
+        ):
+            returned_items = []
+            async for page in client.drive_items(drive_id):
+                for item in page:
+                    returned_items.append(item)
+
+        assert returned_items == fresh_items
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_drive_items_does_not_retry_410_infinitely(self, client):
+        drive_id = "drive-1"
+
+        async def drive_items_delta_mock(url):
+            msg = "expired"
+            raise DeltaLinkExpired(msg)
+            yield  # pragma: no cover - makes this an async generator for patching
+
+        with patch.object(
+            client, "drive_items_delta", side_effect=drive_items_delta_mock
+        ):
+            with pytest.raises(DeltaLinkExpired):
+                async for _page in client.drive_items(drive_id):
+                    pass
+
+    @pytest.mark.asyncio
     async def test_drive_items(self, client, patch_fetch):
         drive_id = "12345"
         delta_url_next_sync = "https://sharepoint.com/delta-link-lalal/page-2"
@@ -1524,6 +1565,7 @@ class TestSharepointOnlineClient:
         assert len(returned_items) == len(actual_attachments)
         assert returned_items[0]["FileName"] == "notes.txt"
         assert returned_items[0]["graph_attachment_id"] == "attachment-1"
+        assert returned_items[0]["odata.id"] == "list-1-item-1-attachment-attachment-1"
 
     @pytest.mark.asyncio
     async def test_graph_site_list_item_attachments_not_found(
@@ -1540,7 +1582,7 @@ class TestSharepointOnlineClient:
         assert returned_items == []
 
     @pytest.mark.asyncio
-    async def test_graph_site_pages(self, client, patch_scroll):
+    async def test_graph_site_pages(self, client, patch_scroll, patch_fetch):
         site_id = "site-1"
         actual_items = [
             {
@@ -1552,6 +1594,12 @@ class TestSharepointOnlineClient:
                 "lastModifiedDateTime": "2024-01-02T00:00:00Z",
             }
         ]
+        patch_fetch.return_value = {
+            "id": "page-1",
+            "description": "Welcome detail",
+            "canvasLayout": {"horizontalSections": []},
+            "sharepointIds": {"listItemId": "4"},
+        }
 
         returned_items = await self._execute_scrolling_method(
             partial(client.graph_site_pages, site_id), patch_scroll, actual_items
@@ -1560,6 +1608,9 @@ class TestSharepointOnlineClient:
         assert len(returned_items) == 1
         assert returned_items[0]["Title"] == "Home"
         assert returned_items[0]["Modified"] == "2024-01-02T00:00:00Z"
+        assert returned_items[0]["Id"] == "4"
+        assert returned_items[0]["graph_page_id"] == "page-1"
+        patch_fetch.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_graph_site_page_to_document(self):
@@ -1570,12 +1621,15 @@ class TestSharepointOnlineClient:
             "description": "Welcome",
             "createdDateTime": "2024-01-01T00:00:00Z",
             "lastModifiedDateTime": "2024-01-02T00:00:00Z",
+            "sharepointIds": {"listItemId": "4"},
+            "canvasLayout": {"sections": [{"text": "Hello"}]},
         }
 
         document = graph_site_page_to_document(graph_page)
 
-        assert document["Id"] == "page-1"
-        assert document["CanvasContent1"] == "Welcome"
+        assert document["Id"] == "4"
+        assert document["graph_page_id"] == "page-1"
+        assert "sections" in document["CanvasContent1"]
         assert document["Modified"] == "2024-01-02T00:00:00Z"
 
     @pytest.mark.asyncio
@@ -2273,7 +2327,7 @@ class TestSharepointOnlineDataSource:
     def site_list_item_attachments(self):
         return [
             {
-                "odata.id": "9",
+                "odata.id": f"{SITE_LIST_ONE_ID}-1-attachment-9",
                 "FileName": "attachment 1.txt",
                 "graph_site_id": "site-1",
                 "graph_list_id": SITE_LIST_ONE_ID,
@@ -2281,7 +2335,7 @@ class TestSharepointOnlineDataSource:
                 "graph_attachment_id": "9",
             },
             {
-                "odata.id": "10",
+                "odata.id": f"{SITE_LIST_ONE_ID}-1-attachment-10",
                 "FileName": "attachment 2.txt",
                 "graph_site_id": "site-1",
                 "graph_list_id": SITE_LIST_ONE_ID,
@@ -2295,9 +2349,11 @@ class TestSharepointOnlineDataSource:
         return [
             {
                 "Id": "4",
-                "odata.id": "11",
+                "graph_page_id": "page-graph-id",
+                "odata.id": "4",
                 "GUID": "thats-not-a-guid",
                 "Modified": self.day_ago,
+                "CanvasContent1": "page content",
             }
         ]
 

--- a/app/connectors_service/tests/sources/test_sharepoint_online.py
+++ b/app/connectors_service/tests/sources/test_sharepoint_online.py
@@ -31,6 +31,7 @@ from connectors.sources.sharepoint.sharepoint_online.client import (
     BadRequestError,
     DriveItemsPage,
     EntraAPIToken,
+    GoneError,
     GraphAPIToken,
     InternalServerError,
     InvalidSharepointTenant,
@@ -1014,7 +1015,7 @@ class TestMicrosoftAPISession:
         patch_sleep,
         patch_cancellable_sleeps,
     ):
-        url = "http://localhost:1234/delta-link"
+        url = "http://localhost:1234/some-resource"
 
         gone_error = ClientResponseError(MagicMock(), MagicMock())
         gone_error.status = 410
@@ -1022,7 +1023,7 @@ class TestMicrosoftAPISession:
 
         mock_responses.get(url, exception=gone_error)
 
-        with pytest.raises(DeltaLinkExpired):
+        with pytest.raises(GoneError):
             async with microsoft_api_session._get(url) as _:
                 pass
 
@@ -1377,6 +1378,19 @@ class TestSharepointOnlineClient:
         assert len(returned_pages) == 1
         assert list(returned_pages[0]) == []
         assert returned_pages[0].delta_link() == next_delta_url
+
+    @pytest.mark.asyncio
+    async def test_drive_items_delta_maps_gone_to_delta_link_expired(
+        self, client, patch_scroll_delta_url
+    ):
+        delta_url = "https://sharepoint.com/stale-delta"
+        patch_scroll_delta_url.side_effect = GoneError()
+
+        with pytest.raises(DeltaLinkExpired) as exc_info:
+            async for _page in client.drive_items_delta(delta_url):
+                pass
+
+        assert delta_url in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_drive_items_recovers_from_expired_delta_link(self, client):


### PR DESCRIPTION
## Relates to https://github.com/elastic/sdh-search/issues/1940

Minimal fix for the customer's current blocker after 8.19.20: full sync fails with Graph drive delta `410 Gone` (~108 docs indexed, then stuck).

### What this PR does

- Map Graph `410 Gone` to `DeltaLinkExpired` (not retried by the generic aiohttp retry loop)
- On expired delta: clear the stored drive delta link in the sync cursor and restart once from `root/delta`
- Yield empty final delta pages when `@odata.deltaLink` is present (so the cursor is updated correctly)
- If recovery still fails: fail the sync with a clear message that includes the drive id

### What this PR deliberately does **not** do

- Does **not** migrate site pages or list attachments from SharePoint REST to Microsoft Graph
- Does **not** change attachment document ids or site page body format
- Does **not** skip drives after a failed recovery (sync fails loudly so missing data is visible)

Historical REST `Unauthorized` on Site Pages / attachments is a tenant permissions / auth-configuration issue for client-secret apps, not covered here. `SharePointHomeCacheList` skip remains from #4306 / #4310.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4306 — skip `SharePointHomeCacheList` (already in 8.19.20)
* https://github.com/elastic/connectors/pull/4310 — 8.19 backport of the above

## Release Note

SharePoint Online connector now recovers from expired drive delta tokens (`410 Gone`) with one restart from `root/delta` per drive, and fails the sync with a clear drive-id message if recovery does not succeed.

## Risk note

If Microsoft Graph returns persistent `410` on a fresh `root/delta` for a specific drive (tenant/Graph-side issue rather than a stale cursor), sync will still fail after the single recovery attempt — by design.