### PR TITLE
[8.19] fix: honor ssl.verification_mode from Elastic Agent output config (#4391)

### DIFF
--- a/connectors/agent/config.py
+++ b/connectors/agent/config.py
@@ -107,6 +107,8 @@ class ConnectorsAgentConfigurationWrapper:
                 msg = "Invalid Elasticsearch credentials"
                 raise ValueError(msg)
 
+            es_creds.update(self._extract_ssl_config(source))
+
             assumed_configuration["elasticsearch"] = es_creds
 
         if self.config_changed(assumed_configuration):
@@ -121,6 +123,25 @@ class ConnectorsAgentConfigurationWrapper:
 
         logger.debug("No changes detected for connectors-relevant configurations")
         return False
+
+    def _extract_ssl_config(self, source):
+        if not source.fields.get("ssl"):
+            return {}
+
+        ssl_source = source["ssl"]
+        # ESClient ignores verify_certs unless ssl is enabled.
+        ssl_config = {"ssl": True}
+
+        verification_mode = ssl_source.get("verification_mode")
+        if verification_mode is not None:
+            verify_certs = verification_mode != "none"
+            logger.debug(
+                f"Found ssl.verification_mode '{verification_mode}', "
+                f"setting verify_certs to {verify_certs}"
+            )
+            ssl_config["verify_certs"] = verify_certs
+
+        return ssl_config
 
     def config_changed(self, new_config):
         """See if configuration passed in new_config will update currently stored configuration

--- a/tests/agent/test_agent_config.py
+++ b/tests/agent/test_agent_config.py
@@ -3,9 +3,13 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import warnings
 from unittest.mock import MagicMock, Mock
 
+from elastic_transport import SecurityWarning
+
 from connectors.agent.config import ConnectorsAgentConfigurationWrapper
+from connectors.es.client import ESClient
 
 
 def prepare_unit_mock(fields, log_level):
@@ -69,6 +73,86 @@ def test_try_update_with_basic_auth_auth_data():
     assert config_wrapper.get()["elasticsearch"]["host"] == hosts[0]
     assert config_wrapper.get()["elasticsearch"]["username"] == username
     assert config_wrapper.get()["elasticsearch"]["password"] == password
+
+
+def test_try_update_with_ssl_verification_mode_none_disables_verify_certs():
+    hosts = ["https://localhost:9200"]
+    api_key = "lemme_in"
+
+    config_wrapper = ConnectorsAgentConfigurationWrapper()
+    unit_mock = prepare_unit_mock(
+        {
+            "hosts": hosts,
+            "api_key": api_key,
+            "ssl": {"verification_mode": "none"},
+        },
+        None,
+    )
+
+    assert config_wrapper.try_update(unit_mock) is True
+    es_config = config_wrapper.specific_config["elasticsearch"]
+    assert es_config["ssl"] is True
+    assert es_config["verify_certs"] is False
+    assert config_wrapper.get()["elasticsearch"]["verify_certs"] is False
+
+
+def test_ssl_config_from_agent_applies_to_es_client_without_defaults():
+    hosts = ["https://localhost:9200"]
+    api_key = "lemme_in"
+
+    config_wrapper = ConnectorsAgentConfigurationWrapper()
+    unit_mock = prepare_unit_mock(
+        {
+            "hosts": hosts,
+            "api_key": api_key,
+            "ssl": {"verification_mode": "none"},
+        },
+        None,
+    )
+
+    config_wrapper.try_update(unit_mock)
+
+    es_config = config_wrapper.specific_config["elasticsearch"]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=SecurityWarning)
+        client = ESClient(es_config)
+    node = list(client.client.transport.node_pool.all())[0]
+    assert node.config.verify_certs is False
+
+
+def test_try_update_with_ssl_verification_mode_full_enables_verify_certs():
+    hosts = ["https://localhost:9200"]
+    api_key = "lemme_in"
+
+    config_wrapper = ConnectorsAgentConfigurationWrapper()
+    unit_mock = prepare_unit_mock(
+        {
+            "hosts": hosts,
+            "api_key": api_key,
+            "ssl": {"verification_mode": "full"},
+        },
+        None,
+    )
+
+    assert config_wrapper.try_update(unit_mock) is True
+    es_config = config_wrapper.specific_config["elasticsearch"]
+    assert es_config["ssl"] is True
+    assert es_config["verify_certs"] is True
+    assert config_wrapper.get()["elasticsearch"]["verify_certs"] is True
+
+
+def test_try_update_without_ssl_config_keeps_default_verify_certs():
+    hosts = ["https://localhost:9200"]
+    api_key = "lemme_in"
+
+    config_wrapper = ConnectorsAgentConfigurationWrapper()
+    unit_mock = prepare_unit_mock({"hosts": hosts, "api_key": api_key}, None)
+
+    assert config_wrapper.try_update(unit_mock) is True
+    es_config = config_wrapper.specific_config["elasticsearch"]
+    assert "ssl" not in es_config
+    assert "verify_certs" not in es_config
+    assert config_wrapper.get()["elasticsearch"]["verify_certs"] is True
 
 
 def test_try_update_multiple_times_does_not_reset_config_values():


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix: honor ssl.verification_mode from Elastic Agent output config (#4391)