### PR TITLE
fix(outlook): skip accounts with non-primary SMTP addresses

### DIFF
--- a/app/connectors_service/connectors/sources/outlook/datasource.py
+++ b/app/connectors_service/connectors/sources/outlook/datasource.py
@@ -15,7 +15,11 @@ from connectors_sdk.utils import (
 )
 from exchangelib import UTC
 from exchangelib.attachments import FileAttachment
-from exchangelib.errors import ErrorAccessDenied, ErrorNonExistentMailbox
+from exchangelib.errors import (
+    ErrorAccessDenied,
+    ErrorNonExistentMailbox,
+    ErrorNonPrimarySmtpAddress,
+)
 from exchangelib.items import (
     CalendarItem,
     Contact,
@@ -756,7 +760,11 @@ class OutlookDataSource(BaseDataSource):
                     account=account, timezone=timezone
                 ):
                     yield child_calendar
-            except (ErrorNonExistentMailbox, ErrorAccessDenied) as error:
+            except (
+                ErrorNonExistentMailbox,
+                ErrorNonPrimarySmtpAddress,
+                ErrorAccessDenied,
+            ) as error:
                 # Account-specific failure: skip this account. Connection-wide errors
                 # propagate so an empty "successful" sync can't wipe the index.
                 self._logger.warning(

--- a/app/connectors_service/tests/sources/test_outlook.py
+++ b/app/connectors_service/tests/sources/test_outlook.py
@@ -22,6 +22,7 @@ from exchangelib.errors import (
     ErrorFolderNotFound,
     ErrorManagedFolderNotFound,
     ErrorNonExistentMailbox,
+    ErrorNonPrimarySmtpAddress,
     TransportError,
 )
 from exchangelib.folders import BaseFolder, Calendar, Messages, Tasks
@@ -1186,6 +1187,29 @@ async def test_get_docs_skips_account_without_mailbox_and_continues():
         warning_message = source._logger.warning.call_args.args[0]
         assert "no.mailbox@example.com" in warning_message
         assert "ErrorNonExistentMailbox" in warning_message
+
+
+@pytest.mark.asyncio
+async def test_get_docs_skips_account_with_non_primary_smtp_address_and_continues():
+    async with create_outlook_source() as source:
+        bad_account = _account_raising_on_inbox(
+            ErrorNonPrimarySmtpAddress("non-primary smtp"),
+            smtp="alias@example.com",
+        )
+        source.client._get_user_instance.get_user_accounts = AsyncIterator(
+            [bad_account, MockAccount()]
+        )
+        source._logger = MagicMock()
+
+        documents = [document async for document, _ in source.get_docs()]
+
+        assert all(document in EXPECTED_RESPONSE for document in documents)
+        assert any(document["_id"] == "contact_1" for document in documents)
+
+        source._logger.warning.assert_called_once()
+        warning_message = source._logger.warning.call_args.args[0]
+        assert "alias@example.com" in warning_message
+        assert "ErrorNonPrimarySmtpAddress" in warning_message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part of https://github.com/elastic/sdh-search/issues/1898
Part of https://github.com/elastic/connectors/issues/2931

## Problem

On large on-prem Exchange deployments the connector enumerates users from Active Directory and opens each mailbox via EWS impersonation using the LDAP `mail` attribute. When that value is a proxy or alias address rather than the account's primary SMTP address, Exchange raises `ErrorNonPrimarySmtpAddress` during folder resolution (`account.inbox` → `account.root`).

This is a distinct failure mode from the cases already handled in #4085:

| Already handled | This PR |
|-----------------|---------|
| No `mail` attribute (#4078) | Has `mail`, but it is not the primary SMTP |
| `ErrorNonExistentMailbox` — no mailbox provisioned (#4085) | `ErrorNonPrimarySmtpAddress` — mailbox exists, wrong address used |

Because `ErrorNonPrimarySmtpAddress` was not in the per-account skip handler, a single bad AD entry aborted the entire sync. A customer on SDH #1898 hit this after indexing 1.6M+ documents over ~15 hours.

## Fix

Add `ErrorNonPrimarySmtpAddress` to the existing per-account `try/except` in `get_docs()`. The affected account is skipped with a warning; the sync continues with remaining accounts. Connection-wide errors still propagate.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4085 — established the per-account skip pattern for `ErrorNonExistentMailbox`
* https://github.com/elastic/connectors/pull/4078 — skip AD users without a valid `mail` attribute

## Release Note

**Outlook Server connector**: sync jobs no longer abort when an Active Directory user has a valid `mail` attribute that is not the primary SMTP address (`ErrorNonPrimarySmtpAddress`). The affected account is skipped with a warning and the sync continues.