### PR TITLE
fix: honor ssl.verification_mode from Elastic Agent output config (#4084)

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -6926,7 +6926,7 @@ THE SOFTWARE.
 
 
 pyspnego
-0.12.1
+0.12.2
 MIT
 MIT License
 

--- a/app/connectors_service/connectors/agent/config.py
+++ b/app/connectors_service/connectors/agent/config.py
@@ -95,6 +95,9 @@ class ConnectorsAgentConfigurationWrapper:
                 msg = "Invalid Elasticsearch credentials"
                 raise ValueError(msg)
 
+            # SSL-related
+            es_creds.update(self._extract_ssl_config(source))
+
             assumed_configuration["elasticsearch"] = es_creds
 
         if self.config_changed(assumed_configuration):
@@ -109,6 +112,34 @@ class ConnectorsAgentConfigurationWrapper:
 
         logger.debug("No changes detected for connectors-relevant configurations")
         return False
+
+    def _extract_ssl_config(self, source):
+        """Translate Elastic Agent output `ssl` settings into Connectors Service config.
+
+        Elastic Agent reports the Elasticsearch output SSL options (e.g.
+        `ssl.verification_mode`) on the output unit. Connectors Service uses
+        `verify_certs` to decide whether to validate the server certificate, so
+        without this translation the agent-provided SSL settings are silently
+        ignored and certificate verification is always enforced.
+        """
+        if not source.fields.get("ssl"):
+            return {}
+
+        ssl_source = source["ssl"]
+        ssl_config = {}
+
+        # Elastic Agent supports "full", "strict", "certificate" and "none".
+        # Only "none" disables server certificate verification.
+        verification_mode = ssl_source.get("verification_mode")
+        if verification_mode is not None:
+            verify_certs = verification_mode != "none"
+            logger.debug(
+                f"Found ssl.verification_mode '{verification_mode}', "
+                f"setting verify_certs to {verify_certs}"
+            )
+            ssl_config["verify_certs"] = verify_certs
+
+        return ssl_config
 
     def config_changed(self, new_config):
         """See if configuration passed in new_config will update currently stored configuration

--- a/app/connectors_service/connectors/agent/config.py
+++ b/app/connectors_service/connectors/agent/config.py
@@ -95,7 +95,6 @@ class ConnectorsAgentConfigurationWrapper:
                 msg = "Invalid Elasticsearch credentials"
                 raise ValueError(msg)
 
-            # SSL-related
             es_creds.update(self._extract_ssl_config(source))
 
             assumed_configuration["elasticsearch"] = es_creds
@@ -114,25 +113,13 @@ class ConnectorsAgentConfigurationWrapper:
         return False
 
     def _extract_ssl_config(self, source):
-        """Translate Elastic Agent output `ssl` settings into Connectors Service config.
-
-        Elastic Agent reports the Elasticsearch output SSL options (e.g.
-        `ssl.verification_mode`) on the output unit. Connectors Service uses
-        `verify_certs` to decide whether to validate the server certificate, so
-        without this translation the agent-provided SSL settings are silently
-        ignored and certificate verification is always enforced.
-        """
         if not source.fields.get("ssl"):
             return {}
 
         ssl_source = source["ssl"]
-        # ESClient only applies verify_certs when ssl is enabled in config.
-        # get_specific_config() does not merge defaults, so ssl must be set here
-        # for agent-reported SSL settings to take effect on the first ES call.
+        # ESClient ignores verify_certs unless ssl is enabled.
         ssl_config = {"ssl": True}
 
-        # Elastic Agent supports "full", "strict", "certificate" and "none".
-        # Only "none" disables server certificate verification.
         verification_mode = ssl_source.get("verification_mode")
         if verification_mode is not None:
             verify_certs = verification_mode != "none"

--- a/app/connectors_service/connectors/agent/config.py
+++ b/app/connectors_service/connectors/agent/config.py
@@ -126,7 +126,10 @@ class ConnectorsAgentConfigurationWrapper:
             return {}
 
         ssl_source = source["ssl"]
-        ssl_config = {}
+        # ESClient only applies verify_certs when ssl is enabled in config.
+        # get_specific_config() does not merge defaults, so ssl must be set here
+        # for agent-reported SSL settings to take effect on the first ES call.
+        ssl_config = {"ssl": True}
 
         # Elastic Agent supports "full", "strict", "certificate" and "none".
         # Only "none" disables server certificate verification.

--- a/app/connectors_service/tests/agent/test_agent_config.py
+++ b/app/connectors_service/tests/agent/test_agent_config.py
@@ -114,6 +114,76 @@ def test_try_update_with_basic_auth_auth_data():
     assert config_wrapper.get()["elasticsearch"]["password"] == password
 
 
+def test_try_update_with_ssl_verification_mode_none_disables_verify_certs():
+    hosts = ["https://localhost:9200"]
+    api_key = "lemme_in"
+
+    config_wrapper = prepare_config_wrapper()
+    unit_mock = prepare_unit_mock(
+        {
+            "hosts": hosts,
+            "api_key": api_key,
+            "ssl": {"verification_mode": "none"},
+        },
+        None,
+    )
+
+    assert (
+        config_wrapper.try_update(
+            connector_id=CONNECTOR_ID,
+            service_type=SERVICE_TYPE,
+            output_unit=unit_mock,
+        )
+        is True
+    )
+    assert config_wrapper.get()["elasticsearch"]["verify_certs"] is False
+
+
+def test_try_update_with_ssl_verification_mode_full_enables_verify_certs():
+    hosts = ["https://localhost:9200"]
+    api_key = "lemme_in"
+
+    config_wrapper = prepare_config_wrapper()
+    unit_mock = prepare_unit_mock(
+        {
+            "hosts": hosts,
+            "api_key": api_key,
+            "ssl": {"verification_mode": "full"},
+        },
+        None,
+    )
+
+    assert (
+        config_wrapper.try_update(
+            connector_id=CONNECTOR_ID,
+            service_type=SERVICE_TYPE,
+            output_unit=unit_mock,
+        )
+        is True
+    )
+    assert config_wrapper.get()["elasticsearch"]["verify_certs"] is True
+
+
+def test_try_update_without_ssl_config_keeps_default_verify_certs():
+    hosts = ["https://localhost:9200"]
+    api_key = "lemme_in"
+
+    config_wrapper = prepare_config_wrapper()
+    unit_mock = prepare_unit_mock({"hosts": hosts, "api_key": api_key}, None)
+
+    assert (
+        config_wrapper.try_update(
+            connector_id=CONNECTOR_ID,
+            service_type=SERVICE_TYPE,
+            output_unit=unit_mock,
+        )
+        is True
+    )
+    # verify_certs is not overridden, so the Connectors Service default applies
+    assert "verify_certs" not in config_wrapper.get_specific_config()["elasticsearch"]
+    assert config_wrapper.get()["elasticsearch"]["verify_certs"] is True
+
+
 def test_try_update_multiple_times_does_not_reset_config_values():
     hosts = ["https://localhost:9200"]
     api_key = "lemme_in"

--- a/app/connectors_service/tests/agent/test_agent_config.py
+++ b/app/connectors_service/tests/agent/test_agent_config.py
@@ -3,9 +3,13 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import warnings
 from unittest.mock import MagicMock, Mock
 
+from elastic_transport import SecurityWarning
+
 from connectors.agent.config import ConnectorsAgentConfigurationWrapper
+from connectors.es.client import ESClient
 
 CONNECTOR_ID = "test-connector"
 SERVICE_TYPE = "test-service-type"
@@ -136,7 +140,39 @@ def test_try_update_with_ssl_verification_mode_none_disables_verify_certs():
         )
         is True
     )
+    es_config = config_wrapper.get_specific_config()["elasticsearch"]
+    assert es_config["ssl"] is True
+    assert es_config["verify_certs"] is False
     assert config_wrapper.get()["elasticsearch"]["verify_certs"] is False
+
+
+def test_ssl_config_from_agent_applies_to_es_client_without_defaults():
+    hosts = ["https://localhost:9200"]
+    api_key = "lemme_in"
+
+    config_wrapper = prepare_config_wrapper()
+    unit_mock = prepare_unit_mock(
+        {
+            "hosts": hosts,
+            "api_key": api_key,
+            "ssl": {"verification_mode": "none"},
+        },
+        None,
+    )
+
+    config_wrapper.try_update(
+        connector_id=CONNECTOR_ID,
+        service_type=SERVICE_TYPE,
+        output_unit=unit_mock,
+    )
+
+    # ConnectorRecordManager uses get_specific_config(), not get().
+    es_config = config_wrapper.get_specific_config()["elasticsearch"]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=SecurityWarning)
+        client = ESClient(es_config)
+    node = list(client.client.transport.node_pool.all())[0]
+    assert node.config.verify_certs is False
 
 
 def test_try_update_with_ssl_verification_mode_full_enables_verify_certs():
@@ -161,6 +197,9 @@ def test_try_update_with_ssl_verification_mode_full_enables_verify_certs():
         )
         is True
     )
+    es_config = config_wrapper.get_specific_config()["elasticsearch"]
+    assert es_config["ssl"] is True
+    assert es_config["verify_certs"] is True
     assert config_wrapper.get()["elasticsearch"]["verify_certs"] is True
 
 
@@ -180,7 +219,9 @@ def test_try_update_without_ssl_config_keeps_default_verify_certs():
         is True
     )
     # verify_certs is not overridden, so the Connectors Service default applies
-    assert "verify_certs" not in config_wrapper.get_specific_config()["elasticsearch"]
+    es_config = config_wrapper.get_specific_config()["elasticsearch"]
+    assert "ssl" not in es_config
+    assert "verify_certs" not in es_config
     assert config_wrapper.get()["elasticsearch"]["verify_certs"] is True
 
 

--- a/app/connectors_service/tests/agent/test_agent_config.py
+++ b/app/connectors_service/tests/agent/test_agent_config.py
@@ -166,7 +166,6 @@ def test_ssl_config_from_agent_applies_to_es_client_without_defaults():
         output_unit=unit_mock,
     )
 
-    # ConnectorRecordManager uses get_specific_config(), not get().
     es_config = config_wrapper.get_specific_config()["elasticsearch"]
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=SecurityWarning)
@@ -218,7 +217,6 @@ def test_try_update_without_ssl_config_keeps_default_verify_certs():
         )
         is True
     )
-    # verify_certs is not overridden, so the Connectors Service default applies
     es_config = config_wrapper.get_specific_config()["elasticsearch"]
     assert "ssl" not in es_config
     assert "verify_certs" not in es_config


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/4084


When running connectors under Elastic Agent, the Elasticsearch output `ssl.verification_mode` setting from the agent policy was ignored. Connectors always verified TLS certificates, which breaks dev environments that rely on `ssl.verification_mode: none` for self-signed certificates.

This change parses the agent output `ssl` block and maps `verification_mode` to Connectors Service settings. It also sets `ssl: true` alongside `verify_certs`, which is required because `ESClient` only applies certificate verification settings when SSL is enabled. That matters on the first agent check-in, where `ConnectorRecordManager` uses `get_specific_config()` (without merged defaults) to talk to Elasticsearch.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* None

## Release Note

When running under Elastic Agent, connectors now honor the Elasticsearch output `ssl.verification_mode` policy setting instead of always enforcing certificate verification.