### PR TITLE
buildkite: use connectors agent for DRA Prep step on 8.19

### DIFF
--- a/.buildkite/publish/dra/stage_artifacts.sh
+++ b/.buildkite/publish/dra/stage_artifacts.sh
@@ -15,6 +15,11 @@ elif [[ "${WORKFLOW}" != "staging" ]]; then
   exit 1
 fi
 
+# core-ubuntu-2204 has Python 3.10 without python3-venv; use pyenv from the
+# connectors agent image so make sdist can create the .venv prerequisite
+source ~/.bash_profile
+pyenv global "${DRA_PYTHON_VERSION:?DRA_PYTHON_VERSION is required}"
+
 echo "--- :package: Building sdist artifact"
 # Run before downloading Python artifacts — make clean deletes dist/
 make clean sdist

--- a/.buildkite/publish/dra/upload-dra-pipeline.sh
+++ b/.buildkite/publish/dra/upload-dra-pipeline.sh
@@ -18,7 +18,7 @@ emit_dra_pair() {
       PROJECT_ROOT: "."
     agents:
       provider: "gcp"
-      image: family/core-ubuntu-2204
+      image: family/enterprise-search-ubuntu-2204-connectors-py
       machineType: "n1-standard-4"
     plugins:
       - elastic/dra-prep#v0.1.5:


### PR DESCRIPTION
The `DRA Prep (snapshot/staging)` step in the backported DRA pipeline runs `make clean sdist` to build the source distribution artifact. `make sdist` depends on `.venv/bin/python` — it calls `python3 -m venv .venv` as a Make prerequisite. The `core-ubuntu-2204` agent has Python 3.10 but without the `python3.10-venv` package, so venv creation fails immediately:

```
python3 -m venv .venv
The virtual environment was not created successfully because ensurepip is not available.
[...]
apt install python3.10-venv
```

The `enterprise-search-ubuntu-2204-connectors-py` agent already has pyenv with Python 3.11 and full venv support — it's the same agent used by the `build_python_packages` step in this pipeline. We also activate pyenv in `stage_artifacts.sh` so the `python3` command used by `make sdist` resolves to the pyenv-managed Python rather than the system one.

Part of the follow-up from the incomplete backport in #4390: previous fixes in #4401 and #4402 unblocked earlier failures in the pipeline chain; this unblocks the DRA Prep step itself.

See build 24739 for the failure: https://buildkite.com/elastic/connectors/builds/24739

Assisted-by: Claude Code (claude-sonnet-4-6)