### PR TITLE
buildkite: add missing DRA_PYTHON_VERSION env var to 8.19 pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,7 @@ definitions:
 
 env:
   DOCKERFILE_FTEST_PATH: "Dockerfile.ftest.wolfi"
+  DRA_PYTHON_VERSION: "3.11"
 
 steps:
   - label: ":face_with_peeking_eye: Lint"


### PR DESCRIPTION
Follow-up to #4401.

The backport of "migrate DRA publish to dractl" (#4390) added a step that references `DRA_PYTHON_VERSION` but didn't include the global env definition present on `main` (`DRA_PYTHON_VERSION: "3.11"`). Without it, `build-python-packages.sh` exits immediately with:

```
.buildkite/publish/build-python-packages.sh: line 6: DRA_PYTHON_VERSION: DRA_PYTHON_VERSION is required
```

One-line fix: add `DRA_PYTHON_VERSION: "3.11"` to the global `env:` block in `pipeline.yml`, matching what `main` has at line 44.

Assisted-by: Claude (claude-sonnet-4-6)