### PR TITLE
[8.19] fix: read agent ssl config from protobuf Struct (#4084) (#4456)

### DIFF
--- a/connectors/agent/config.py
+++ b/connectors/agent/config.py
@@ -132,8 +132,9 @@ class ConnectorsAgentConfigurationWrapper:
         # ESClient ignores verify_certs unless ssl is enabled.
         ssl_config = {"ssl": True}
 
-        verification_mode = ssl_source.get("verification_mode")
-        if verification_mode is not None:
+        verification_mode_field = ssl_source.fields.get("verification_mode")
+        if verification_mode_field is not None:
+            verification_mode = ssl_source["verification_mode"]
             verify_certs = verification_mode != "none"
             logger.debug(
                 f"Found ssl.verification_mode '{verification_mode}', "

--- a/tests/agent/test_agent_config.py
+++ b/tests/agent/test_agent_config.py
@@ -7,6 +7,8 @@ import warnings
 from unittest.mock import MagicMock, Mock
 
 from elastic_transport import SecurityWarning
+from google.protobuf import json_format
+from google.protobuf.struct_pb2 import Struct
 
 from connectors.agent.config import ConnectorsAgentConfigurationWrapper
 from connectors.es.client import ESClient
@@ -21,6 +23,18 @@ def prepare_unit_mock(fields, log_level):
     unit_mock.config.source.fields = fields
     unit_mock.config.source.__getitem__.side_effect = fields.__getitem__
 
+    unit_mock.log_level = log_level
+
+    return unit_mock
+
+
+def prepare_agent_proto_unit_mock(config_dict, log_level):
+    source = Struct()
+    json_format.ParseDict(config_dict, source)
+
+    unit_mock = Mock()
+    unit_mock.config = Mock()
+    unit_mock.config.source = source
     unit_mock.log_level = log_level
 
     return unit_mock
@@ -80,7 +94,7 @@ def test_try_update_with_ssl_verification_mode_none_disables_verify_certs():
     api_key = "lemme_in"
 
     config_wrapper = ConnectorsAgentConfigurationWrapper()
-    unit_mock = prepare_unit_mock(
+    unit_mock = prepare_agent_proto_unit_mock(
         {
             "hosts": hosts,
             "api_key": api_key,
@@ -101,7 +115,7 @@ def test_ssl_config_from_agent_applies_to_es_client_without_defaults():
     api_key = "lemme_in"
 
     config_wrapper = ConnectorsAgentConfigurationWrapper()
-    unit_mock = prepare_unit_mock(
+    unit_mock = prepare_agent_proto_unit_mock(
         {
             "hosts": hosts,
             "api_key": api_key,
@@ -125,7 +139,7 @@ def test_try_update_with_ssl_verification_mode_full_enables_verify_certs():
     api_key = "lemme_in"
 
     config_wrapper = ConnectorsAgentConfigurationWrapper()
-    unit_mock = prepare_unit_mock(
+    unit_mock = prepare_agent_proto_unit_mock(
         {
             "hosts": hosts,
             "api_key": api_key,


### PR DESCRIPTION
Backports the following commits to 8.19:
 - fix: read agent ssl config from protobuf Struct (#4084) (#4456)