### PR TITLE
test: mock real I/O in unit tests to stop fail-slow flakes

### DIFF
--- a/app/connectors_service/connectors/sources/graphql/client.py
+++ b/app/connectors_service/connectors/sources/graphql/client.py
@@ -257,10 +257,8 @@ class GraphQLClient:
 
     async def close(self):
         self._sleeps.cancel()
-        session = self.__dict__.get("session")
-        if session is not None:
-            await session.close()
-            del self.session
+        await self.session.close()
+        del self.session
 
     async def ping(self):
         await self.make_request(graphql_query=PING_QUERY)

--- a/app/connectors_service/connectors/sources/graphql/client.py
+++ b/app/connectors_service/connectors/sources/graphql/client.py
@@ -257,8 +257,10 @@ class GraphQLClient:
 
     async def close(self):
         self._sleeps.cancel()
-        await self.session.close()
-        del self.session
+        session = self.__dict__.get("session")
+        if session is not None:
+            await session.close()
+            del self.session
 
     async def ping(self):
         await self.make_request(graphql_query=PING_QUERY)

--- a/app/connectors_service/tests/sources/test_generic_database.py
+++ b/app/connectors_service/tests/sources/test_generic_database.py
@@ -5,7 +5,9 @@
 #
 """Tests the Generic Database source class methods"""
 
+from contextlib import contextmanager
 from functools import partial
+from unittest.mock import patch
 
 import pytest
 
@@ -118,6 +120,15 @@ class CursorSync:
                     ),
                 ]
         return []
+
+
+@contextmanager
+def mock_sync_db_engine(create_engine_target, query_object):
+    """Mock SQLAlchemy engine creation for sync database connector tests."""
+    with patch(create_engine_target) as mock_create_engine:
+        mock_engine = mock_create_engine.return_value
+        mock_engine.connect.return_value = ConnectionSync(query_object)
+        yield mock_engine
 
 
 @pytest.mark.parametrize(

--- a/app/connectors_service/tests/sources/test_gitlab.py
+++ b/app/connectors_service/tests/sources/test_gitlab.py
@@ -1642,6 +1642,7 @@ class TestGitLabDataSourceIntegration:
 
         source.gitlab_client.get_projects = mock_get_projects
         source.gitlab_client.get_work_items_project = mock_get_work_items
+        source.gitlab_client.get_work_items_group = lambda *a, **k: async_gen_empty()
         source.gitlab_client.get_merge_requests = mock_get_merge_requests
         source.gitlab_client.get_releases = mock_get_releases
         source.gitlab_client.fetch_remaining_work_item_assignees = (
@@ -1729,6 +1730,7 @@ class TestGitLabDataSourceIntegration:
 
         source.gitlab_client.get_projects = mock_get_projects
         source.gitlab_client.get_work_items_project = mock_get_work_items
+        source.gitlab_client.get_work_items_group = lambda *a, **k: async_gen_empty()
         source.gitlab_client.get_merge_requests = lambda *a, **k: async_gen_empty()
         source.gitlab_client.get_releases = lambda *a, **k: async_gen_empty()
         source.gitlab_client.fetch_remaining_work_item_assignees = (
@@ -2150,6 +2152,7 @@ class TestGitLabDataSourceIntegration:
 
         source.gitlab_client.get_projects = mock_get_projects
         source.gitlab_client.get_work_items_project = lambda *a, **k: async_gen_empty()
+        source.gitlab_client.get_work_items_group = lambda *a, **k: async_gen_empty()
         source.gitlab_client.get_merge_requests = mock_get_mrs
         source.gitlab_client.get_releases = lambda *a, **k: async_gen_empty()
         source.gitlab_client.fetch_remaining_field = mock_remaining_field
@@ -2206,6 +2209,7 @@ class TestGitLabDataSourceIntegration:
 
         source.gitlab_client.get_projects = mock_get_projects
         source.gitlab_client.get_work_items_project = lambda *a, **k: async_gen_empty()
+        source.gitlab_client.get_work_items_group = lambda *a, **k: async_gen_empty()
         source.gitlab_client.get_merge_requests = lambda *a, **k: async_gen_empty()
         source.gitlab_client.get_releases = mock_get_releases
         source.gitlab_client._get_rest = AsyncMock(return_value=[])

--- a/app/connectors_service/tests/sources/test_graphql.py
+++ b/app/connectors_service/tests/sources/test_graphql.py
@@ -320,6 +320,15 @@ async def test_fetch_data_without_pageinfo():
 
 
 @pytest.mark.asyncio
+async def test_close_without_open_session_does_not_create_client():
+    with patch("aiohttp.ClientSession") as mock_client_session:
+        async with create_graphql_source():
+            pass
+
+        mock_client_session.assert_not_called()
+
+
+@pytest.mark.asyncio
 @freeze_time("2024-01-24T04:07:19")
 async def test_get_docs():
     expected_response = [

--- a/app/connectors_service/tests/sources/test_graphql.py
+++ b/app/connectors_service/tests/sources/test_graphql.py
@@ -46,16 +46,22 @@ async def create_graphql_source(
     graphql_query="{users {name {firstName } } }",
     graphql_object_to_id_map='{"users": "id"}',
 ):
-    async with create_source(
-        GraphQLDataSource,
-        http_endpoint="http://127.0.0.1:1234",
-        authentication_method="none",
-        graphql_query=graphql_query,
-        graphql_object_to_id_map=graphql_object_to_id_map,
-        headers=headers,
-        graphql_variables=graphql_variables,
-    ) as source:
-        yield source
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    with patch(
+        "connectors.sources.graphql.client.aiohttp.ClientSession",
+        return_value=mock_session,
+    ):
+        async with create_source(
+            GraphQLDataSource,
+            http_endpoint="http://127.0.0.1:1234",
+            authentication_method="none",
+            graphql_query=graphql_query,
+            graphql_object_to_id_map=graphql_object_to_id_map,
+            headers=headers,
+            graphql_variables=graphql_variables,
+        ) as source:
+            yield source
 
 
 @pytest.mark.asyncio
@@ -320,12 +326,13 @@ async def test_fetch_data_without_pageinfo():
 
 
 @pytest.mark.asyncio
-async def test_close_without_open_session_does_not_create_client():
-    with patch("aiohttp.ClientSession") as mock_client_session:
+async def test_teardown_does_not_use_real_client_session():
+    """Regression: source teardown must not instantiate a real aiohttp.ClientSession."""
+    with patch("aiohttp.ClientSession") as real_client_session:
         async with create_graphql_source():
             pass
 
-        mock_client_session.assert_not_called()
+        real_client_session.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/app/connectors_service/tests/sources/test_mssql.py
+++ b/app/connectors_service/tests/sources/test_mssql.py
@@ -10,7 +10,6 @@ from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
 from connectors_sdk.filtering.validation import Filter, SyncRuleValidationResult
-from sqlalchemy.engine import Engine
 from sqlalchemy.exc import ProgrammingError
 
 from connectors.sources.mssql import (
@@ -19,7 +18,9 @@ from connectors.sources.mssql import (
     MSSQLQueries,
 )
 from tests.sources.support import create_source
-from tests.sources.test_generic_database import ConnectionSync
+from tests.sources.test_generic_database import ConnectionSync, mock_sync_db_engine
+
+MSSQL_CREATE_ENGINE = "connectors.sources.mssql.client.create_engine"
 
 ADVANCED_SNIPPET = "advanced_snippet"
 
@@ -43,10 +44,7 @@ class MockEngine:
 @pytest.mark.asyncio
 async def test_ping():
     async with create_source(MSSQLDataSource) as source:
-        source.engine = MockEngine()
-        with patch.object(
-            Engine, "connect", return_value=ConnectionSync(MSSQLQueries())
-        ):
+        with mock_sync_db_engine(MSSQL_CREATE_ENGINE, MSSQLQueries()):
             await source.ping()
 
 
@@ -55,7 +53,10 @@ async def test_ping():
 async def test_ping_negative():
     with pytest.raises(Exception):
         async with create_source(MSSQLDataSource) as source:
-            with patch.object(Engine, "connect", side_effect=Exception()):
+            with mock_sync_db_engine(
+                MSSQL_CREATE_ENGINE, MSSQLQueries()
+            ) as mock_engine:
+                mock_engine.connect.side_effect = Exception()
                 await source.ping()
 
 
@@ -150,9 +151,7 @@ async def test_get_docs():
     async with create_source(
         MSSQLDataSource, database="xe", tables="*", schema="dbo"
     ) as source:
-        with patch.object(
-            Engine, "connect", return_value=ConnectionSync(MSSQLQueries())
-        ):
+        with mock_sync_db_engine(MSSQL_CREATE_ENGINE, MSSQLQueries()):
             actual_response = []
             expected_response = [
                 {
@@ -270,9 +269,7 @@ async def test_advanced_rules_validation(advanced_rules, expected_validation_res
     async with create_source(
         MSSQLDataSource, database="xe", tables="*", schema="dbo"
     ) as source:
-        with patch.object(
-            Engine, "connect", return_value=ConnectionSync(MSSQLQueries())
-        ):
+        with mock_sync_db_engine(MSSQL_CREATE_ENGINE, MSSQLQueries()):
             validation_result = await MSSQLAdvancedRulesValidator(source).validate(
                 advanced_rules
             )
@@ -412,9 +409,7 @@ async def test_advanced_rules_validation_when_id_in_source_available(
     async with create_source(
         MSSQLDataSource, database="xe", tables="*", schema="dbo"
     ) as source:
-        with patch.object(
-            Engine, "connect", return_value=ConnectionSync(MSSQLQueries())
-        ):
+        with mock_sync_db_engine(MSSQL_CREATE_ENGINE, MSSQLQueries()):
             validation_result = await MSSQLAdvancedRulesValidator(source).validate(
                 advanced_rules
             )
@@ -559,9 +554,7 @@ async def test_get_docs_with_advanced_rules(filtering, expected_response):
     async with create_source(
         MSSQLDataSource, database="xe", tables="*", schema="dbo"
     ) as source:
-        with patch.object(
-            Engine, "connect", return_value=ConnectionSync(MSSQLQueries())
-        ):
+        with mock_sync_db_engine(MSSQL_CREATE_ENGINE, MSSQLQueries()):
             actual_response = []
 
             async for doc in source.get_docs(filtering=filtering):

--- a/app/connectors_service/tests/sources/test_oracle.py
+++ b/app/connectors_service/tests/sources/test_oracle.py
@@ -9,16 +9,16 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
-from sqlalchemy.engine import Engine
 
 from connectors.sources.oracle import OracleClient, OracleDataSource, OracleQueries
 from tests.sources.support import create_source
-from tests.sources.test_generic_database import ConnectionSync
+from tests.sources.test_generic_database import mock_sync_db_engine
 
 DSN_SID = "oracle+oracledb://admin:Password_123@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=9090))(CONNECT_DATA=(SID=xe)))"
 DSN_SERVICE_NAME = "oracle+oracledb://admin:Password_123@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=127.0.0.1)(PORT=9090))(CONNECT_DATA=(service_name=xe)))"
 SID = "sid"
 SERVICE_NAME = "service_name"
+ORACLE_CREATE_ENGINE = "connectors.sources.oracle.client.create_engine"
 
 
 @contextmanager
@@ -45,7 +45,7 @@ def oracle_client(**extras):
         client.close()
 
 
-@patch("connectors.sources.oracle.client.create_engine")
+@patch(ORACLE_CREATE_ENGINE)
 @pytest.mark.parametrize(
     "connection_source, DSN",
     [
@@ -65,7 +65,7 @@ def test_engine_in_thin_mode(mock_fun, connection_source, DSN):
         mock_fun.assert_called_with(DSN)
 
 
-@patch("connectors.sources.oracle.client.create_engine")
+@patch(ORACLE_CREATE_ENGINE)
 @pytest.mark.parametrize(
     "connection_source, DSN",
     [
@@ -93,9 +93,7 @@ def test_engine_in_thick_mode(mock_fun, connection_source, DSN):
 @pytest.mark.asyncio
 async def test_ping():
     async with create_source(OracleDataSource) as source:
-        with patch.object(
-            Engine, "connect", return_value=ConnectionSync(OracleQueries())
-        ):
+        with mock_sync_db_engine(ORACLE_CREATE_ENGINE, OracleQueries()):
             await source.ping()
 
 
@@ -110,9 +108,7 @@ async def test_get_docs():
         sid="xe",
         tables="*",
     ) as source:
-        with patch.object(
-            Engine, "connect", return_value=ConnectionSync(OracleQueries())
-        ):
+        with mock_sync_db_engine(ORACLE_CREATE_ENGINE, OracleQueries()):
             actual_response = []
             expected_response = [
                 {


### PR DESCRIPTION
<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

Several unit tests passed assertions but intermittently failed CI under the default 1s `pytest-fail-slow` threshold because they still hit real I/O:

- Oracle/MSSQL tests patched `Engine.connect` but still called real `create_engine`
- GraphQL `close()` accessed the cached `session` property, creating an `aiohttp.ClientSession` even when none was used
- Some GitLab `get_docs` integration tests left `get_work_items_group` unmocked, triggering real HTTP for epic fetches

This PR mocks `create_engine` via a shared test helper, guards GraphQL session teardown, stubs epic fetches where not under test, and adds a regression test for GraphQL close behavior.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [x] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4184
* https://github.com/elastic/connectors/pull/4442

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->