### PR TITLE
[8.19] fix: recover MSSQL sync from "Invalid TDS marker" on retried queries (#4407)

### DIFF
--- a/connectors/sources/mssql.py
+++ b/connectors/sources/mssql.py
@@ -190,7 +190,24 @@ class MSSQLClient:
                     f"Something went wrong while removing temporary certificate file. Exception: {exception}"
                 )
         if self.connection is not None:
-            self.connection.close()
+            try:
+                self.connection.close()
+            except Exception as exception:
+                # Closing a pytds connection that still has an interrupted result
+                # set triggers a rollback/cancel that reads a corrupted TDS stream
+                # ("Invalid TDS marker"). Fall back to invalidating the underlying
+                # connection so cleanup never crashes.
+                self._logger.warning(
+                    f"Something went wrong while closing the MSSQL connection. Exception: {exception}"
+                )
+                try:
+                    self.connection.invalidate()
+                except Exception as invalidate_exception:
+                    self._logger.debug(
+                        f"Something went wrong while invalidating the MSSQL connection. Exception: {invalidate_exception}"
+                    )
+            finally:
+                self.connection = None
 
     @cached_property
     def engine(self):
@@ -244,7 +261,31 @@ class MSSQLClient:
             self._logger.warning(
                 f"Something went wrong while executing query. Exception: {exception}"
             )
+            # The shared connection may be left with an interrupted result set
+            # (e.g. when a large streaming query is retried). Reusing it makes
+            # pytds cancel the pending request and read a corrupted stream,
+            # surfacing as "Invalid TDS marker". Drop it so the retry reconnects.
+            await self._reset_connection()
             raise
+
+    async def _reset_connection(self):
+        """Discard the current connection so the next query reconnects cleanly.
+
+        Uses ``invalidate`` rather than ``close`` because a poisoned pytds
+        connection cannot be gracefully closed: the implicit rollback/cancel
+        reads a corrupted TDS stream and raises again.
+        """
+        if self.connection is None:
+            return
+        connection = self.connection
+        self.connection = None
+        try:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(executor=None, func=connection.invalidate)
+        except Exception as exception:
+            self._logger.debug(
+                f"Something went wrong while resetting the MSSQL connection. Exception: {exception}"
+            )
 
     async def ping(self):
         return await anext(

--- a/tests/sources/test_mssql.py
+++ b/tests/sources/test_mssql.py
@@ -61,6 +61,63 @@ async def test_ping_negative():
 
 
 @pytest.mark.asyncio
+async def test_get_cursor_resets_connection_on_error():
+    """A failed query must drop the shared connection so a retry does not reuse
+    a poisoned pytds connection and raise "Invalid TDS marker"."""
+    async with create_source(MSSQLDataSource) as source:
+        broken_connection = Mock()
+        broken_connection.execute = Mock(
+            side_effect=Exception("Invalid TDS marker: 0(0)")
+        )
+        source.mssql_client.connection = broken_connection
+
+        with pytest.raises(Exception, match="Invalid TDS marker"):
+            await source.mssql_client.get_cursor("SELECT * FROM dbo.transactions")
+
+        broken_connection.invalidate.assert_called_once()
+        assert source.mssql_client.connection is None
+
+
+@pytest.mark.asyncio
+async def test_get_cursor_reconnects_after_reset():
+    """After a poisoned connection is dropped, the next query establishes a
+    fresh connection instead of failing again."""
+    async with create_source(MSSQLDataSource) as source:
+        source.mssql_client.engine = MockEngine()
+
+        broken_connection = Mock()
+        broken_connection.execute = Mock(
+            side_effect=Exception("Invalid TDS marker: 0(0)")
+        )
+        source.mssql_client.connection = broken_connection
+
+        with pytest.raises(Exception, match="Invalid TDS marker"):
+            await source.mssql_client.get_cursor("SELECT * FROM dbo.transactions")
+        assert source.mssql_client.connection is None
+
+        cursor = await source.mssql_client.get_cursor("SELECT * FROM dbo.transactions")
+        assert cursor is not None
+        assert source.mssql_client.connection is not None
+
+
+@pytest.mark.asyncio
+async def test_close_is_resilient_when_connection_close_fails():
+    """Closing a connection that still has an interrupted result set must not
+    crash cleanup; it should fall back to invalidating the connection."""
+    async with create_source(MSSQLDataSource) as source:
+        broken_connection = Mock()
+        broken_connection.close = Mock(
+            side_effect=Exception("Invalid TDS marker: 0(0)")
+        )
+        source.mssql_client.connection = broken_connection
+
+        source.mssql_client.close()
+
+        broken_connection.invalidate.assert_called_once()
+        assert source.mssql_client.connection is None
+
+
+@pytest.mark.asyncio
 @patch("connectors.utils.time_to_sleep_between_retries", Mock(return_value=0))
 async def test_fetch_documents_from_table_negative():
     async with create_source(MSSQLDataSource) as source:


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix: recover MSSQL sync from "Invalid TDS marker" on retried queries (#4407)