### PR TITLE
test(s3): mock AWS client in close-with-session test

### DIFF
--- a/app/connectors_service/NOTICE.txt
+++ b/app/connectors_service/NOTICE.txt
@@ -1750,7 +1750,7 @@ SOFTWARE.
 
 
 anyio
-4.14.2
+4.15.0
 MIT
 The MIT License (MIT)
 
@@ -4241,7 +4241,7 @@ Apache Software License
 
 
 google-auth
-2.57.0
+2.57.1
 Apache Software License
                                  Apache License
                            Version 2.0, January 2004

--- a/app/connectors_service/tests/sources/test_s3.py
+++ b/app/connectors_service/tests/sources/test_s3.py
@@ -494,14 +494,16 @@ async def test_get_content_with_clienterror():
 @pytest.mark.asyncio
 async def test_close_with_client_session():
     """Test close method of S3DataSource with client session"""
-
     async with create_s3_source() as source:
-        source.session = aioboto3.Session()
-        await source.s3_client.client()
-
-        await source.close()
-        with pytest.raises(ClientError):
-            await source.ping()
+        with (
+            mock.patch("aiobotocore.client.AioBaseClient", S3Object),
+            mock.patch(
+                "contextlib.AsyncExitStack.aclose", new_callable=mock.AsyncMock
+            ) as aclose_mock,
+        ):
+            await source.s3_client.client()
+            await source.close()
+            aclose_mock.assert_awaited_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`test_close_with_client_session` was making real AWS `ListBuckets` HTTP calls with dummy credentials. That caused slow, flaky failures under `--fail-slow=1` when network latency exceeded 1s.

The test now mocks the S3 client (same pattern as `test_ping`) and asserts that `close()` tears down the `AsyncExitStack` used for the client session.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [x] Contributed any configuration settings changes to the configuration reference
- [x] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4441 — Outlook LDAP retry fix (where the flake was first observed)

## Release Note

n/a — test-only change.

Made with [Cursor](https://cursor.com)