### PR TITLE
Revert "[Connectors Python] Lower default max file download size from 10MiB to 8MiB" (#4137)

### DIFF
--- a/app/connectors_service/config.yml.example
+++ b/app/connectors_service/config.yml.example
@@ -277,7 +277,7 @@
 #
 ##  The maximum size (in bytes) of files that the framework should be willing
 ##    to download and/or process.
-#service.max_file_download_size: 8388608
+#service.max_file_download_size: 10485760
 #
 #
 ##  The interval (in seconds) to run job cleanup task.

--- a/app/connectors_service/connectors/config.py
+++ b/app/connectors_service/connectors/config.py
@@ -36,7 +36,7 @@ DEFAULT_MAX_CONCURRENCY = 5
 DEFAULT_CONCURRENT_DOWNLOADS = 10
 
 # --- File handling defaults ----------------------------------------------------------
-DEFAULT_MAX_FILE_SIZE = 8388608  # 8MiB
+DEFAULT_MAX_FILE_SIZE = 10485760  # 10MiB
 
 
 def load_config(config_file):


### PR DESCRIPTION
Reverts https://github.com/elastic/connectors/pull/4137

## Summary

Restores the default `service.max_file_download_size` from 8MiB (8388608)
back to 10MiB (10485760).

PR #4137 lowered the connectors default to align with a proposed 8MiB
`ingest.attachment.max_field_size` cap for Elasticsearch Serverless
([elastic/dev#3565](https://github.com/elastic/dev/issues/3565)). That
Serverless breaking change was subsequently rejected/backlogged (Aug 12,
2026 discussion on #3565), so the connectors alignment is no longer
justified.

The 8MiB default has not shipped in any released connectors version yet
(`v9.6.0` only); this revert keeps `main` consistent with shipped behavior
and avoids silently dropping files between 8–10 MiB before ingestion.

## Changes

- `app/connectors_service/connectors/config.py`: `DEFAULT_MAX_FILE_SIZE` → 10485760
- `app/connectors_service/config.yml.example`: `service.max_file_download_size` → 10485760

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4137
* https://github.com/elastic/elasticsearch/pull/153221 (docs update from #4137; may need a follow-up revert)

## Release Note

Restored the default maximum file download size (`service.max_file_download_size`) from 8MiB back to 10MiB.