### PR TITLE
fix: decorate OneDrive advanced-rule docs with DLS access control

### DIFF
--- a/app/connectors_service/connectors/sources/onedrive/datasource.py
+++ b/app/connectors_service/connectors/sources/onedrive/datasource.py
@@ -426,6 +426,10 @@ class OneDriveDataSource(BaseDataSource):
                     async for entity, download_url in self.client.get_owned_files(
                         user_id, skipped_extensions, pattern
                     ):
+                        if self._dls_enabled():
+                            entity = await self._decorate_with_access_control(
+                                entity, user_id
+                            )
                         yield self.send_document_to_es(entity, download_url)
         else:
             requests = []

--- a/app/connectors_service/tests/sources/test_onedrive.py
+++ b/app/connectors_service/tests/sources/test_onedrive.py
@@ -1221,6 +1221,74 @@ async def test_get_docs_with_advanced_rules(filtering):
         assert documents == expected_responses
 
 
+@pytest.mark.parametrize(
+    "filtering",
+    [
+        Filter(
+            {
+                ADVANCED_SNIPPET: {
+                    "value": [
+                        {
+                            "owners": ["AdeleV@w076v.onmicrosoft.com"],
+                            "skipFilesWithExtensions": [".py"],
+                        },
+                        {
+                            "owners": ["AlexW@w076v.onmicrosoft.com"],
+                            "parentPathPattern": "/drive/root:/hello/*",
+                        },
+                    ],
+                }
+            }
+        ),
+    ],
+)
+@patch.object(
+    OneDriveClient,
+    "list_file_permission",
+    side_effect=[
+        (AsyncIterator([RESPONSE_PERMISSION1])),
+        (AsyncIterator([RESPONSE_PERMISSION2])),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_docs_with_advanced_rules_and_dls_enabled(
+    permissions_patch, filtering
+):
+    async with create_onedrive_source() as source:
+        source._dls_enabled = MagicMock(return_value=True)
+
+        with patch.object(AccessToken, "get", return_value="abc"):
+            with patch.object(
+                OneDriveClient,
+                "list_users",
+                return_value=AsyncIterator(EXPECTED_USERS),
+            ):
+                async_response_user1 = AsyncMock()
+                async_response_user1.__aenter__ = AsyncMock(
+                    return_value=JSONAsyncMock({"value": RESPONSE_USER1_FILES})
+                )
+
+                async_response_user2 = AsyncMock()
+                async_response_user2.__aenter__ = AsyncMock(
+                    return_value=JSONAsyncMock({"value": RESPONSE_USER2_FILES})
+                )
+
+                with patch(
+                    "aiohttp.ClientSession.get",
+                    side_effect=[async_response_user1, async_response_user2],
+                ):
+                    documents = []
+                    expected_responses = [
+                        EXPECTED_USER1_FILES_PERMISSION[0],
+                        EXPECTED_USER2_FILES_PERMISSION[1],
+                    ]
+                    async for item, _ in source.get_docs(filtering):
+                        item.get("_allow_access_control", []).sort()
+                        documents.append(item)
+
+        assert documents == expected_responses
+
+
 @pytest.mark.asyncio
 async def test_get_access_control_dls_disabled():
     async with create_onedrive_source() as source:


### PR DESCRIPTION
## Part of https://github.com/elastic/sdh-search/issues/1970

When document level security is enabled on the OneDrive connector, full content
syncs that use advanced sync rules crash with `KeyError: '_allow_access_control'`.
The default `get_docs()` path decorates documents via `_decorate_with_access_control()`
before indexing, but the advanced-rules branch skipped that step. This change
applies the same DLS decoration in the advanced-rules path.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* N/A

## Release Note

Fixed a bug where OneDrive full content syncs failed with
`KeyError: '_allow_access_control'` when both document level security and
advanced sync rules were enabled.