### PR TITLE
buildkite: inline init_python in build-python-packages.sh for 8.19

### DIFF
--- a/.buildkite/publish/build-python-packages.sh
+++ b/.buildkite/publish/build-python-packages.sh
@@ -3,10 +3,11 @@
 # Outputs are uploaded as Buildkite artifacts by the pipeline step.
 set -euo pipefail
 
-source .buildkite/shared.sh
-
 PYTHON_VERSION="${DRA_PYTHON_VERSION:?DRA_PYTHON_VERSION is required}"
-init_python
+source ~/.bash_profile
+pyenv global "$PYTHON_VERSION"
+echo "Python version:"
+pyenv global
 
 echo "--- :page_facing_up: Generating dependency CSV"
 make install deps-csv


### PR DESCRIPTION
The backport of #4390 ("migrate DRA publish to dractl") introduced a `build-python-packages.sh` that sources `.buildkite/shared.sh`, but `shared.sh` only exists on `main` — it was added in early 2025 and never backported to 8.19.

This has been breaking the 8.19 DRA build since Aug 27, causing the `Build Python packages` step to fail with:

```
.buildkite/publish/build-python-packages.sh: line 6: .buildkite/shared.sh: No such file or directory
```

Because `Publish DRA Items` is gated on that step, connectors never publishes its DRA artifacts, so `unified-release-snapshot` can't find the expected container images in `docker.elastic.co/dra-snapshot`.

## Fix

The script only uses `init_python` from `shared.sh`, which is two lines (`source ~/.bash_profile` + `pyenv global $PYTHON_VERSION`). Inline them directly and drop the `shared.sh` dependency.

Assisted-by: Claude (claude-sonnet-4-6)