### PR TITLE
fix: exclude write-only allow ACEs from network drive DLS read access (#1963) (#2875)

### DIFF
--- a/app/connectors_service/connectors/sources/network_drive/datasource.py
+++ b/app/connectors_service/connectors/sources/network_drive/datasource.py
@@ -609,10 +609,14 @@ class NASDataSource(BaseDataSource):
             else:
                 # Else the SID corresponds to a user, hence we use it directly.
                 permissions = [_prefix_sid(sid)]
+            # A write-only allow ACE grants write but not read access, so it must
+            # not make the document visible in search (Windows: write does not
+            # imply read). A deny-write ACE only removes write access and leaves
+            # read intact, so it is treated as an allow to preserve read access.
             if (
                 ace_type == ACCESS_ALLOWED_TYPE
-                or mask == ACCESS_MASK_DENIED_WRITE_PERMISSION
-            ):
+                and mask != ACCESS_MASK_ALLOWED_WRITE_PERMISSION
+            ) or mask == ACCESS_MASK_DENIED_WRITE_PERMISSION:
                 allow_permissions.extend(permissions)
 
             if (

--- a/app/connectors_service/connectors/sources/network_drive/datasource.py
+++ b/app/connectors_service/connectors/sources/network_drive/datasource.py
@@ -609,10 +609,7 @@ class NASDataSource(BaseDataSource):
             else:
                 # Else the SID corresponds to a user, hence we use it directly.
                 permissions = [_prefix_sid(sid)]
-            # A write-only allow ACE grants write but not read access, so it must
-            # not make the document visible in search (Windows: write does not
-            # imply read). A deny-write ACE only removes write access and leaves
-            # read intact, so it is treated as an allow to preserve read access.
+            # Write-only allow ACEs don't grant read; deny-write ACEs still do.
             if (
                 ace_type == ACCESS_ALLOWED_TYPE
                 and mask != ACCESS_MASK_ALLOWED_WRITE_PERMISSION

--- a/app/connectors_service/tests/sources/test_network_drive.py
+++ b/app/connectors_service/tests/sources/test_network_drive.py
@@ -34,6 +34,9 @@ from connectors.sources.network_drive import (
     SMBSession,
     UserAccountDisabledException,
 )
+from connectors.sources.network_drive.datasource import (
+    ACCESS_MASK_ALLOWED_WRITE_PERMISSION,
+)
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
 
@@ -133,7 +136,7 @@ def side_effect_function(MAX_CHUNK_SIZE):
     return b"Mock...."
 
 
-def mock_permission(sid, ace):
+def mock_permission(sid, ace, mask=234):
     mock_response = {}
 
     class MockSID:
@@ -144,7 +147,7 @@ def mock_permission(sid, ace):
     mock_response["ace_type"].value = ace
 
     mock_response["mask"] = mock.Mock()
-    mock_response["mask"].value = 234
+    mock_response["mask"].value = mask
 
     mock_response["sid"] = MockSID()
 
@@ -1129,6 +1132,68 @@ async def test_group_allow_ace_member1_allow_member2_deny_ace_then_member1_has_a
             groups_info=mock_groups_info,
         )
         assert document_permissions[ACCESS_CONTROL] == expected_result
+
+
+@pytest.mark.asyncio
+@mock.patch.object(
+    NASDataSource,
+    "list_file_permission",
+    return_value=[
+        # User with only write permission (no read access) allowed.
+        mock_permission(
+            sid="S-2-21-211-411", ace=0, mask=ACCESS_MASK_ALLOWED_WRITE_PERMISSION
+        ),
+    ],
+)
+async def test_write_only_allow_ace_does_not_grant_read_access(
+    mock_list_file_permission,
+):
+    """A user whose only allow ACE grants write (not read) must not see the
+    document, matching Windows where write access does not imply read access."""
+    async with create_source(NASDataSource) as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        document_permissions = await source._decorate_with_access_control(
+            document={"id": "123", "title": "sample.py"},
+            file_path="dummy_url/file1",
+            file_type="file",
+            groups_info={},
+        )
+        assert document_permissions[ACCESS_CONTROL] == []
+
+
+@pytest.mark.asyncio
+@mock.patch.object(
+    NASDataSource,
+    "list_file_permission",
+    return_value=[
+        # Group granted read access.
+        mock_permission(sid="S-1-11-11", ace=0),
+        # Member of that group additionally granted write-only access.
+        mock_permission(
+            sid="S-2-21-211-411", ace=0, mask=ACCESS_MASK_ALLOWED_WRITE_PERMISSION
+        ),
+    ],
+)
+async def test_group_read_access_is_kept_when_member_has_extra_write_only_ace(
+    mock_list_file_permission,
+):
+    """A write-only allow ACE must not revoke read access the user already has
+    through a group's read grant."""
+    mock_groups_info = {
+        "S-1-11-11": {"user-1": "S-2-21-211-411", "user-2": "S-3-23-222-221"}
+    }
+    async with create_source(NASDataSource) as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        document_permissions = await source._decorate_with_access_control(
+            document={"id": "123", "title": "sample.py"},
+            file_path="dummy_url/file1",
+            file_type="file",
+            groups_info=mock_groups_info,
+        )
+        assert sorted(document_permissions[ACCESS_CONTROL]) == [
+            "sid:S-2-21-211-411",
+            "sid:S-3-23-222-221",
+        ]
 
 
 async def test_validate_drive_path():

--- a/app/connectors_service/tests/sources/test_network_drive.py
+++ b/app/connectors_service/tests/sources/test_network_drive.py
@@ -36,6 +36,7 @@ from connectors.sources.network_drive import (
 )
 from connectors.sources.network_drive.datasource import (
     ACCESS_MASK_ALLOWED_WRITE_PERMISSION,
+    ACCESS_MASK_DENIED_WRITE_PERMISSION,
 )
 from tests.commons import AsyncIterator
 from tests.sources.support import create_source
@@ -1194,6 +1195,64 @@ async def test_group_read_access_is_kept_when_member_has_extra_write_only_ace(
             "sid:S-2-21-211-411",
             "sid:S-3-23-222-221",
         ]
+
+
+@pytest.mark.asyncio
+@mock.patch.object(
+    NASDataSource,
+    "list_file_permission",
+    return_value=[
+        # User 1 has a regular allow (read) permission
+        mock_permission(sid="S-2-21-211-411", ace=0),
+        # User 2 is only granted write access, so must not be able to read
+        mock_permission(
+            sid="S-3-23-222-221",
+            ace=0,
+            mask=ACCESS_MASK_ALLOWED_WRITE_PERMISSION,
+        ),
+    ],
+)
+async def test_write_only_allow_ace_excluded_while_read_allow_ace_kept(
+    mock_list_file_permission,
+):
+    """Among multiple users, only those with read-capable allow ACEs keep access."""
+    async with create_source(NASDataSource) as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        document_permissions = await source._decorate_with_access_control(
+            document={"id": "123", "title": "sample.py"},
+            file_path="dummy_url/file1",
+            file_type="file",
+            groups_info={},
+        )
+        assert document_permissions[ACCESS_CONTROL] == ["sid:S-2-21-211-411"]
+
+
+@pytest.mark.asyncio
+@mock.patch.object(
+    NASDataSource,
+    "list_file_permission",
+    return_value=[
+        # Deny ACE that only denies write must still leave read access intact
+        mock_permission(
+            sid="S-2-21-211-411",
+            ace=1,
+            mask=ACCESS_MASK_DENIED_WRITE_PERMISSION,
+        ),
+    ],
+)
+async def test_deny_write_only_ace_still_grants_read_access(
+    mock_list_file_permission,
+):
+    """A deny-write ACE removes write access but must not remove read access."""
+    async with create_source(NASDataSource) as source:
+        source._dls_enabled = MagicMock(return_value=True)
+        document_permissions = await source._decorate_with_access_control(
+            document={"id": "123", "title": "sample.py"},
+            file_path="dummy_url/file1",
+            file_type="file",
+            groups_info={},
+        )
+        assert document_permissions[ACCESS_CONTROL] == ["sid:S-2-21-211-411"]
 
 
 async def test_validate_drive_path():

--- a/app/connectors_service/tests/sources/test_network_drive.py
+++ b/app/connectors_service/tests/sources/test_network_drive.py
@@ -1140,17 +1140,14 @@ async def test_group_allow_ace_member1_allow_member2_deny_ace_then_member1_has_a
     NASDataSource,
     "list_file_permission",
     return_value=[
-        # User with only write permission (no read access) allowed.
         mock_permission(
             sid="S-2-21-211-411", ace=0, mask=ACCESS_MASK_ALLOWED_WRITE_PERMISSION
-        ),
+        ),  # Write-only allow ACE
     ],
 )
 async def test_write_only_allow_ace_does_not_grant_read_access(
     mock_list_file_permission,
 ):
-    """A user whose only allow ACE grants write (not read) must not see the
-    document, matching Windows where write access does not imply read access."""
     async with create_source(NASDataSource) as source:
         source._dls_enabled = MagicMock(return_value=True)
         document_permissions = await source._decorate_with_access_control(
@@ -1167,19 +1164,15 @@ async def test_write_only_allow_ace_does_not_grant_read_access(
     NASDataSource,
     "list_file_permission",
     return_value=[
-        # Group granted read access.
-        mock_permission(sid="S-1-11-11", ace=0),
-        # Member of that group additionally granted write-only access.
+        mock_permission(sid="S-1-11-11", ace=0),  # Group allow
         mock_permission(
             sid="S-2-21-211-411", ace=0, mask=ACCESS_MASK_ALLOWED_WRITE_PERMISSION
-        ),
+        ),  # User write-only allow ACE
     ],
 )
 async def test_group_read_access_is_kept_when_member_has_extra_write_only_ace(
     mock_list_file_permission,
 ):
-    """A write-only allow ACE must not revoke read access the user already has
-    through a group's read grant."""
     mock_groups_info = {
         "S-1-11-11": {"user-1": "S-2-21-211-411", "user-2": "S-3-23-222-221"}
     }
@@ -1202,20 +1195,15 @@ async def test_group_read_access_is_kept_when_member_has_extra_write_only_ace(
     NASDataSource,
     "list_file_permission",
     return_value=[
-        # User 1 has a regular allow (read) permission
-        mock_permission(sid="S-2-21-211-411", ace=0),
-        # User 2 is only granted write access, so must not be able to read
+        mock_permission(sid="S-2-21-211-411", ace=0),  # User with allow permission
         mock_permission(
-            sid="S-3-23-222-221",
-            ace=0,
-            mask=ACCESS_MASK_ALLOWED_WRITE_PERMISSION,
-        ),
+            sid="S-3-23-222-221", ace=0, mask=ACCESS_MASK_ALLOWED_WRITE_PERMISSION
+        ),  # User with write-only allow permission
     ],
 )
 async def test_write_only_allow_ace_excluded_while_read_allow_ace_kept(
     mock_list_file_permission,
 ):
-    """Among multiple users, only those with read-capable allow ACEs keep access."""
     async with create_source(NASDataSource) as source:
         source._dls_enabled = MagicMock(return_value=True)
         document_permissions = await source._decorate_with_access_control(
@@ -1232,18 +1220,14 @@ async def test_write_only_allow_ace_excluded_while_read_allow_ace_kept(
     NASDataSource,
     "list_file_permission",
     return_value=[
-        # Deny ACE that only denies write must still leave read access intact
         mock_permission(
-            sid="S-2-21-211-411",
-            ace=1,
-            mask=ACCESS_MASK_DENIED_WRITE_PERMISSION,
-        ),
+            sid="S-2-21-211-411", ace=1, mask=ACCESS_MASK_DENIED_WRITE_PERMISSION
+        ),  # Deny-write ACE
     ],
 )
 async def test_deny_write_only_ace_still_grants_read_access(
     mock_list_file_permission,
 ):
-    """A deny-write ACE removes write access but must not remove read access."""
     async with create_source(NASDataSource) as source:
         source._dls_enabled = MagicMock(return_value=True)
         document_permissions = await source._decorate_with_access_control(


### PR DESCRIPTION
## Closes https://github.com/elastic/connectors/issues/1963
## Closes https://github.com/elastic/connectors/issues/2875


On Windows, write permission does not grant read access. Network Drive DLS was treating write-only allow ACEs as read access, so users who could only write to a file still saw it in search results.

This change excludes `ACCESS_MASK_ALLOWED_WRITE_PERMISSION` from `allow_permissions`, so only read-capable allow ACEs grant document visibility. Deny-write ACE handling is unchanged.

Deny precedence (group allow + user deny) was already fixed on `main`; this PR addresses the remaining write-only gap reported in both issues.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Release Note

Network Drive document-level security no longer grants read access for users who only have write permission on a file, matching Windows file server behavior.