### PR TITLE
buildkite: remove whl/sdist from DRA staged artifacts

### DIFF
--- a/.buildkite/publish/dra/stage_artifacts.sh
+++ b/.buildkite/publish/dra/stage_artifacts.sh
@@ -27,11 +27,7 @@ mkdir -p artifacts/
 buildkite-agent artifact download '.artifacts/*.tar.gz' . --step build_docker_image_amd64
 buildkite-agent artifact download '.artifacts/*.tar.gz' . --step build_docker_image_arm64
 
-# Python packages and dependency CSV — built by build_python_packages step
-buildkite-agent artifact download 'app/connectors_service/dist/*.whl' . --step build_python_packages
-buildkite-agent artifact download 'app/connectors_service/dist/*.tar.gz' . --step build_python_packages
-buildkite-agent artifact download 'libs/connectors_sdk/dist/*.whl' . --step build_python_packages
-buildkite-agent artifact download 'libs/connectors_sdk/dist/*.tar.gz' . --step build_python_packages
+# Dependency CSV — built by build_python_packages step
 buildkite-agent artifact download 'app/connectors_service/dist/dependencies.csv' . --step build_python_packages
 
 cp "elasticsearch_connectors-${VERSION}.zip" "artifacts/${PROJECT_NAME}-${VERSION}${WORKFLOW_SUFFIX}.zip"
@@ -47,21 +43,6 @@ mv ".artifacts/${DOCKER_ARTIFACT_KEY}-${VERSION}-arm64.tar.gz" \
 # Dependency CSV — named with version and workflow suffix for DRA
 cp "app/connectors_service/dist/dependencies.csv" \
    "artifacts/${PROJECT_NAME}-${VERSION}${WORKFLOW_SUFFIX}-dependencies.csv"
-
-# Python packages — add workflow suffix
-for f in app/connectors_service/dist/*.whl app/connectors_service/dist/*.tar.gz \
-          libs/connectors_sdk/dist/*.whl libs/connectors_sdk/dist/*.tar.gz; do
-  [[ -f "$f" ]] || continue
-  filename=$(basename "$f")
-  # whl: name-VERSION-py3-none-any.whl  → suffix inserted before -py3
-  # sdist: name-VERSION.tar.gz          → suffix inserted before .tar.gz
-  if [[ "${filename}" == *"-${VERSION}-"* ]]; then
-    newname="${filename/-${VERSION}-/-${VERSION}${WORKFLOW_SUFFIX}-}"
-  else
-    newname="${filename/-${VERSION}./-${VERSION}${WORKFLOW_SUFFIX}.}"
-  fi
-  cp "$f" "artifacts/${newname}"
-done
 
 chmod -R a+r artifacts/
 chmod -R a+w artifacts/


### PR DESCRIPTION
## Summary

Fixes the daily DRA snapshot build which has been failing since #4344 merged.

`dractl` (used by `dra-prep-buildkite-plugin`) does not have a classifier for `.whl` files and exits with:

```
Error: classifying "elasticsearch_connectors-9.6.0-SNAPSHOT-py3-none-any.whl":
unrecognized artifact "elasticsearch_connectors-9.6.0-SNAPSHOT-py3-none-any.whl":
no classifier for this extension
```

Python wheels and sdists are intermediate build outputs used to assemble the zip and docker image — they are not intended DRA artifacts. The `build_python_packages` step exists solely to produce `dependencies.csv` in an environment with a Python venv (following the same pattern as ems-server, cloud-defend, and endpoint-dev). The wheel downloads are also unnecessary since `make zip` runs before they are downloaded.

**Changes:**
- Remove whl/sdist `buildkite-agent artifact download` lines from `stage_artifacts.sh`
- Remove the loop that copied whl/sdist files into `artifacts/` with a workflow suffix

The `dependencies.csv` download and staging are unchanged and working correctly.

## Impact

This has been breaking every daily `main` DRA snapshot build since #4344 merged on 2026-08-18, causing `unified-release-snapshot` to fail on the Connectors DRA job.