### PR TITLE
fix: retry bulk SerializationError and stop dropping ConcurrentTasks failures

### DIFF
--- a/app/connectors_service/connectors/es/client.py
+++ b/app/connectors_service/connectors/es/client.py
@@ -268,9 +268,7 @@ class TransientElasticsearchRetrier:
                 if retry >= self._max_retries:
                     raise
             except SerializationError as e:
-                # Retry response deserialize failures (e.g. proxy body
-                # "Client Closed Request"). Request serialize failures will
-                # never succeed and must not burn the retry budget.
+                # Retry response deserialize failures only (not request serialize).
                 if not str(e).startswith("Unable to deserialize"):
                     raise
 

--- a/app/connectors_service/connectors/es/client.py
+++ b/app/connectors_service/connectors/es/client.py
@@ -9,7 +9,11 @@ import time
 from enum import Enum
 
 from connectors_sdk.logger import logger, set_extra_logger
-from elastic_transport import ConnectionTimeout
+from elastic_transport import (
+    ConnectionError as TransportConnectionError,
+    ConnectionTimeout,
+    SerializationError,
+)
 from elastic_transport.client_utils import url_to_node_config
 from elasticsearch import ApiError, AsyncElasticsearch, ConflictError
 from elasticsearch import (
@@ -253,9 +257,14 @@ class TransientElasticsearchRetrier:
             try:
                 result = await func()
                 return result
-            except ConnectionTimeout:
+            except (
+                ConnectionTimeout,
+                TransportConnectionError,
+                SerializationError,
+            ) as e:
                 self._logger.warning(
-                    f"Client method '{func_name}' retry {retry}: connection timeout"
+                    f"Client method '{func_name}' retry {retry}: "
+                    f"{type(e).__name__}: {e}"
                 )
 
                 if retry >= self._max_retries:

--- a/app/connectors_service/connectors/es/client.py
+++ b/app/connectors_service/connectors/es/client.py
@@ -11,6 +11,8 @@ from enum import Enum
 from connectors_sdk.logger import logger, set_extra_logger
 from elastic_transport import (
     ConnectionError as TransportConnectionError,
+)
+from elastic_transport import (
     ConnectionTimeout,
     SerializationError,
 )
@@ -257,11 +259,21 @@ class TransientElasticsearchRetrier:
             try:
                 result = await func()
                 return result
-            except (
-                ConnectionTimeout,
-                TransportConnectionError,
-                SerializationError,
-            ) as e:
+            except (ConnectionTimeout, TransportConnectionError) as e:
+                self._logger.warning(
+                    f"Client method '{func_name}' retry {retry}: "
+                    f"{type(e).__name__}: {e}"
+                )
+
+                if retry >= self._max_retries:
+                    raise
+            except SerializationError as e:
+                # Retry response deserialize failures (e.g. proxy body
+                # "Client Closed Request"). Request serialize failures will
+                # never succeed and must not burn the retry budget.
+                if not str(e).startswith("Unable to deserialize"):
+                    raise
+
                 self._logger.warning(
                     f"Client method '{func_name}' retry {retry}: "
                     f"{type(e).__name__}: {e}"

--- a/app/connectors_service/connectors/es/sink.py
+++ b/app/connectors_service/connectors/es/sink.py
@@ -61,7 +61,6 @@ from connectors.utils import (
     MemQueue,
     aenumerate,
     get_size,
-    retryable,
     sanitize,
 )
 
@@ -174,8 +173,9 @@ class Sink:
         self.chunk_mem_size = chunk_mem_size * 1024 * 1024
         self.bulk_tasks = ConcurrentTasks(max_concurrency=max_concurrency)
         self.error_monitor = error_monitor
-        self.max_retires = max_retries
-        self.retry_interval = retry_interval
+        # Retries are handled by TransientElasticsearchRetrier on the ES client.
+        # These kwargs stay for SyncOrchestrator / elasticsearch.bulk config compatibility.
+        _, _ = max_retries, retry_interval
         self.error = None
         self._logger = logger_ or logger
         self._canceled = False
@@ -211,14 +211,8 @@ class Sink:
 
     @tracer.start_as_current_span("_bulk API call", slow_log=1.0)
     async def _batch_bulk(self, operations, stats):
-        # TODO: make this retry policy work with unified retry strategy
-        @retryable(retries=self.max_retires, interval=self.retry_interval)
-        async def _bulk_api_call():
-            return await self.client.client.bulk(
-                operations=operations, pipeline=self.pipeline["name"]
-            )
-
-        # TODO: treat result to retry errors like in async_streaming_bulk
+        # Retries for transient transport/proxy errors are handled by
+        # TransientElasticsearchRetrier inside bulk_insert.
         task_num = len(self.bulk_tasks)
 
         if self._logger.isEnabledFor(logging.DEBUG):

--- a/app/connectors_service/connectors/es/sink.py
+++ b/app/connectors_service/connectors/es/sink.py
@@ -173,8 +173,7 @@ class Sink:
         self.chunk_mem_size = chunk_mem_size * 1024 * 1024
         self.bulk_tasks = ConcurrentTasks(max_concurrency=max_concurrency)
         self.error_monitor = error_monitor
-        # Retries are handled by TransientElasticsearchRetrier on the ES client.
-        # These kwargs stay for SyncOrchestrator / elasticsearch.bulk config compatibility.
+        # Retries live on TransientElasticsearchRetrier; kwargs kept for call-site compat.
         _, _ = max_retries, retry_interval
         self.error = None
         self._logger = logger_ or logger
@@ -211,8 +210,6 @@ class Sink:
 
     @tracer.start_as_current_span("_bulk API call", slow_log=1.0)
     async def _batch_bulk(self, operations, stats):
-        # Retries for transient transport/proxy errors are handled by
-        # TransientElasticsearchRetrier inside bulk_insert.
         task_num = len(self.bulk_tasks)
 
         if self._logger.isEnabledFor(logging.DEBUG):

--- a/app/connectors_service/connectors/utils.py
+++ b/app/connectors_service/connectors/utils.py
@@ -366,16 +366,24 @@ class ConcurrentTasks:
             await asyncio.gather(*self.tasks, return_exceptions=(not raise_on_error))
         except:
             self.cancel()
+            self._errors.clear()
             raise
 
         if raise_on_error and self._errors:
+            error = self._errors[0]
+            self._errors.clear()
             self.cancel()
-            raise self._errors[0]
+            raise error
+
+        # Drop retained failures so long-lived pools cannot raise stale errors.
+        self._errors.clear()
 
     def raise_any_exception(self):
         if self._errors:
+            error = self._errors[0]
+            self._errors.clear()
             self.cancel()
-            raise self._errors[0]
+            raise error
 
         for task in self.tasks:
             if task.done() and not task.cancelled():

--- a/app/connectors_service/connectors/utils.py
+++ b/app/connectors_service/connectors/utils.py
@@ -311,8 +311,7 @@ class ConcurrentTasks:
     def __init__(self, max_concurrency=5):
         self.tasks = []
         self._sem = NonBlockingBoundedSemaphore(max_concurrency)
-        # Finished tasks are removed in `_callback`; keep their exceptions so
-        # `raise_any_exception` / `join(raise_on_error=True)` still observe them.
+        # Retain failures after finished tasks are removed from self.tasks.
         self._errors = []
 
     def __len__(self):
@@ -375,7 +374,6 @@ class ConcurrentTasks:
             self.cancel()
             raise error
 
-        # Drop retained failures so long-lived pools cannot raise stale errors.
         self._errors.clear()
 
     def raise_any_exception(self):

--- a/app/connectors_service/connectors/utils.py
+++ b/app/connectors_service/connectors/utils.py
@@ -311,6 +311,9 @@ class ConcurrentTasks:
     def __init__(self, max_concurrency=5):
         self.tasks = []
         self._sem = NonBlockingBoundedSemaphore(max_concurrency)
+        # Finished tasks are removed in `_callback`; keep their exceptions so
+        # `raise_any_exception` / `join(raise_on_error=True)` still observe them.
+        self._errors = []
 
     def __len__(self):
         return len(self.tasks)
@@ -323,6 +326,7 @@ class ConcurrentTasks:
                 f"Task {task.get_name()} was cancelled",
             )
         elif task.exception():
+            self._errors.append(task.exception())
             logger.error(
                 f"Exception found for task {task.get_name()}", exc_info=task.exception()
             )
@@ -364,7 +368,15 @@ class ConcurrentTasks:
             self.cancel()
             raise
 
+        if raise_on_error and self._errors:
+            self.cancel()
+            raise self._errors[0]
+
     def raise_any_exception(self):
+        if self._errors:
+            self.cancel()
+            raise self._errors[0]
+
         for task in self.tasks:
             if task.done() and not task.cancelled():
                 if task.exception():

--- a/app/connectors_service/tests/es/test_client.py
+++ b/app/connectors_service/tests/es/test_client.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, Mock
 
 import elasticsearch
 import pytest
+from elastic_transport import SerializationError
 
 from connectors import __version__
 from connectors.es.client import (
@@ -345,6 +346,78 @@ class TestTransientElasticsearchRetrier:
             await retrier.execute_with_retry(_func)
 
         assert e is not None
+        assert patch_sleep.awaited_exactly(self.max_retries)
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_connection_error_with_recovery(self, patch_sleep):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        nr_failed_requests = 2
+        attempt = 0
+
+        async def _func():
+            nonlocal attempt
+            if attempt < nr_failed_requests:
+                attempt += 1
+                raise elasticsearch.ConnectionError("connection reset")
+
+        await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.awaited_exactly(2)
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_connection_error_no_recovery(self, patch_sleep):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        async def _func():
+            raise elasticsearch.ConnectionError("connection reset")
+
+        with pytest.raises(elasticsearch.ConnectionError):
+            await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.awaited_exactly(self.max_retries)
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_serialization_error_with_recovery(
+        self, patch_sleep
+    ):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        nr_failed_requests = 2
+        attempt = 0
+
+        async def _func():
+            nonlocal attempt
+            if attempt < nr_failed_requests:
+                attempt += 1
+                raise SerializationError(
+                    "Unable to deserialize as JSON: b'Client Closed Request'"
+                )
+
+        await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.awaited_exactly(2)
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_serialization_error_no_recovery(self, patch_sleep):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        async def _func():
+            raise SerializationError(
+                "Unable to deserialize as JSON: b'Client Closed Request'"
+            )
+
+        with pytest.raises(SerializationError):
+            await retrier.execute_with_retry(_func)
+
         assert patch_sleep.awaited_exactly(self.max_retries)
 
     @pytest.mark.asyncio

--- a/app/connectors_service/tests/es/test_client.py
+++ b/app/connectors_service/tests/es/test_client.py
@@ -361,11 +361,12 @@ class TestTransientElasticsearchRetrier:
             nonlocal attempt
             if attempt < nr_failed_requests:
                 attempt += 1
-                raise elasticsearch.ConnectionError("connection reset")
+                msg = "connection reset"
+                raise elasticsearch.ConnectionError(msg)
 
         await retrier.execute_with_retry(_func)
 
-        assert patch_sleep.awaited_exactly(2)
+        assert patch_sleep.await_count == 2
 
     @pytest.mark.asyncio
     async def test_execute_with_retry_connection_error_no_recovery(self, patch_sleep):
@@ -374,12 +375,14 @@ class TestTransientElasticsearchRetrier:
         )
 
         async def _func():
-            raise elasticsearch.ConnectionError("connection reset")
+            msg = "connection reset"
+            raise elasticsearch.ConnectionError(msg)
 
         with pytest.raises(elasticsearch.ConnectionError):
             await retrier.execute_with_retry(_func)
 
-        assert patch_sleep.awaited_exactly(self.max_retries)
+        # Final attempt raises without sleeping.
+        assert patch_sleep.await_count == self.max_retries - 1
 
     @pytest.mark.asyncio
     async def test_execute_with_retry_serialization_error_with_recovery(
@@ -396,29 +399,46 @@ class TestTransientElasticsearchRetrier:
             nonlocal attempt
             if attempt < nr_failed_requests:
                 attempt += 1
-                raise SerializationError(
-                    "Unable to deserialize as JSON: b'Client Closed Request'"
-                )
+                msg = "Unable to deserialize as JSON: b'Client Closed Request'"
+                raise SerializationError(msg)
 
         await retrier.execute_with_retry(_func)
 
-        assert patch_sleep.awaited_exactly(2)
+        assert patch_sleep.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_execute_with_retry_serialization_error_no_recovery(self, patch_sleep):
+    async def test_execute_with_retry_serialization_error_no_recovery(
+        self, patch_sleep
+    ):
         retrier = TransientElasticsearchRetrier(
             self.logger_mock, self.max_retries, self.retry_interval
         )
 
         async def _func():
-            raise SerializationError(
-                "Unable to deserialize as JSON: b'Client Closed Request'"
-            )
+            msg = "Unable to deserialize as JSON: b'Client Closed Request'"
+            raise SerializationError(msg)
 
         with pytest.raises(SerializationError):
             await retrier.execute_with_retry(_func)
 
-        assert patch_sleep.awaited_exactly(self.max_retries)
+        assert patch_sleep.await_count == self.max_retries - 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_serialization_error_not_retriable(
+        self, patch_sleep
+    ):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        async def _func():
+            msg = "Unable to serialize to JSON: <object>"
+            raise SerializationError(msg)
+
+        with pytest.raises(SerializationError, match="Unable to serialize"):
+            await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.await_count == 0
 
     @pytest.mark.asyncio
     async def test_execute_with_retry_cancelled_midway(self, patch_sleep):

--- a/app/connectors_service/tests/es/test_client.py
+++ b/app/connectors_service/tests/es/test_client.py
@@ -381,7 +381,6 @@ class TestTransientElasticsearchRetrier:
         with pytest.raises(elasticsearch.ConnectionError):
             await retrier.execute_with_retry(_func)
 
-        # Final attempt raises without sleeping.
         assert patch_sleep.await_count == self.max_retries - 1
 
     @pytest.mark.asyncio

--- a/app/connectors_service/tests/test_preflight_check.py
+++ b/app/connectors_service/tests/test_preflight_check.py
@@ -284,8 +284,7 @@ async def test_index_exist_transient_error(mock_responses):
     mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, repeat=True)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=False)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, repeat=True)
-    # Missing indices trigger create; mock it so ConnectionError is not retried
-    # against a real localhost:9200 for the full TransientElasticsearchRetrier budget.
+    # Mock create so the missing-index path does not hit real ES.
     mock_create_index(mock_responses, CONCRETE_CONNECTORS_INDEX)
     mock_create_index(mock_responses, CONCRETE_JOBS_INDEX)
     preflight = PreflightCheck(config, connectors_version)

--- a/app/connectors_service/tests/test_preflight_check.py
+++ b/app/connectors_service/tests/test_preflight_check.py
@@ -284,6 +284,10 @@ async def test_index_exist_transient_error(mock_responses):
     mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, repeat=True)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=False)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, repeat=True)
+    # Missing indices trigger create; mock it so ConnectionError is not retried
+    # against a real localhost:9200 for the full TransientElasticsearchRetrier budget.
+    mock_create_index(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_create_index(mock_responses, CONCRETE_JOBS_INDEX)
     preflight = PreflightCheck(config, connectors_version)
     result = await preflight.run()
     assert result == (True, False)

--- a/app/connectors_service/tests/test_utils.py
+++ b/app/connectors_service/tests/test_utils.py
@@ -576,8 +576,6 @@ async def test_concurrent_tasks_raise_any_exception():
 
 @pytest.mark.asyncio
 async def test_concurrent_tasks_raise_any_exception_after_callback():
-    """Failed tasks are removed in `_callback`; errors must still propagate."""
-
     async def raise_error():
         msg = "This task had an error"
         raise Exception(msg)
@@ -592,7 +590,6 @@ async def test_concurrent_tasks_raise_any_exception_after_callback():
     with pytest.raises(Exception, match="This task had an error"):
         runner.raise_any_exception()
 
-    # Error is consumed so a later check does not re-raise a stale failure.
     runner.raise_any_exception()
 
 
@@ -633,8 +630,6 @@ async def test_concurrent_tasks_join_raise_on_error():
 
 @pytest.mark.asyncio
 async def test_concurrent_tasks_join_raise_on_error_after_callback():
-    """join(raise_on_error=True) must raise even after the failed task was removed."""
-
     async def raise_error():
         msg = "This task had an error"
         raise Exception(msg)
@@ -649,7 +644,6 @@ async def test_concurrent_tasks_join_raise_on_error_after_callback():
     with pytest.raises(Exception, match="This task had an error"):
         await runner.join(raise_on_error=True)
 
-    # Sticky errors must not survive a completed join.
     runner.raise_any_exception()
 
 

--- a/app/connectors_service/tests/test_utils.py
+++ b/app/connectors_service/tests/test_utils.py
@@ -592,6 +592,9 @@ async def test_concurrent_tasks_raise_any_exception_after_callback():
     with pytest.raises(Exception, match="This task had an error"):
         runner.raise_any_exception()
 
+    # Error is consumed so a later check does not re-raise a stale failure.
+    runner.raise_any_exception()
+
 
 @pytest.mark.asyncio
 async def test_concurrent_tasks_join_raise_on_error():
@@ -645,6 +648,9 @@ async def test_concurrent_tasks_join_raise_on_error_after_callback():
     assert len(runner) == 0
     with pytest.raises(Exception, match="This task had an error"):
         await runner.join(raise_on_error=True)
+
+    # Sticky errors must not survive a completed join.
+    runner.raise_any_exception()
 
 
 class CustomException(Exception):

--- a/app/connectors_service/tests/test_utils.py
+++ b/app/connectors_service/tests/test_utils.py
@@ -575,6 +575,25 @@ async def test_concurrent_tasks_raise_any_exception():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_tasks_raise_any_exception_after_callback():
+    """Failed tasks are removed in `_callback`; errors must still propagate."""
+
+    async def raise_error():
+        msg = "This task had an error"
+        raise Exception(msg)
+
+    runner = ConcurrentTasks()
+    await runner.put(functools.partial(raise_error))
+
+    while len(runner) > 0:
+        await asyncio.sleep(0)
+
+    assert len(runner) == 0
+    with pytest.raises(Exception, match="This task had an error"):
+        runner.raise_any_exception()
+
+
+@pytest.mark.asyncio
 async def test_concurrent_tasks_join_raise_on_error():
     results = []
 
@@ -607,6 +626,25 @@ async def test_concurrent_tasks_join_raise_on_error():
 
     assert len(results) == 1
     assert results[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tasks_join_raise_on_error_after_callback():
+    """join(raise_on_error=True) must raise even after the failed task was removed."""
+
+    async def raise_error():
+        msg = "This task had an error"
+        raise Exception(msg)
+
+    runner = ConcurrentTasks()
+    await runner.put(functools.partial(raise_error))
+
+    while len(runner) > 0:
+        await asyncio.sleep(0)
+
+    assert len(runner) == 0
+    with pytest.raises(Exception, match="This task had an error"):
+        await runner.join(raise_on_error=True)
 
 
 class CustomException(Exception):


### PR DESCRIPTION
## Relates to https://github.com/elastic/sdh-search/issues/1898

Long-running connector syncs under Elasticsearch/proxy pressure could fail on `_bulk` with `SerializationError: Unable to deserialize as JSON: b'Client Closed Request'`. That error was not retried by `TransientElasticsearchRetrier`, and `ConcurrentTasks` could log-and-drop finished bulk failures after `_callback` removed them—leading to data loss or a later sink death that surfaced as idle cleanup (“The job has not seen any update for some time.”).

This is a different failure mode from #4345 / #4311 (refresh-storm / heartbeat). Same SDH customer path, bulk transport layer.

**Changes:**
- Retry `ConnectionError` and response deserialize-side `SerializationError` in `TransientElasticsearchRetrier` (not request-serialize failures)
- Retain ConcurrentTasks failures across `_callback` removal, then consume them on `raise_any_exception` / `join` so they are neither lost nor sticky
- Remove unused Sink `_bulk_api_call` / `@retryable` stub (live path is `bulk_insert`)
- Mock index create in `test_index_exist_transient_error` so ConnectionError retries do not hammer localhost

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* Prior long-sync idle fix: https://github.com/elastic/connectors/pull/4345
* Customer report: https://github.com/elastic/sdh-search/issues/1898#issuecomment-5395874812

## Release Note

Long-running connector syncs no longer fail permanently on transient non-JSON Elasticsearch/proxy bulk responses (for example `Client Closed Request`). Failed concurrent bulk tasks are also no longer silently dropped.