### PR TITLE
fix: recover MSSQL sync from "Invalid TDS marker" on retried queries (#3723)

### DIFF
--- a/app/connectors_service/connectors/sources/mssql/client.py
+++ b/app/connectors_service/connectors/sources/mssql/client.py
@@ -71,7 +71,24 @@ class MSSQLClient:
                     f"Something went wrong while removing temporary certificate file. Exception: {exception}"
                 )
         if self.connection is not None:
-            self.connection.close()
+            try:
+                self.connection.close()
+            except Exception as exception:
+                # Closing a pytds connection that still has an interrupted result
+                # set triggers a rollback/cancel that reads a corrupted TDS stream
+                # ("Invalid TDS marker"). Fall back to invalidating the underlying
+                # connection so cleanup never crashes.
+                self._logger.warning(
+                    f"Something went wrong while closing the MSSQL connection. Exception: {exception}"
+                )
+                try:
+                    self.connection.invalidate()
+                except Exception as invalidate_exception:
+                    self._logger.debug(
+                        f"Something went wrong while invalidating the MSSQL connection. Exception: {invalidate_exception}"
+                    )
+            finally:
+                self.connection = None
 
     @cached_property
     def engine(self):
@@ -125,7 +142,31 @@ class MSSQLClient:
             self._logger.warning(
                 f"Something went wrong while executing query. Exception: {exception}"
             )
+            # The shared connection may be left with an interrupted result set
+            # (e.g. when a large streaming query is retried). Reusing it makes
+            # pytds cancel the pending request and read a corrupted stream,
+            # surfacing as "Invalid TDS marker". Drop it so the retry reconnects.
+            await self._reset_connection()
             raise
+
+    async def _reset_connection(self):
+        """Discard the current connection so the next query reconnects cleanly.
+
+        Uses ``invalidate`` rather than ``close`` because a poisoned pytds
+        connection cannot be gracefully closed: the implicit rollback/cancel
+        reads a corrupted TDS stream and raises again.
+        """
+        if self.connection is None:
+            return
+        connection = self.connection
+        self.connection = None
+        try:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(executor=None, func=connection.invalidate)
+        except Exception as exception:
+            self._logger.debug(
+                f"Something went wrong while resetting the MSSQL connection. Exception: {exception}"
+            )
 
     async def ping(self):
         return await anext(

--- a/app/connectors_service/tests/sources/test_mssql.py
+++ b/app/connectors_service/tests/sources/test_mssql.py
@@ -60,6 +60,63 @@ async def test_ping_negative():
 
 
 @pytest.mark.asyncio
+async def test_get_cursor_resets_connection_on_error():
+    """A failed query must drop the shared connection so a retry does not reuse
+    a poisoned pytds connection and raise "Invalid TDS marker"."""
+    async with create_source(MSSQLDataSource) as source:
+        broken_connection = Mock()
+        broken_connection.execute = Mock(
+            side_effect=Exception("Invalid TDS marker: 0(0)")
+        )
+        source.mssql_client.connection = broken_connection
+
+        with pytest.raises(Exception, match="Invalid TDS marker"):
+            await source.mssql_client.get_cursor("SELECT * FROM dbo.transactions")
+
+        broken_connection.invalidate.assert_called_once()
+        assert source.mssql_client.connection is None
+
+
+@pytest.mark.asyncio
+async def test_get_cursor_reconnects_after_reset():
+    """After a poisoned connection is dropped, the next query establishes a
+    fresh connection instead of failing again."""
+    async with create_source(MSSQLDataSource) as source:
+        source.mssql_client.engine = MockEngine()
+
+        broken_connection = Mock()
+        broken_connection.execute = Mock(
+            side_effect=Exception("Invalid TDS marker: 0(0)")
+        )
+        source.mssql_client.connection = broken_connection
+
+        with pytest.raises(Exception, match="Invalid TDS marker"):
+            await source.mssql_client.get_cursor("SELECT * FROM dbo.transactions")
+        assert source.mssql_client.connection is None
+
+        cursor = await source.mssql_client.get_cursor("SELECT * FROM dbo.transactions")
+        assert cursor is not None
+        assert source.mssql_client.connection is not None
+
+
+@pytest.mark.asyncio
+async def test_close_is_resilient_when_connection_close_fails():
+    """Closing a connection that still has an interrupted result set must not
+    crash cleanup; it should fall back to invalidating the connection."""
+    async with create_source(MSSQLDataSource) as source:
+        broken_connection = Mock()
+        broken_connection.close = Mock(
+            side_effect=Exception("Invalid TDS marker: 0(0)")
+        )
+        source.mssql_client.connection = broken_connection
+
+        source.mssql_client.close()
+
+        broken_connection.invalidate.assert_called_once()
+        assert source.mssql_client.connection is None
+
+
+@pytest.mark.asyncio
 @patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
 async def test_fetch_documents_from_table_negative():
     async with create_source(MSSQLDataSource) as source:


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/3723


Large MSSQL syncs can fail with `pytds.tds_base.InterfaceError: Invalid TDS marker: 0(0)` when a streaming query is retried on a shared pytds connection that still has a pending result set. pytds cancels the in-flight request and reads a corrupted TDS stream. The same failure can crash connection cleanup during `close()`.

This change drops (invalidates) the poisoned connection when a query fails so the retry reconnects cleanly, and makes `close()` fall back to `invalidate()` so cleanup never crashes.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

## Related Pull Requests

## Release Note

Fixes MSSQL connector sync failures with `Invalid TDS marker` when large table queries are retried on a poisoned pytds connection.