### PR TITLE
Feature (ServiceNow): OAuth 2.0 for Service Now and user:email for Document Level Security

### DIFF
--- a/app/connectors_service/connectors/sources/servicenow/client.py
+++ b/app/connectors_service/connectors/sources/servicenow/client.py
@@ -6,9 +6,16 @@
 import base64
 import json
 import math
+import time
 import uuid
-from functools import cached_property
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
+
+try:
+    import jwt as pyjwt  # PyJWT; optional — only needed for jwt_bearer grant
+    _PYJWT_AVAILABLE = True
+except ImportError:
+    pyjwt = None  # type: ignore[assignment]
+    _PYJWT_AVAILABLE = False
 
 import aiohttp
 from connectors_sdk.logger import logger
@@ -48,38 +55,243 @@ class ServiceNowClient:
         self.services = self.configuration["services"]
         self.retry_count = self.configuration["retry_count"]
         self._logger = logger
+        self._session = None  # initialised lazily on first async call
+        self._token_expiry = 0.0  # epoch seconds via monotonic clock; 0 = not yet fetched
 
     def set_logger(self, logger_):
         self._logger = logger_
 
-    @cached_property
-    def _get_session(self):
-        """Generate aiohttp client session with configuration fields.
+    def _build_jwt_assertion(self, token_url):
+        """Build a signed JWT assertion for the jwt_bearer grant type.
+
+        The JWT is signed with the configured RSA/EC private key using the
+        algorithm specified by 'jwt_algorithm' (default RS256).  The 'iss'
+        and 'sub' claims are both set to the client_id unless a separate
+        'jwt_subject' is provided.
+
+        Args:
+            token_url (str): The token endpoint URL — used as the 'aud' claim.
+
+        Returns:
+            str: Compact serialised, signed JWT.
+
+        Raises:
+            RuntimeError: If PyJWT is not installed.
+            InvalidResponse: If the private key is not configured.
+        """
+        if not _PYJWT_AVAILABLE:
+            raise RuntimeError(
+                "PyJWT is required for the jwt_bearer grant type. "
+                "Install it with: pip install PyJWT cryptography"
+            )
+        private_key = self.configuration.get("jwt_private_key", "")
+        if not private_key:
+            raise InvalidResponse(
+                "jwt_private_key must be set when OAuth Grant Type is 'JWT Bearer'."
+            )
+        client_id = self.configuration["client_id"]
+        subject = self.configuration.get("jwt_subject", "") or client_id
+        algorithm = self.configuration.get("jwt_algorithm", "RS256")
+        now = int(time.time())
+        payload = {
+            "iss": client_id,
+            "sub": subject,
+            "aud": token_url,
+            "iat": now,
+            "exp": now + 3600,
+        }
+        key_id = self.configuration.get("jwt_key_id", "")
+        headers = {"kid": key_id} if key_id else {}
+        return pyjwt.encode(payload, private_key, algorithm=algorithm, headers=headers)
+
+    async def _fetch_access_token(self):
+        """Fetch an OAuth 2.0 Bearer token from ServiceNow.
+
+        Supports five grant types selected by the 'oauth_grant_type' config field:
+
+        - 'password' (default): Resource Owner Password Credentials; requires
+          client_id, client_secret, username, and oauth_password.  Works on all
+          instances including ServiceNow PDIs.
+
+        - 'client_credentials': Machine-to-machine; requires only client_id and
+          client_secret.  Not available on ServiceNow developer (PDI) instances.
+
+        - 'refresh_token': Refresh Token grant; requires client_id, client_secret,
+          username, and refresh_token.
+
+        - 'authorization_code': Authorization Code grant (+ optional PKCE); the
+          caller is expected to have completed the browser-based auth flow and
+          stored the resulting authorization code in 'oauth_authorization_code'.
+          A redirect_uri must also be supplied.  When PKCE is used the
+          'pkce_code_verifier' field must carry the original code verifier.
+          After the initial exchange the response's refresh_token is used for
+          all subsequent refreshes.
+
+        - 'jwt_bearer': JWT Bearer assertion grant
+          (urn:ietf:params:oauth:grant-type:jwt-bearer); requires client_id,
+          jwt_private_key (PEM), and optionally jwt_subject, jwt_key_id, and
+          jwt_algorithm.
+
+        The token URL is derived from scheme + host only to avoid double-path bugs.
+
+        Returns:
+            str: Access token string.
+        """
+        parsed = urlparse(self.configuration["url"])
+        token_url = f"{parsed.scheme}://{parsed.netloc}/oauth_token.do"
+        grant_type = self.configuration.get("oauth_grant_type", "password")
+
+        if grant_type == "jwt_bearer":
+            data = {
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "client_id": self.configuration["client_id"],
+                "assertion": self._build_jwt_assertion(token_url),
+            }
+            client_secret = self.configuration.get("client_secret", "")
+            if client_secret:
+                data["client_secret"] = client_secret
+        elif grant_type == "authorization_code":
+            # If we already have a cached refresh token from a previous code
+            # exchange, use it to obtain a fresh access token instead of
+            # re-exchanging the one-time authorization code.
+            cached_refresh = getattr(self, "_cached_refresh_token", None)
+            if cached_refresh:
+                data = {
+                    "grant_type": "refresh_token",
+                    "client_id": self.configuration["client_id"],
+                    "client_secret": self.configuration["client_secret"],
+                    "refresh_token": cached_refresh,
+                }
+            else:
+                data = {
+                    "grant_type": "authorization_code",
+                    "client_id": self.configuration["client_id"],
+                    "client_secret": self.configuration["client_secret"],
+                    "code": self.configuration["oauth_authorization_code"],
+                    "redirect_uri": self.configuration["oauth_redirect_uri"],
+                }
+                pkce_verifier = self.configuration.get("pkce_code_verifier", "")
+                if pkce_verifier:
+                    data["code_verifier"] = pkce_verifier
+        else:
+            data = {
+                "grant_type": grant_type,
+                "client_id": self.configuration["client_id"],
+                "client_secret": self.configuration["client_secret"],
+            }
+            if grant_type == "password":
+                data["username"] = self.configuration["oauth_username"]
+                data["password"] = self.configuration["oauth_password"]
+            elif grant_type == "refresh_token":
+                data["username"] = self.configuration["oauth_username_refresh"]
+                data["refresh_token"] = self.configuration["refresh_token"]
+
+        self._logger.debug(f"Fetching OAuth token using grant_type={grant_type}")
+        self._logger.debug(
+            f"Token request -> url={token_url} "
+            f"client_id={'set' if data.get('client_id') else 'MISSING'} "
+            f"client_secret={'set' if data.get('client_secret') else 'MISSING'} "
+            f"username={'set' if data.get('username') else 'n/a'} "
+            f"refresh_token={'set' if data.get('refresh_token') else 'n/a'} "
+            f"code={'set' if data.get('code') else 'n/a'} "
+            f"assertion={'set' if data.get('assertion') else 'n/a'}"
+        )
+        timeout = aiohttp.ClientTimeout(total=None)  # pyright: ignore
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                token_url,
+                data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            ) as response:
+                if response.status == 401:
+                    body = await response.text()
+                    self._logger.error(
+                        f"OAuth token request returned 401. Response body: {body}"
+                    )
+                response.raise_for_status()
+                token_response = await response.json(content_type=None)
+
+        # Cache the refresh token returned by authorization_code exchanges so
+        # that subsequent calls use the refresh_token grant instead of the
+        # one-time code.
+        new_refresh_token = token_response.get("refresh_token")
+        if grant_type == "authorization_code" and new_refresh_token:
+            self._cached_refresh_token = new_refresh_token
+
+        access_token = token_response.get("access_token")
+        if not access_token:
+            msg = "OAuth token response did not contain an access_token."
+            raise InvalidResponse(msg)
+        expires_in = int(token_response.get("expires_in", 1800))  # ServiceNow default is 1800s
+        # Subtract 60s so we refresh before the token actually expires
+        self._token_expiry = time.monotonic() + expires_in - 60
+        self._logger.debug(
+            f"OAuth access token fetched successfully (expires in {expires_in}s, "
+            f"will refresh after {expires_in - 60}s)."
+        )
+        return access_token
+
+    async def _create_session(self):
+        """Async helper: build and return a configured ClientSession.
+
+        Uses Basic Auth when auth_method is 'basic', otherwise fetches an
+        OAuth 2.0 Bearer token and injects it as an Authorization header.
+        """
+        auth_method = self.configuration.get("auth_method", "oauth")
+        connector = aiohttp.TCPConnector(limit=MAX_CONCURRENT_CLIENT_SUPPORT)
+        timeout = aiohttp.ClientTimeout(total=None)  # pyright: ignore
+        if auth_method == "basic":
+            self._logger.debug("Generating aiohttp client session (Basic Auth)")
+            basic_auth = aiohttp.BasicAuth(
+                login=self.configuration["username"],
+                password=self.configuration["basic_auth_password"],
+            )
+            return aiohttp.ClientSession(
+                connector=connector,
+                base_url=self.configuration["url"],
+                auth=basic_auth,
+                headers={"Content-Type": "application/json", "Accept": "application/json"},
+                timeout=timeout,
+                raise_for_status=True,
+            )
+        # OAuth (default)
+        self._logger.debug("Generating aiohttp client session (OAuth)")
+        access_token = await self._fetch_access_token()
+        return aiohttp.ClientSession(
+            connector=connector,
+            base_url=self.configuration["url"],
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {access_token}",
+            },
+            timeout=timeout,
+            raise_for_status=True,
+        )
+
+    async def _get_session(self):
+        """Return a lazily-created, cached aiohttp ClientSession.
+
+        For OAuth: proactively refreshes the session when the access token is
+        within 60s of expiry so long-running syncs never hit a mid-batch 401.
+        For Basic Auth: session is created once and reused indefinitely.
 
         Returns:
             aiohttp.ClientSession: An instance of Client Session
         """
-
-        self._logger.debug("Generating aiohttp client session")
-        connector = aiohttp.TCPConnector(limit=MAX_CONCURRENT_CLIENT_SUPPORT)
-        basic_auth = aiohttp.BasicAuth(
-            login=self.configuration["username"],
-            password=self.configuration["password"],
-        )
-        request_headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-        }
-        timeout = aiohttp.ClientTimeout(total=None)  # pyright: ignore
-
-        return aiohttp.ClientSession(
-            connector=connector,
-            base_url=self.configuration["url"],
-            auth=basic_auth,
-            headers=request_headers,
-            timeout=timeout,
-            raise_for_status=True,
-        )
+        auth_method = self.configuration.get("auth_method", "oauth")
+        if (
+            auth_method != "basic"
+            and self._session is not None
+            and time.monotonic() >= self._token_expiry
+        ):
+            self._logger.debug(
+                "OAuth access token near expiry. Proactively refreshing session."
+            )
+            await self.close_session()  # sets self._session = None
+        if self._session is None:
+            self._session = await self._create_session()
+        return self._session
 
     async def _read_response(self, response):
         fetched_response = await response.read()
@@ -205,12 +417,46 @@ class ServiceNowClient:
         strategy=RetryStrategy.EXPONENTIAL_BACKOFF,
     )
     async def _batch_api_call(self, batch_data):
+        """Execute a ServiceNow batch API request and yield each serviced result.
+
+        On a 401 response inside the batch envelope:
+        - OAuth: closes the session so the @retryable decorator gets a fresh token
+          on the next attempt.
+        - Basic Auth: credentials are baked into the session and cannot be refreshed
+          at runtime, so close_session() is skipped. The error is logged at ERROR
+          level because it indicates a configuration problem rather than a transient
+          token expiry.
+
+        Args:
+            batch_data (dict): Batch request payload as produced by _prepare_batch().
+
+        Yields:
+            list: Decoded 'result' list from each successfully serviced sub-request.
+
+        Raises:
+            InvalidResponse: If any sub-request returns a non-200 status code.
+        """
         response = await self._api_call(
             url=ENDPOINTS["BATCH"], params={}, actions=batch_data, method="post"
         )
         json_response = json.loads(await self._read_response(response=response))
 
+        auth_method = self.configuration.get("auth_method", "oauth")
         for response in json_response["serviced_requests"]:
+            if response["status_code"] == 401:
+                if auth_method != "basic":
+                    # Session close lets @retryable rebuild it with a fresh token.
+                    self._logger.warning(
+                        "OAuth token expired (401 inside batch response). Refreshing session."
+                    )
+                    await self.close_session()
+                else:
+                    # Credentials are wrong; recreating the session would not help.
+                    self._logger.error(
+                        "Basic Auth credentials rejected (401 inside batch response). Check username and password."
+                    )
+                msg = f"Cannot proceed due to invalid status code 401; Message {json.loads(base64.b64decode(response['body']))['error']}."
+                raise InvalidResponse(msg)
             if response["status_code"] != 200:
                 error_message = json.loads(base64.b64decode(response["body"]))["error"]
                 msg = f"Cannot proceed due to invalid status code {response['status_code']}; Message {error_message}."
@@ -218,7 +464,22 @@ class ServiceNowClient:
             yield json.loads(base64.b64decode(response["body"]))["result"]
 
     async def _api_call(self, url, params, actions, method):
-        return await getattr(self._get_session, method)(
+        """Dispatch a single HTTP request through the managed session.
+
+        Awaits _get_session() on every call so that OAuth token refresh and
+        lazy session creation are handled transparently.
+
+        Args:
+            url (str): Relative URL path (resolved against the base_url on the session).
+            params (dict): Query-string parameters.
+            actions (dict): Request body serialised as JSON.
+            method (str): HTTP verb as a lowercase string (e.g. 'get', 'post').
+
+        Returns:
+            aiohttp.ClientResponse: The raw response object.
+        """
+        session = await self._get_session()
+        return await getattr(session, method)(
             url=url, params=params, json=actions
         )
 
@@ -287,7 +548,15 @@ class ServiceNowClient:
         await self.get_table_length(table_name="sys_db_object")
 
     async def close_session(self):
-        """Closes unclosed client session"""
+        """Close the active client session and reset session state.
+
+        Guards against double-close: a no-op when no session has been created
+        yet or after the session has already been closed. Sets self._session to
+        None so that the next call to _get_session() will create a fresh one —
+        this is relied upon by the OAuth token-refresh path in _get_session()
+        and by the 401 recovery path in _batch_api_call().
+        """
         self._sleeps.cancel()
-        await self._get_session.close()
-        del self._get_session
+        if self._session is not None:
+            await self._session.close()
+            self._session = None

--- a/app/connectors_service/connectors/sources/servicenow/datasource.py
+++ b/app/connectors_service/connectors/sources/servicenow/datasource.py
@@ -69,6 +69,16 @@ def _prefix_user_id(user_id):
     return prefix_identity("user_id", user_id)
 
 
+def _prefix_user(email):
+    """Return a 'user:<email>' identity token.
+
+    Uses the 'user' prefix (rather than 'email') to match the identity format
+    emitted by other connectors such as SharePoint and OneDrive, enabling
+    consistent cross-connector document-level security (DLS) evaluation.
+    """
+    return prefix_identity("user", email)
+
+
 class EndSignal(Enum):
     SERVICE = "SERVICE_TASK_FINISHED"
     RECORD = "RECORD_TASK_FINISHED"
@@ -116,27 +126,305 @@ class ServiceNowDataSource(BaseDataSource):
 
     @classmethod
     def get_default_configuration(cls):
+        """Return the default connector configuration schema.
+
+        Each key maps to a UI field definition understood by the Kibana connector
+        framework.  Fields use ``depends_on`` lists to declare which other field
+        value(s) must be active before the field is shown in the UI, so only the
+        fields relevant to the chosen Authentication Method and OAuth Grant Type
+        are ever visible to the user at one time.
+
+        Authentication modes
+        --------------------
+        ``auth_method = "basic"``
+            Shows: url, username, basic_auth_password, services (+ advanced fields)
+
+        ``auth_method = "oauth"``
+            Always shows: url, oauth_grant_type, client_id, client_secret,
+            services (+ advanced)
+
+            Then per grant type:
+
+            ``oauth_grant_type = "password"``
+                + oauth_username, oauth_password
+
+            ``oauth_grant_type = "client_credentials"``
+                (no extra fields)
+
+            ``oauth_grant_type = "refresh_token"``
+                + oauth_username_refresh, refresh_token
+
+            ``oauth_grant_type = "authorization_code"``
+                + client_secret, oauth_authorization_code, oauth_redirect_uri,
+                  pkce_code_verifier (optional)
+
+            ``oauth_grant_type = "jwt_bearer"``
+                + jwt_private_key, jwt_subject (optional), jwt_key_id (optional),
+                  jwt_algorithm
+                  (client_secret is optional and not shown by default)
+
+        Returns:
+            dict: Connector configuration schema.
+        """
         return {
             "url": {
                 "label": "Service URL",
                 "order": 1,
                 "type": "str",
             },
-            "username": {
-                "label": "Username",
+            "auth_method": {
+                "display": "dropdown",
+                "label": "Authentication Method",
+                "options": [
+                    {"label": "OAuth 2.0", "value": "oauth"},
+                    {"label": "Basic Auth (username / password)", "value": "basic"},
+                ],
                 "order": 2,
+                "tooltip": "Use 'OAuth 2.0' for token-based authentication (recommended). Use 'Basic Auth' for simple username and password authentication.",
                 "type": "str",
+                "value": "oauth",
             },
-            "password": {
-                "label": "Password",
+            "oauth_grant_type": {
+                "depends_on": [{"field": "auth_method", "value": "oauth"}],
+                "display": "dropdown",
+                "label": "OAuth Grant Type",
+                "options": [
+                    {"label": "Password", "value": "password"},
+                    {"label": "Client Credentials (requires non-PDI instance)", "value": "client_credentials"},
+                    {"label": "Refresh Token", "value": "refresh_token"},
+                    {"label": "Authorization Code", "value": "authorization_code"},
+                    {"label": "JWT Bearer", "value": "jwt_bearer"},
+                ],
                 "order": 3,
-                "sensitive": True,
+                "tooltip": (
+                    "Select the OAuth 2.0 grant type that matches your ServiceNow configuration. "
+                    "'Password' works on all instances including PDIs. "
+                    "'Client Credentials' is machine-to-machine (non-PDI only). "
+                    "'Refresh Token' exchanges a long-lived refresh token. "
+                    "'Authorization Code' completes the browser-based flow (supports PKCE). "
+                    "'JWT Bearer' uses a signed JWT assertion (requires a private key)."
+                ),
                 "type": "str",
+                "value": "password",
+                "required": False,
+            },
+            "client_id": {
+                "depends_on": [{"field": "auth_method", "value": "oauth"}],
+                "label": "OAuth Client ID",
+                "order": 4,
+                "tooltip": "Required when Authentication Method is 'OAuth 2.0'.",
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # client_secret is shown for all OAuth grant types.  Gated on
+            # auth_method=oauth only (single entry) so Kibana's OR evaluation
+            # doesn't cause it to bleed through to other states.
+            "client_secret": {
+                "depends_on": [{"field": "auth_method", "value": "oauth"}],
+                "label": "OAuth Client Secret",
+                "order": 5,
+                "sensitive": True,
+                "tooltip": (
+                    "Required for Password, Client Credentials, Refresh Token, and "
+                    "Authorization Code grant types. Optional for JWT Bearer — only "
+                    "include if your ServiceNow OAuth application requires it."
+                ),
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # ── Username (Basic Auth) ─────────────────────────────────────────
+            # depends_on uses AND semantics in the SDK: a field is shown only
+            # when ALL listed conditions are simultaneously true.  Because
+            # "basic" and "oauth" are mutually exclusive auth_method values,
+            # username for Basic Auth and username for OAuth must be separate
+            # field keys.
+            "username": {
+                "depends_on": [{"field": "auth_method", "value": "basic"}],
+                "label": "Username",
+                "order": 6,
+                "tooltip": "Required when Authentication Method is 'Basic Auth'.",
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # ── Basic Auth password ──────────────────────────────────────────
+            "basic_auth_password": {
+                "depends_on": [{"field": "auth_method", "value": "basic"}],
+                "label": "Password",
+                "order": 7,
+                "sensitive": True,
+                "tooltip": "Required when Authentication Method is 'Basic Auth'.",
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # ── OAuth Username (Password grant) ──────────────────────────────
+            # depends_on AND semantics: both conditions must be true simultaneously.
+            # A single field cannot satisfy two different values for the same key,
+            # so covering both Password and Refresh Token grant types requires two
+            # separate field entries — one per grant type.
+            "oauth_username": {
+                "depends_on": [
+                    {"field": "auth_method", "value": "oauth"},
+                    {"field": "oauth_grant_type", "value": "password"},
+                ],
+                "label": "Username",
+                "order": 8,
+                "tooltip": "Required when OAuth Grant Type is 'Password'.",
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # ── OAuth Username (Refresh Token grant) ─────────────────────────
+            "oauth_username_refresh": {
+                "depends_on": [
+                    {"field": "auth_method", "value": "oauth"},
+                    {"field": "oauth_grant_type", "value": "refresh_token"},
+                ],
+                "label": "Username",
+                "order": 8,
+                "tooltip": "Required when OAuth Grant Type is 'Refresh Token'.",
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # ── OAuth Password grant ─────────────────────────────────────────
+            # AND semantics: both conditions must hold simultaneously.
+            # oauth_grant_type alone is not sufficient because its default value
+            # is "password", which causes this field to bleed through to Basic
+            # Auth mode where oauth_grant_type is hidden but its stored value
+            # is still "password".
+            "oauth_password": {
+                "depends_on": [
+                    {"field": "auth_method", "value": "oauth"},
+                    {"field": "oauth_grant_type", "value": "password"},
+                ],
+                "label": "Password",
+                "order": 9,
+                "sensitive": True,
+                "tooltip": "Required when OAuth Grant Type is 'Password'.",
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # ── Refresh Token grant ──────────────────────────────────────────
+            # Gating on oauth_grant_type alone is safe here: "refresh_token" is
+            # never the default value of oauth_grant_type, so it cannot bleed
+            # through to Basic Auth mode.
+            "refresh_token": {
+                "depends_on": [{"field": "oauth_grant_type", "value": "refresh_token"}],
+                "label": "Refresh Token",
+                "order": 10,
+                "sensitive": True,
+                "tooltip": "Required when OAuth Grant Type is 'Refresh Token'.",
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # ── Authorization Code grant ─────────────────────────────────────
+            "oauth_authorization_code": {
+                "depends_on": [{"field": "oauth_grant_type", "value": "authorization_code"}],
+                "label": "Authorization Code",
+                "order": 10,
+                "sensitive": True,
+                "tooltip": (
+                    "The one-time authorization code returned by ServiceNow after the "
+                    "user completes the browser-based consent flow. Required when "
+                    "OAuth Grant Type is 'Authorization Code'."
+                ),
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            "oauth_redirect_uri": {
+                "depends_on": [{"field": "oauth_grant_type", "value": "authorization_code"}],
+                "label": "Redirect URI",
+                "order": 11,
+                "tooltip": (
+                    "The redirect URI registered in ServiceNow for this OAuth application. "
+                    "Must exactly match the URI used during the authorization flow."
+                ),
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            "pkce_code_verifier": {
+                "depends_on": [{"field": "oauth_grant_type", "value": "authorization_code"}],
+                "label": "PKCE Code Verifier",
+                "order": 12,
+                "sensitive": True,
+                "tooltip": (
+                    "Optional. The PKCE code verifier used when generating the "
+                    "authorization request. Leave blank if PKCE was not used."
+                ),
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            # ── JWT Bearer grant ─────────────────────────────────────────────
+            "jwt_private_key": {
+                "depends_on": [{"field": "oauth_grant_type", "value": "jwt_bearer"}],
+                "display": "textarea",
+                "label": "JWT Private Key (PEM)",
+                "order": 13,
+                "sensitive": True,
+                "tooltip": (
+                    "PEM-encoded RSA or EC private key used to sign the JWT assertion. "
+                    "Required when OAuth Grant Type is 'JWT Bearer'. "
+                    "Paste the full key including the -----BEGIN ... KEY----- header and footer."
+                ),
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            "jwt_subject": {
+                "depends_on": [{"field": "oauth_grant_type", "value": "jwt_bearer"}],
+                "label": "JWT Subject (sub)",
+                "order": 14,
+                "tooltip": (
+                    "Optional. The 'sub' claim in the JWT assertion. "
+                    "Defaults to the OAuth Client ID when left blank."
+                ),
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            "jwt_key_id": {
+                "depends_on": [{"field": "oauth_grant_type", "value": "jwt_bearer"}],
+                "label": "JWT Key ID (kid)",
+                "order": 15,
+                "tooltip": (
+                    "Optional. The 'kid' header in the JWT, used to identify the "
+                    "signing key on the ServiceNow side. Leave blank if not required."
+                ),
+                "type": "str",
+                "value": "",
+                "required": False,
+            },
+            "jwt_algorithm": {
+                "depends_on": [{"field": "oauth_grant_type", "value": "jwt_bearer"}],
+                "display": "dropdown",
+                "label": "JWT Signing Algorithm",
+                "options": [
+                    {"label": "RS256 (RSA, recommended)", "value": "RS256"},
+                    {"label": "RS384", "value": "RS384"},
+                    {"label": "RS512", "value": "RS512"},
+                    {"label": "ES256 (ECDSA)", "value": "ES256"},
+                    {"label": "ES384", "value": "ES384"},
+                    {"label": "ES512", "value": "ES512"},
+                ],
+                "order": 16,
+                "tooltip": "Algorithm used to sign the JWT assertion. RS256 is recommended.",
+                "type": "str",
+                "value": "RS256",
+                "required": False,
             },
             "services": {
                 "display": "textarea",
                 "label": "Comma-separated list of services",
-                "order": 4,
+                "order": 17,
                 "tooltip": "List of services is ignored when Advanced Sync Rules are used.",
                 "type": "list",
                 "value": "*",
@@ -145,7 +433,7 @@ class ServiceNowDataSource(BaseDataSource):
                 "default_value": RETRIES,
                 "display": "numeric",
                 "label": "Retries per request",
-                "order": 5,
+                "order": 18,
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
@@ -154,7 +442,7 @@ class ServiceNowDataSource(BaseDataSource):
                 "default_value": MAX_CONCURRENT_CLIENT_SUPPORT,
                 "display": "numeric",
                 "label": "Maximum concurrent downloads",
-                "order": 6,
+                "order": 19,
                 "required": False,
                 "type": "int",
                 "ui_restrictions": ["advanced"],
@@ -162,7 +450,7 @@ class ServiceNowDataSource(BaseDataSource):
             "use_text_extraction_service": {
                 "display": "toggle",
                 "label": "Use text extraction service",
-                "order": 7,
+                "order": 20,
                 "tooltip": "Requires a separate deployment of the Elastic Text Extraction Service. Requires that pipeline settings disable text extraction.",
                 "type": "bool",
                 "ui_restrictions": ["advanced"],
@@ -171,7 +459,7 @@ class ServiceNowDataSource(BaseDataSource):
             "use_document_level_security": {
                 "display": "toggle",
                 "label": "Enable document level security",
-                "order": 8,
+                "order": 21,
                 "tooltip": "Document level security ensures identities and permissions set in ServiceNow are maintained in Elasticsearch. This enables you to restrict and personalize read-access users and groups have to documents in this index. Access control syncs ensure this metadata is kept up to date in your Elasticsearch documents.",
                 "type": "bool",
                 "value": False,
@@ -193,6 +481,21 @@ class ServiceNowDataSource(BaseDataSource):
         return self.configuration["use_document_level_security"]
 
     async def _user_access_control_doc(self, user):
+        """Build an Elasticsearch access-control document for a ServiceNow user.
+
+        Emits four identity tokens so that DLS queries can match the user
+        regardless of which token format was indexed by a peer connector:
+          - user_id:<sys_id>      (ServiceNow internal ID)
+          - username:<user_name>  (login name)
+          - email:<email>         (RFC 5321 address)
+          - user:<email>          (cross-connector format; matches SharePoint / OneDrive)
+
+        Args:
+            user (dict): A user record as returned by _fetch_all_users().
+
+        Returns:
+            dict: Access-control document ready for bulk indexing.
+        """
         user_id = user.get("_id", "")
         user_name = user.get("user_name", "")
         user_email = user.get("email", "")
@@ -200,6 +503,7 @@ class ServiceNowDataSource(BaseDataSource):
         _prefixed_user_id = _prefix_user_id(user_id=user_id)
         _prefixed_user_name = _prefix_username(user=user_name)
         _prefixed_email = _prefix_email(email=user_email)
+        _prefixed_user = _prefix_user(user_email)  # cross-connector format
         return {
             "_id": user_id,
             "identity": {
@@ -209,7 +513,7 @@ class ServiceNowDataSource(BaseDataSource):
             },
             "created_at": user.get("_timestamp"),
         } | es_access_control_query(
-            access_control=[_prefixed_user_id, _prefixed_user_name, _prefixed_email]
+            access_control=[_prefixed_user_id, _prefixed_user_name, _prefixed_email, _prefixed_user]
         )
 
     async def _fetch_all_users(self):
@@ -413,6 +717,14 @@ class ServiceNowDataSource(BaseDataSource):
 
     async def _fetch_access_controls(self, table_name):
         access_control, user_roles, roles = [], [], {}
+
+        # Build a sys_id -> email map from the full user list so role-based
+        # lookups (which only return a sys_id reference) can emit user:<email>
+        # tokens that match the format used by other connectors (SharePoint, OneDrive).
+        user_email_map = {}
+        async for u in self._fetch_all_users():
+            user_email_map[u.get("sys_id")] = u.get("email", "")
+
         if table_name in DEFAULT_SERVICE_NAMES.keys():
             async for role in self._table_data_generator(
                 service_name="sys_user_role", params={}
@@ -420,10 +732,23 @@ class ServiceNowDataSource(BaseDataSource):
                 roles[role.get("name")] = role.get("sys_id")
 
             for role in DEFAULT_SERVICE_NAMES.get(table_name, []):
-                async for user in self._fetch_users_by_roles(roles[role]):
-                    access_control.append(
-                        _prefix_user_id(user_id=user.get("user", {}).get("value"))
+                role_sys_id = roles.get(role)
+                if role_sys_id is None:
+                    # Role defined in DEFAULT_SERVICE_NAMES but absent from the
+                    # instance's sys_user_role table — skip rather than KeyError.
+                    self._logger.warning(
+                        f"Role '{role}' not found in sys_user_role for table '{table_name}'. Skipping."
                     )
+                    continue
+                async for user in self._fetch_users_by_roles(role_sys_id):
+                    uid = user.get("user", {}).get("value")
+                    # Prefer user:<email> for cross-connector DLS consistency;
+                    # fall back to user_id:<sys_id> when email is unavailable.
+                    email = user_email_map.get(uid, "")
+                    if email:
+                        access_control.append(_prefix_user(email))
+                    else:
+                        access_control.append(_prefix_user_id(uid))
         else:
             async for role in self._table_data_generator(
                 service_name="sys_user_role", params={}
@@ -448,14 +773,22 @@ class ServiceNowDataSource(BaseDataSource):
                         f"Found public role in {table_name}, Fetching all users."
                     )
                     async for user in self._fetch_all_users():
-                        access_control.append(
-                            _prefix_user_id(user_id=user.get("sys_id"))
-                        )
+                        uid = user.get("sys_id")
+                        # Prefer user:<email>; fall back to user_id:<sys_id>.
+                        email = user_email_map.get(uid, "")
+                        if email:
+                            access_control.append(_prefix_user(email))
+                        else:
+                            access_control.append(_prefix_user_id(uid))
 
                 async for user in self._fetch_users_by_roles(role):
-                    access_control.append(
-                        _prefix_user_id(user_id=user.get("user", {}).get("value"))
-                    )
+                    uid = user.get("user", {}).get("value")
+                    # Prefer user:<email>; fall back to user_id:<sys_id>.
+                    email = user_email_map.get(uid, "")
+                    if email:
+                        access_control.append(_prefix_user(email))
+                    else:
+                        access_control.append(_prefix_user_id(uid))
         return list(set(access_control))
 
     async def _get_batched_apis(self, service_name, params):

--- a/app/connectors_service/tests/sources/test_servicenow.py
+++ b/app/connectors_service/tests/sources/test_servicenow.py
@@ -75,9 +75,13 @@ class StreamerReader:
         yield self._res
 
 
-@pytest.mark.parametrize("field", ["username", "password", "services"])
+@pytest.mark.parametrize("field", ["services"])
 @pytest.mark.asyncio
 async def test_validate_config_missing_fields_then_raise(field):
+    # username is conditional (depends_on auth_method/grant_type) so omitting
+    # it does not raise for the default oauth+password config used in this test.
+    # basic_auth_password / oauth_password are tested via their own grant-type
+    # paths. Only 'services' is unconditionally required.
     async with create_service_now_source() as source:
         source.configuration.get_field(field).value = ""
 
@@ -960,6 +964,7 @@ async def test_get_access_control():
                         "user_id:id_1",
                         "username:demo.user",
                         "email:admin@email.com",
+                        "user:admin@email.com",
                     ]
                 },
                 "source": DLS_QUERY,
@@ -1008,6 +1013,9 @@ async def test_fetch_access_control():
             ServiceNowDataSource,
             "_table_data_generator",
             side_effect=[
+                # 1st call: _fetch_all_users() → user_email_map (no email → empty map)
+                AsyncIterator([]),
+                # 2nd call: sys_user_role → roles dict
                 AsyncIterator(
                     [
                         {
@@ -1016,6 +1024,7 @@ async def test_fetch_access_control():
                         },
                     ]
                 ),
+                # 3rd call: sys_security_acl_role → user_roles list
                 AsyncIterator(
                     [
                         {
@@ -1023,6 +1032,7 @@ async def test_fetch_access_control():
                         },
                     ]
                 ),
+                # 4th call: _fetch_users_by_roles(role_id_1) → users
                 AsyncIterator([{"user": {"value": "user_id_1"}}]),
             ],
         ):
@@ -1037,21 +1047,7 @@ async def test_fetch_access_control_for_public():
             ServiceNowDataSource,
             "_table_data_generator",
             side_effect=[
-                AsyncIterator(
-                    [
-                        {
-                            "sys_id": "role_id_1",
-                            "name": "public",
-                        },
-                    ]
-                ),
-                AsyncIterator(
-                    [
-                        {
-                            "sys_user_role": {"value": "role_id_1"},
-                        },
-                    ]
-                ),
+                # 1st call: _fetch_all_users() → user_email_map
                 AsyncIterator(
                     [
                         {
@@ -1063,17 +1059,52 @@ async def test_fetch_access_control_for_public():
                         {
                             "sys_updated_on": "2023-10-10 05:21:45",
                             "sys_id": "user_id_2",
-                            "email": "admin@email.com",
+                            "email": "sample@email.com",
                             "user_name": "sample.user",
                         },
                     ]
                 ),
+                # 2nd call: sys_user_role → roles dict
+                AsyncIterator(
+                    [
+                        {
+                            "sys_id": "role_id_1",
+                            "name": "public",
+                        },
+                    ]
+                ),
+                # 3rd call: sys_security_acl_role → user_roles list
+                AsyncIterator(
+                    [
+                        {
+                            "sys_user_role": {"value": "role_id_1"},
+                        },
+                    ]
+                ),
+                # 4th call: _fetch_all_users() for the public role → all users
+                AsyncIterator(
+                    [
+                        {
+                            "sys_updated_on": "2023-10-10 05:21:45",
+                            "sys_id": "user_id_1",
+                            "email": "admin@email.com",
+                            "user_name": "demo.user",
+                        },
+                        {
+                            "sys_updated_on": "2023-10-10 05:21:45",
+                            "sys_id": "user_id_2",
+                            "email": "sample@email.com",
+                            "user_name": "sample.user",
+                        },
+                    ]
+                ),
+                # 5th call: _fetch_users_by_roles(role_id_1) → users
                 AsyncIterator([{"user": {"value": "user_id_1"}}]),
             ],
         ):
             access_control = await source._fetch_access_controls("service_name")
             assert sorted(access_control) == sorted(
-                ["user_id:user_id_1", "user_id:user_id_2"]
+                ["user:admin@email.com", "user:sample@email.com"]
             )
 
 
@@ -1091,3 +1122,303 @@ async def test_end_signal_is_added_to_queue_in_case_of_exception():
                     records_ids=["record_1", "record_2"], access_control=[]
                 )
                 assert source.queue.get_nowait() == END_SIGNAL
+
+
+# ── OAuth grant type tests ────────────────────────────────────────────────────
+
+def _make_token_response(access_token="tok_abc", expires_in=1800, refresh_token=None):
+    """Return a minimal mock JSON payload matching ServiceNow's token endpoint."""
+    payload = {"access_token": access_token, "expires_in": expires_in}
+    if refresh_token:
+        payload["refresh_token"] = refresh_token
+    return payload
+
+
+def _mock_token_post(token_payload, status=200):
+    """Construct a nested mock that makes aiohttp.ClientSession().post() work."""
+    response = mock.AsyncMock()
+    response.status = status
+    response.json = mock.AsyncMock(return_value=token_payload)
+    response.raise_for_status = mock.MagicMock()
+    ctx = mock.AsyncMock()
+    ctx.__aenter__ = mock.AsyncMock(return_value=response)
+    ctx.__aexit__ = mock.AsyncMock(return_value=False)
+    session = mock.AsyncMock()
+    session.post = mock.MagicMock(return_value=ctx)
+    session_ctx = mock.AsyncMock()
+    session_ctx.__aenter__ = mock.AsyncMock(return_value=session)
+    session_ctx.__aexit__ = mock.AsyncMock(return_value=False)
+    return session_ctx, session
+
+
+def _make_client(extra_config=None):
+    """Return a ServiceNowClient with a minimal valid configuration."""
+    from connectors_sdk.source import DataSourceConfiguration
+
+    config_dict = ServiceNowDataSource.get_default_configuration()
+    defaults = {
+        "url": "https://dev12345.service-now.com",
+        "username": "basic_admin",       # Basic Auth username field
+        "oauth_username": "admin",           # OAuth username field (password grant)
+        "oauth_username_refresh": "admin",   # OAuth username field (refresh_token grant)
+        "services": "*",
+        "client_id": "test_client_id",
+        "client_secret": "test_client_secret",
+        "oauth_password": "test_password",
+        "basic_auth_password": "test_basic_pw",
+    }
+    for k, v in defaults.items():
+        if k in config_dict:
+            config_dict[k]["value"] = v
+    if extra_config:
+        for k, v in extra_config.items():
+            if k in config_dict:
+                config_dict[k]["value"] = v
+            else:
+                from connectors_sdk.source import DEFAULT_CONFIGURATION
+                config_dict[k] = DEFAULT_CONFIGURATION.copy() | {"value": v}
+    return ServiceNowClient(configuration=DataSourceConfiguration(config_dict))
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_password_grant():
+    """Password grant: username + password are sent to the token endpoint."""
+    client = _make_client({"oauth_grant_type": "password"})
+    token_payload = _make_token_response()
+    session_ctx, session = _mock_token_post(token_payload)
+
+    with mock.patch("aiohttp.ClientSession", return_value=session_ctx):
+        token = await client._fetch_access_token()
+
+    assert token == "tok_abc"
+    call_kwargs = session.post.call_args
+    sent_data = call_kwargs[1]["data"]
+    assert sent_data["grant_type"] == "password"
+    assert sent_data["username"] == "admin"
+    assert sent_data["password"] == "test_password"
+    assert sent_data["client_id"] == "test_client_id"
+    assert sent_data["client_secret"] == "test_client_secret"
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_client_credentials_grant():
+    """Client Credentials grant: no username or password in the request."""
+    client = _make_client({"oauth_grant_type": "client_credentials"})
+    token_payload = _make_token_response()
+    session_ctx, session = _mock_token_post(token_payload)
+
+    with mock.patch("aiohttp.ClientSession", return_value=session_ctx):
+        token = await client._fetch_access_token()
+
+    assert token == "tok_abc"
+    sent_data = session.post.call_args[1]["data"]
+    assert sent_data["grant_type"] == "client_credentials"
+    assert "username" not in sent_data
+    assert "password" not in sent_data
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_refresh_token_grant():
+    """Refresh Token grant: refresh_token value sent, no password."""
+    client = _make_client({
+        "oauth_grant_type": "refresh_token",
+        "refresh_token": "my_refresh_tok",
+    })
+    token_payload = _make_token_response()
+    session_ctx, session = _mock_token_post(token_payload)
+
+    with mock.patch("aiohttp.ClientSession", return_value=session_ctx):
+        token = await client._fetch_access_token()
+
+    assert token == "tok_abc"
+    sent_data = session.post.call_args[1]["data"]
+    assert sent_data["grant_type"] == "refresh_token"
+    assert sent_data["username"] == "admin"
+    assert sent_data["refresh_token"] == "my_refresh_tok"
+    assert "password" not in sent_data
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_authorization_code_grant_first_call():
+    """Authorization Code grant: first call exchanges the authorization code."""
+    client = _make_client({
+        "oauth_grant_type": "authorization_code",
+        "oauth_authorization_code": "one_time_code_xyz",
+        "oauth_redirect_uri": "https://myapp.example.com/callback",
+    })
+    token_payload = _make_token_response(refresh_token="returned_refresh")
+    session_ctx, session = _mock_token_post(token_payload)
+
+    with mock.patch("aiohttp.ClientSession", return_value=session_ctx):
+        token = await client._fetch_access_token()
+
+    assert token == "tok_abc"
+    sent_data = session.post.call_args[1]["data"]
+    assert sent_data["grant_type"] == "authorization_code"
+    assert sent_data["code"] == "one_time_code_xyz"
+    assert sent_data["redirect_uri"] == "https://myapp.example.com/callback"
+    # The returned refresh token should be cached for subsequent calls
+    assert client._cached_refresh_token == "returned_refresh"
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_authorization_code_grant_subsequent_call():
+    """Authorization Code grant: subsequent calls use the cached refresh token."""
+    client = _make_client({
+        "oauth_grant_type": "authorization_code",
+        "oauth_authorization_code": "one_time_code_xyz",
+        "oauth_redirect_uri": "https://myapp.example.com/callback",
+    })
+    # Pre-seed the cached refresh token as if a first call already happened
+    client._cached_refresh_token = "cached_refresh_tok"
+    token_payload = _make_token_response()
+    session_ctx, session = _mock_token_post(token_payload)
+
+    with mock.patch("aiohttp.ClientSession", return_value=session_ctx):
+        token = await client._fetch_access_token()
+
+    assert token == "tok_abc"
+    sent_data = session.post.call_args[1]["data"]
+    # Should use refresh_token grant internally, not authorization_code
+    assert sent_data["grant_type"] == "refresh_token"
+    assert sent_data["refresh_token"] == "cached_refresh_tok"
+    assert "code" not in sent_data
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_authorization_code_grant_with_pkce():
+    """Authorization Code + PKCE: code_verifier is included in the request."""
+    client = _make_client({
+        "oauth_grant_type": "authorization_code",
+        "oauth_authorization_code": "pkce_code_abc",
+        "oauth_redirect_uri": "https://myapp.example.com/callback",
+        "pkce_code_verifier": "my_code_verifier_string",
+    })
+    token_payload = _make_token_response()
+    session_ctx, session = _mock_token_post(token_payload)
+
+    with mock.patch("aiohttp.ClientSession", return_value=session_ctx):
+        await client._fetch_access_token()
+
+    sent_data = session.post.call_args[1]["data"]
+    assert sent_data["code_verifier"] == "my_code_verifier_string"
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_jwt_bearer_grant():
+    """JWT Bearer grant: assertion field is built and sent."""
+    import connectors.sources.servicenow.client as sn_client
+
+    client = _make_client({
+        "oauth_grant_type": "jwt_bearer",
+        "jwt_private_key": "dummy_pem_key",
+        "jwt_subject": "svc_account",
+        "jwt_key_id": "key-1",
+        "jwt_algorithm": "RS256",
+    })
+    token_payload = _make_token_response()
+    session_ctx, session = _mock_token_post(token_payload)
+
+    # Mock PyJWT availability and signing
+    with mock.patch.object(sn_client, "_PYJWT_AVAILABLE", True):
+        with mock.patch.object(sn_client, "pyjwt") as mock_jwt:
+            mock_jwt.encode = mock.MagicMock(return_value="signed_jwt_assertion")
+            with mock.patch("aiohttp.ClientSession", return_value=session_ctx):
+                token = await client._fetch_access_token()
+
+    assert token == "tok_abc"
+    sent_data = session.post.call_args[1]["data"]
+    assert sent_data["grant_type"] == "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    assert sent_data["assertion"] == "signed_jwt_assertion"
+    assert sent_data["client_id"] == "test_client_id"
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_jwt_bearer_no_pyjwt_raises():
+    """JWT Bearer grant raises RuntimeError when PyJWT is not installed."""
+    import connectors.sources.servicenow.client as sn_client
+    from connectors.sources.servicenow.client import InvalidResponse
+
+    client = _make_client({
+        "oauth_grant_type": "jwt_bearer",
+        "jwt_private_key": "dummy_pem_key",
+    })
+
+    with mock.patch.object(sn_client, "_PYJWT_AVAILABLE", False):
+        with pytest.raises(RuntimeError, match="PyJWT is required"):
+            await client._fetch_access_token()
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_jwt_bearer_no_private_key_raises():
+    """JWT Bearer grant raises InvalidResponse when private key is missing."""
+    import connectors.sources.servicenow.client as sn_client
+    from connectors.sources.servicenow.client import InvalidResponse
+
+    client = _make_client({
+        "oauth_grant_type": "jwt_bearer",
+        "jwt_private_key": "",
+    })
+
+    with mock.patch.object(sn_client, "_PYJWT_AVAILABLE", True):
+        with pytest.raises(InvalidResponse, match="jwt_private_key must be set"):
+            await client._fetch_access_token()
+
+
+@pytest.mark.asyncio
+async def test_fetch_access_token_missing_access_token_raises():
+    """Any grant type raises InvalidResponse when access_token is absent."""
+    client = _make_client({"oauth_grant_type": "client_credentials"})
+    # Token endpoint returns a response without access_token
+    session_ctx, _ = _mock_token_post({"expires_in": 1800})
+
+    with mock.patch("aiohttp.ClientSession", return_value=session_ctx):
+        with pytest.raises(Exception, match="access_token"):
+            await client._fetch_access_token()
+
+def test_ui_field_dependencies():
+    """Verify field dependency and visibility rules for UI rendering:
+    - Basic Auth shows only 'username' and 'basic_auth_password' (under auth_method)
+    - OAuth Password grant shows 'client_id', 'client_secret', 'oauth_username', 'oauth_password'
+    - OAuth Refresh Token grant shows 'client_id', 'client_secret', 'oauth_username_refresh', 'refresh_token'
+
+    depends_on uses AND semantics in the SDK: all conditions must be true
+    simultaneously.  Because a single field value cannot satisfy two different
+    values at once, the username field is split into two entries — one per
+    grant type — and oauth_password is also gated on auth_method=oauth to
+    prevent it bleeding through when Basic Auth is selected (the default
+    oauth_grant_type value of "password" would otherwise match).
+    """
+    config = ServiceNowDataSource.get_default_configuration()
+
+    # Basic Auth fields
+    assert config["username"]["depends_on"] == [{"field": "auth_method", "value": "basic"}]
+    assert config["basic_auth_password"]["depends_on"] == [{"field": "auth_method", "value": "basic"}]
+
+    # OAuth core fields
+    assert config["oauth_grant_type"]["depends_on"] == [{"field": "auth_method", "value": "oauth"}]
+    assert config["client_id"]["depends_on"] == [{"field": "auth_method", "value": "oauth"}]
+    assert config["client_secret"]["depends_on"] == [{"field": "auth_method", "value": "oauth"}]
+
+    # OAuth username — separate field per grant type (AND semantics prevents a
+    # single entry covering two different grant-type values simultaneously)
+    assert config["oauth_username"]["depends_on"] == [
+        {"field": "auth_method", "value": "oauth"},
+        {"field": "oauth_grant_type", "value": "password"},
+    ]
+    assert config["oauth_username_refresh"]["depends_on"] == [
+        {"field": "auth_method", "value": "oauth"},
+        {"field": "oauth_grant_type", "value": "refresh_token"},
+    ]
+
+    # OAuth password — AND-gated on both auth_method and grant type to prevent
+    # bleeding through to Basic Auth (where oauth_grant_type defaults to "password")
+    assert config["oauth_password"]["depends_on"] == [
+        {"field": "auth_method", "value": "oauth"},
+        {"field": "oauth_grant_type", "value": "password"},
+    ]
+
+    # Refresh token (shown for refresh_token grant type)
+    assert config["refresh_token"]["depends_on"] == [
+        {"field": "oauth_grant_type", "value": "refresh_token"}
+    ]


### PR DESCRIPTION
Created OAuth 2.0 logic to be used with Service Connector and user:email for DLS

## Closes https://github.com/elastic/connectors-py/issues/4420 & https://github.com/elastic/connectors-py/issues/4428


<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [X] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [X] this PR has a meaningful title
- [X] this PR links to all relevant github issues that it fixes or partially addresses
- [X] this PR has a thorough description
- [X] Covered the changes with automated tests
- [X] Tested the changes locally
- [X] Considered corresponding documentation changes

#### Documentation Changes Needed:

Under the configuration section

Add: Authentication Type (Basic or OAuth 2.0)

Add: Grant Type: (Password, Client Credentials, Refresh Token, Authorization Code, JWT Bearer)

Additional Fields based on Grant Type:

OAuth Client ID
OAuth Client Secret
Refresh Token
Authorization Code 
Redirect URI
PKCE Code Verifier
JWT Private Key (PEM)
JWT Subject (sub)
JWT Key ID (kid)
JWT Signing Algorithm 

## Release Note

OAuth 2.0 capability added for ServiceNow connector with different Grant Types (Password, Client Credentials, Refresh Token, Authorization Code, JWT Bearer).  Pull Request #4432
