### PR TITLE
fix(fips): MD5 will be blocked in FIPS environment without flag

### DIFF
--- a/libs/connectors_sdk/connectors_sdk/utils.py
+++ b/libs/connectors_sdk/connectors_sdk/utils.py
@@ -58,7 +58,8 @@ def get_file_extension(filename):
 def hash_id(_id):
     # Collision probability: 1.47*10^-29
     # S105 rule considers this code unsafe, but we're not using it for security-related
-    # things, only to generate pseudo-ids for documents
+    # things, only to generate pseudo-ids for documents. useforsecurity=False tells the md5 method that
+    # we are NOT using this for security, otherwise FIPS would block this
     return hashlib.md5(_id.encode("utf8"), usedforsecurity=False).hexdigest()  # noqa S105
 
 

--- a/libs/connectors_sdk/connectors_sdk/utils.py
+++ b/libs/connectors_sdk/connectors_sdk/utils.py
@@ -59,7 +59,7 @@ def hash_id(_id):
     # Collision probability: 1.47*10^-29
     # S105 rule considers this code unsafe, but we're not using it for security-related
     # things, only to generate pseudo-ids for documents
-    return hashlib.md5(_id.encode("utf8")).hexdigest()  # noqa S105
+    return hashlib.md5(_id.encode("utf8"), usedforsecurity=False).hexdigest()  # noqa S105
 
 
 def convert_to_b64(source, target=None, overwrite=False):

--- a/libs/connectors_sdk/tests/test_utils.py
+++ b/libs/connectors_sdk/tests/test_utils.py
@@ -46,9 +46,8 @@ def test_hash_id_fips_compatible(monkeypatch):
 
     def fips_strict_md5(data, usedforsecurity=True):
         if usedforsecurity:
-            raise ValueError(
-                "[digital envelope routines] unsupported (simulated FIPS mode)"
-            )
+            msg = "[digital envelope routines] unsupported (simulated FIPS mode)"
+            raise ValueError(msg)
         return original_md5(data, usedforsecurity=False)
 
     monkeypatch.setattr(_hashlib, "md5", fips_strict_md5)

--- a/libs/connectors_sdk/tests/test_utils.py
+++ b/libs/connectors_sdk/tests/test_utils.py
@@ -34,6 +34,29 @@ def test_hash_id():
     assert len(hash_id(random_id_too_long).encode("UTF-8")) < limit
 
 
+def test_hash_id_fips_compatible(monkeypatch):
+    """hash_id must pass usedforsecurity=False to work on FIPS-enabled systems.
+
+    On a FIPS-enabled host, OpenSSL raises ValueError for hashlib.md5() unless
+    usedforsecurity=False is set. This test simulates that enforcement.
+    """
+    import hashlib as _hashlib
+
+    original_md5 = _hashlib.md5
+
+    def fips_strict_md5(data, usedforsecurity=True):
+        if usedforsecurity:
+            raise ValueError(
+                "[digital envelope routines] unsupported (simulated FIPS mode)"
+            )
+        return original_md5(data, usedforsecurity=False)
+
+    monkeypatch.setattr(_hashlib, "md5", fips_strict_md5)
+
+    result = hash_id("some-document-id")
+    assert len(result) == 32
+
+
 @pytest.fixture
 def patch_file_ops():
     with patch("connectors_sdk.utils.open"):


### PR DESCRIPTION
On a FIPS-enabled host, OpenSSL blocks hashlib.md5() unless usedforsecurity=False is passed. This flag is a no-op on non-FIPS systems and does not change the hash output, so existing document IDs are unaffected.

Adds a test that simulates FIPS enforcement via monkeypatching to prevent regression.

## Closes https://github.com/elastic/connectors-py/issues/4415

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [x] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

