### PR TITLE
[8.19] fix: retry bulk SerializationError and stop dropping ConcurrentTasks failures (#4384)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -3591,7 +3591,7 @@ Apache-2.0
 
 
 elasticsearch-connectors
-8.19.20
+8.19.21
 Apache Software License
 Elastic License 2.0
 
@@ -3689,7 +3689,7 @@ these terms.
 
 
 elasticsearch-connectors
-8.19.20
+8.19.21
 Apache Software License
 Elastic License 2.0
 
@@ -4283,7 +4283,7 @@ Apache Software License
 
 
 google-auth
-2.56.3
+2.57.0
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004

--- a/connectors/es/client.py
+++ b/connectors/es/client.py
@@ -8,7 +8,13 @@ import logging
 import time
 from enum import Enum
 
-from elastic_transport import ConnectionTimeout
+from elastic_transport import (
+    ConnectionError as TransportConnectionError,
+)
+from elastic_transport import (
+    ConnectionTimeout,
+    SerializationError,
+)
 from elastic_transport.client_utils import url_to_node_config
 from elasticsearch import ApiError, AsyncElasticsearch, ConflictError
 from elasticsearch import (
@@ -252,11 +258,23 @@ class TransientElasticsearchRetrier:
             retry += 1
             try:
                 result = await func()
-
                 return result
-            except ConnectionTimeout:
+            except (ConnectionTimeout, TransportConnectionError) as e:
                 self._logger.warning(
-                    f"Client method '{func_name}' retry {retry}: connection timeout"
+                    f"Client method '{func_name}' retry {retry}: "
+                    f"{type(e).__name__}: {e}"
+                )
+
+                if retry >= self._max_retries:
+                    raise
+            except SerializationError as e:
+                # Retry response deserialize failures only (not request serialize).
+                if not str(e).startswith("Unable to deserialize"):
+                    raise
+
+                self._logger.warning(
+                    f"Client method '{func_name}' retry {retry}: "
+                    f"{type(e).__name__}: {e}"
                 )
 
                 if retry >= self._max_retries:

--- a/connectors/es/sink.py
+++ b/connectors/es/sink.py
@@ -54,7 +54,6 @@ from connectors.utils import (
     aenumerate,
     get_size,
     iso_utc,
-    retryable,
     sanitize,
 )
 
@@ -149,8 +148,8 @@ class Sink:
         self.pipeline = pipeline
         self.chunk_mem_size = chunk_mem_size * 1024 * 1024
         self.bulk_tasks = ConcurrentTasks(max_concurrency=max_concurrency)
-        self.max_retires = max_retries
-        self.retry_interval = retry_interval
+        # Retries live on TransientElasticsearchRetrier; kwargs kept for call-site compat.
+        _, _ = max_retries, retry_interval
         self.error = None
         self._logger = logger_ or logger
         self._canceled = False
@@ -175,14 +174,6 @@ class Sink:
 
     @tracer.start_as_current_span("_bulk API call", slow_log=1.0)
     async def _batch_bulk(self, operations, stats):
-        # TODO: make this retry policy work with unified retry strategy
-        @retryable(retries=self.max_retires, interval=self.retry_interval)
-        async def _bulk_api_call():
-            return await self.client.client.bulk(
-                operations=operations, pipeline=self.pipeline["name"]
-            )
-
-        # TODO: treat result to retry errors like in async_streaming_bulk
         task_num = len(self.bulk_tasks)
 
         if self._logger.isEnabledFor(logging.DEBUG):

--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -439,6 +439,8 @@ class ConcurrentTasks:
     def __init__(self, max_concurrency=5):
         self.tasks = []
         self._sem = NonBlockingBoundedSemaphore(max_concurrency)
+        # Retain failures after finished tasks are removed from self.tasks.
+        self._errors = []
 
     def __len__(self):
         return len(self.tasks)
@@ -451,6 +453,7 @@ class ConcurrentTasks:
                 f"Task {task.get_name()} was cancelled",
             )
         elif task.exception():
+            self._errors.append(task.exception())
             logger.error(
                 f"Exception found for task {task.get_name()}", exc_info=task.exception()
             )
@@ -490,9 +493,24 @@ class ConcurrentTasks:
             await asyncio.gather(*self.tasks, return_exceptions=(not raise_on_error))
         except:
             self.cancel()
+            self._errors.clear()
             raise
 
+        if raise_on_error and self._errors:
+            error = self._errors[0]
+            self._errors.clear()
+            self.cancel()
+            raise error
+
+        self._errors.clear()
+
     def raise_any_exception(self):
+        if self._errors:
+            error = self._errors[0]
+            self._errors.clear()
+            self.cancel()
+            raise error
+
         for task in self.tasks:
             if task.done() and not task.cancelled():
                 if task.exception():

--- a/tests/es/test_client.py
+++ b/tests/es/test_client.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, Mock
 
 import elasticsearch
 import pytest
+from elastic_transport import SerializationError
 
 from connectors import __version__
 from connectors.es.client import (
@@ -346,6 +347,97 @@ class TestTransientElasticsearchRetrier:
 
         assert e is not None
         assert patch_sleep.awaited_exactly(self.max_retries)
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_connection_error_with_recovery(self, patch_sleep):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        nr_failed_requests = 2
+        attempt = 0
+
+        async def _func():
+            nonlocal attempt
+            if attempt < nr_failed_requests:
+                attempt += 1
+                msg = "connection reset"
+                raise elasticsearch.ConnectionError(msg)
+
+        await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_connection_error_no_recovery(self, patch_sleep):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        async def _func():
+            msg = "connection reset"
+            raise elasticsearch.ConnectionError(msg)
+
+        with pytest.raises(elasticsearch.ConnectionError):
+            await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.await_count == self.max_retries - 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_serialization_error_with_recovery(
+        self, patch_sleep
+    ):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        nr_failed_requests = 2
+        attempt = 0
+
+        async def _func():
+            nonlocal attempt
+            if attempt < nr_failed_requests:
+                attempt += 1
+                msg = "Unable to deserialize as JSON: b'Client Closed Request'"
+                raise SerializationError(msg)
+
+        await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_serialization_error_no_recovery(
+        self, patch_sleep
+    ):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        async def _func():
+            msg = "Unable to deserialize as JSON: b'Client Closed Request'"
+            raise SerializationError(msg)
+
+        with pytest.raises(SerializationError):
+            await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.await_count == self.max_retries - 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_retry_serialization_error_not_retriable(
+        self, patch_sleep
+    ):
+        retrier = TransientElasticsearchRetrier(
+            self.logger_mock, self.max_retries, self.retry_interval
+        )
+
+        async def _func():
+            msg = "Unable to serialize to JSON: <object>"
+            raise SerializationError(msg)
+
+        with pytest.raises(SerializationError, match="Unable to serialize"):
+            await retrier.execute_with_retry(_func)
+
+        assert patch_sleep.await_count == 0
 
     @pytest.mark.asyncio
     async def test_execute_with_retry_cancelled_midway(self, patch_sleep):

--- a/tests/test_preflight_check.py
+++ b/tests/test_preflight_check.py
@@ -266,6 +266,9 @@ async def test_index_exist_transient_error(mock_responses):
     mock_index_exists(mock_responses, CONCRETE_CONNECTORS_INDEX, repeat=True)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, exist=False)
     mock_index_exists(mock_responses, CONCRETE_JOBS_INDEX, repeat=True)
+    # Mock create so the missing-index path does not hit real ES.
+    mock_create_index(mock_responses, CONCRETE_CONNECTORS_INDEX)
+    mock_create_index(mock_responses, CONCRETE_JOBS_INDEX)
     preflight = PreflightCheck(config, connectors_version)
     result = await preflight.run()
     assert result == (True, False)

--- a/tests/test_sink.py
+++ b/tests/test_sink.py
@@ -223,10 +223,17 @@ async def test_prepare_content_index(mock_responses):
     es = SyncOrchestrator(config)
     es._sink = Mock()
     es._extractor = Mock()
-    with mock.patch.object(
-        es.es_management_client,
-        "ensure_content_index_mappings",
-    ) as put_mapping_mock:
+    with (
+        mock.patch.object(
+            es.es_management_client,
+            "ensure_content_index_settings",
+            new_callable=AsyncMock,
+        ),
+        mock.patch.object(
+            es.es_management_client,
+            "ensure_content_index_mappings",
+        ) as put_mapping_mock,
+    ):
         await es.prepare_content_index(index_name, language_code)
 
         await es.close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -621,6 +621,25 @@ async def test_concurrent_tasks_raise_any_exception():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_tasks_raise_any_exception_after_callback():
+    async def raise_error():
+        msg = "This task had an error"
+        raise Exception(msg)
+
+    runner = ConcurrentTasks()
+    await runner.put(functools.partial(raise_error))
+
+    while len(runner) > 0:
+        await asyncio.sleep(0)
+
+    assert len(runner) == 0
+    with pytest.raises(Exception, match="This task had an error"):
+        runner.raise_any_exception()
+
+    runner.raise_any_exception()
+
+
+@pytest.mark.asyncio
 async def test_concurrent_tasks_join_raise_on_error():
     results = []
 
@@ -653,6 +672,25 @@ async def test_concurrent_tasks_join_raise_on_error():
 
     assert len(results) == 1
     assert results[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_tasks_join_raise_on_error_after_callback():
+    async def raise_error():
+        msg = "This task had an error"
+        raise Exception(msg)
+
+    runner = ConcurrentTasks()
+    await runner.put(functools.partial(raise_error))
+
+    while len(runner) > 0:
+        await asyncio.sleep(0)
+
+    assert len(runner) == 0
+    with pytest.raises(Exception, match="This task had an error"):
+        await runner.join(raise_on_error=True)
+
+    runner.raise_any_exception()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix: retry bulk SerializationError and stop dropping ConcurrentTasks failures (#4384)