### PR TITLE
change the name to satisfy release-manager container

### DIFF
--- a/.buildkite/publish/dra/stage_artifacts.sh
+++ b/.buildkite/publish/dra/stage_artifacts.sh
@@ -34,11 +34,13 @@ cp "elasticsearch_connectors-${VERSION}.zip" "artifacts/${PROJECT_NAME}-${VERSIO
 
 echo "--- :package: Staging ${WORKFLOW} artifacts"
 
-# Docker tarballs — rename to DRA layout and add workflow suffix
+# Docker tarballs — rename to DRA layout and add workflow suffix. Named after
+# the docker image itself, not "${PROJECT_NAME}", since downstream DRA
+# consumers key off the image name rather than the project/repo name.
 mv ".artifacts/${DOCKER_ARTIFACT_KEY}-${VERSION}-amd64.tar.gz" \
-   "artifacts/${PROJECT_NAME}-${VERSION}${WORKFLOW_SUFFIX}-docker-image-linux-amd64.tar.gz"
+   "artifacts/elastic-connectors-${VERSION}${WORKFLOW_SUFFIX}-docker-image-linux-amd64.tar.gz"
 mv ".artifacts/${DOCKER_ARTIFACT_KEY}-${VERSION}-arm64.tar.gz" \
-   "artifacts/${PROJECT_NAME}-${VERSION}${WORKFLOW_SUFFIX}-docker-image-linux-arm64.tar.gz"
+   "artifacts/elastic-connectors-${VERSION}${WORKFLOW_SUFFIX}-docker-image-linux-arm64.tar.gz"
 
 # Dependency CSV — named to match the DRA convention expected by
 # unified-release's release-manager DSL (dependencies-{VERSION}[-SNAPSHOT].csv).


### PR DESCRIPTION
PR to fix build:
https://buildkite.com/elastic/unified-release-snapshot/builds/8459#01a02212-fa78-4e4a-8fd1-ec753b240188

Follow up to: https://github.com/elastic/connectors/pull/4341

`main` branch fails due to the naming convention. The other active branches (9.5, 9.4, 8.19) did not receive the changes so they are not failing.  We'll need to backport the changes from [PR](https://github.com/elastic/connectors/pull/4341) to the active branches to complete the migration. 

We will also need to include this PR in the backports as well as the other follow ups:
- https://github.com/elastic/connectors/pull/4344
- https://github.com/elastic/connectors/pull/4371
- https://github.com/elastic/connectors/pull/4373

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->
