### PR TITLE
fix: read agent ssl config from protobuf Struct (#4084)

### DIFF
--- a/app/connectors_service/connectors/agent/config.py
+++ b/app/connectors_service/connectors/agent/config.py
@@ -120,8 +120,9 @@ class ConnectorsAgentConfigurationWrapper:
         # ESClient ignores verify_certs unless ssl is enabled.
         ssl_config = {"ssl": True}
 
-        verification_mode = ssl_source.get("verification_mode")
-        if verification_mode is not None:
+        verification_mode_field = ssl_source.fields.get("verification_mode")
+        if verification_mode_field is not None:
+            verification_mode = ssl_source["verification_mode"]
             verify_certs = verification_mode != "none"
             logger.debug(
                 f"Found ssl.verification_mode '{verification_mode}', "

--- a/app/connectors_service/tests/agent/test_agent_config.py
+++ b/app/connectors_service/tests/agent/test_agent_config.py
@@ -7,6 +7,8 @@ import warnings
 from unittest.mock import MagicMock, Mock
 
 from elastic_transport import SecurityWarning
+from google.protobuf import json_format
+from google.protobuf.struct_pb2 import Struct
 
 from connectors.agent.config import ConnectorsAgentConfigurationWrapper
 from connectors.es.client import ESClient
@@ -24,6 +26,18 @@ def prepare_unit_mock(fields, log_level):
     unit_mock.config.source.fields = fields
     unit_mock.config.source.__getitem__.side_effect = fields.__getitem__
 
+    unit_mock.log_level = log_level
+
+    return unit_mock
+
+
+def prepare_agent_proto_unit_mock(config_dict, log_level):
+    source = Struct()
+    json_format.ParseDict(config_dict, source)
+
+    unit_mock = Mock()
+    unit_mock.config = Mock()
+    unit_mock.config.source = source
     unit_mock.log_level = log_level
 
     return unit_mock
@@ -123,7 +137,7 @@ def test_try_update_with_ssl_verification_mode_none_disables_verify_certs():
     api_key = "lemme_in"
 
     config_wrapper = prepare_config_wrapper()
-    unit_mock = prepare_unit_mock(
+    unit_mock = prepare_agent_proto_unit_mock(
         {
             "hosts": hosts,
             "api_key": api_key,
@@ -151,7 +165,7 @@ def test_ssl_config_from_agent_applies_to_es_client_without_defaults():
     api_key = "lemme_in"
 
     config_wrapper = prepare_config_wrapper()
-    unit_mock = prepare_unit_mock(
+    unit_mock = prepare_agent_proto_unit_mock(
         {
             "hosts": hosts,
             "api_key": api_key,
@@ -179,7 +193,7 @@ def test_try_update_with_ssl_verification_mode_full_enables_verify_certs():
     api_key = "lemme_in"
 
     config_wrapper = prepare_config_wrapper()
-    unit_mock = prepare_unit_mock(
+    unit_mock = prepare_agent_proto_unit_mock(
         {
             "hosts": hosts,
             "api_key": api_key,


### PR DESCRIPTION
## Follows up on https://github.com/elastic/connectors/issues/4084


#4391 started honoring `ssl.verification_mode` from Elastic Agent output config, but
read the nested `ssl` block with dict-style `.get()`. Agent delivers output config as
protobuf `Struct` objects, so check-in crashed with `AttributeError` whenever an `ssl`
block was present (reported in devenv after #4391).

Read `verification_mode` via `fields` and bracket access, matching how other agent
config values are handled. Update SSL tests to use protobuf `Struct` sources like Agent
sends instead of plain dict mocks.

## Checklists

#### Pre-Review Checklist
- [x] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [x] this PR has a meaningful title
- [x] this PR links to all relevant github issues that it fixes or partially addresses
- [x] if there is no GH issue, please create it. Each PR should have a link to an issue
- [x] this PR has a thorough description
- [x] Covered the changes with automated tests
- [x] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [x] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

- [x] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

* https://github.com/elastic/connectors/pull/4391

## Release Note

Fixes a regression where connectors running under Elastic Agent crashed on check-in when
the Elasticsearch output policy included an `ssl` block. Agent SSL settings are now
read correctly from the protobuf config payload.