### PR TITLE
[8.19] fix(fips): MD5 will be blocked in FIPS environment without flag (#4416)

### DIFF
--- a/connectors/utils.py
+++ b/connectors/utils.py
@@ -754,8 +754,9 @@ def get_pem_format(key, postfix="-----END CERTIFICATE-----"):
 def hash_id(_id):
     # Collision probability: 1.47*10^-29
     # S105 rule considers this code unsafe, but we're not using it for security-related
-    # things, only to generate pseudo-ids for documents
-    return hashlib.md5(_id.encode("utf8")).hexdigest()  # noqa S105
+    # things, only to generate pseudo-ids for documents. useforsecurity=False tells the md5 method that
+    # we are NOT using this for security, otherwise FIPS would block this
+    return hashlib.md5(_id.encode("utf8"), usedforsecurity=False).hexdigest()  # noqa S105
 
 
 def truncate_id(_id):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1113,6 +1113,28 @@ def test_hash_id():
     assert len(hash_id(random_id_too_long).encode("UTF-8")) < limit
 
 
+def test_hash_id_fips_compatible(monkeypatch):
+    """hash_id must pass usedforsecurity=False to work on FIPS-enabled systems.
+
+    On a FIPS-enabled host, OpenSSL raises ValueError for hashlib.md5() unless
+    usedforsecurity=False is set. This test simulates that enforcement.
+    """
+    import hashlib as _hashlib
+
+    original_md5 = _hashlib.md5
+
+    def fips_strict_md5(data, usedforsecurity=True):
+        if usedforsecurity:
+            msg = "[digital envelope routines] unsupported (simulated FIPS mode)"
+            raise ValueError(msg)
+        return original_md5(data, usedforsecurity=False)
+
+    monkeypatch.setattr(_hashlib, "md5", fips_strict_md5)
+
+    result = hash_id("some-document-id")
+    assert len(result) == 32
+
+
 def test_truncate_id():
     long_id = "something-12341361361-21905128510263"
     truncated_id = truncate_id(long_id)


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix(fips): MD5 will be blocked in FIPS environment without flag (#4416)