### PR TITLE
Implement environment-based FIPS mode configuration

### DIFF
--- a/app/connectors_service/connectors/agent/cli.py
+++ b/app/connectors_service/connectors/agent/cli.py
@@ -6,6 +6,7 @@
 import asyncio
 import functools
 import signal
+import sys
 
 from elastic_agent_client.util.async_tools import (
     sleeps_for_retryable,
@@ -13,8 +14,13 @@ from elastic_agent_client.util.async_tools import (
 
 from connectors.agent.component import ConnectorsAgentComponent
 from connectors.agent.logger import get_logger
+from connectors.fips import FIPSModeError
 
 logger = get_logger("cli")
+
+# Exit code used when the component stops because of an error, so that Agent can
+# tell a failure apart from a clean shutdown
+FAILURE_EXIT_CODE = 1
 
 
 def main(args=None):
@@ -22,10 +28,20 @@ def main(args=None):
 
     It initialises an event loop, creates a component and runs the component.
     Additionally, signals are handled for graceful termination of the component.
+
+    Returns:
+        int: FAILURE_EXIT_CODE if the component stopped because of an error,
+            None if it shut down cleanly.
     """
     loop = asyncio.get_event_loop()
     logger.info("Running agent")
-    component = ConnectorsAgentComponent()
+
+    try:
+        component = ConnectorsAgentComponent()
+    except FIPSModeError as e:
+        # Raised while reading FIPS mode from the environment
+        logger.error(f"Cannot start connectors agent component: {e}")
+        return FAILURE_EXIT_CODE
 
     def _shutdown(signal_name):
         sleeps_for_retryable.cancel(signal_name)
@@ -34,11 +50,18 @@ def main(args=None):
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, functools.partial(_shutdown, sig.name))
 
-    return loop.run_until_complete(component.run())
+    try:
+        return loop.run_until_complete(component.run())
+    except FIPSModeError as e:
+        logger.error(f"Connectors agent component stopped: {e}")
+        return FAILURE_EXIT_CODE
+    except Exception as e:
+        logger.exception(f"Connectors agent component stopped with an error: {e}")
+        return FAILURE_EXIT_CODE
 
 
 if __name__ == "__main__":
     try:
-        main()
+        sys.exit(main())
     finally:
         logger.info("Bye")

--- a/app/connectors_service/connectors/agent/component.py
+++ b/app/connectors_service/connectors/agent/component.py
@@ -53,6 +53,10 @@ class ConnectorsAgentComponent:
         instance of Connectors Service with this configuration.
 
         Additionally services for handling Check-in and Actions will be started to implement the protocol correctly.
+
+        Raises:
+            Exception: Whatever killed the Connectors Service, so that the process
+                exits with a failure instead of looking like a clean shutdown.
         """
         logger.info("Starting connectors agent component")
         client = new_v2_from_reader(self.buffer, self.ver, self.opts)
@@ -71,6 +75,11 @@ class ConnectorsAgentComponent:
         )
 
         await self.multi_service.run()
+
+        # MultiService returns without re-raising when one of its services dies,
+        # so ask the Connectors Service whether it stopped because of an error
+        if self.connector_service_manager.fatal_error is not None:
+            raise self.connector_service_manager.fatal_error
 
     def stop(self, sig):
         """Shutdown everything running in the component.

--- a/app/connectors_service/connectors/agent/config.py
+++ b/app/connectors_service/connectors/agent/config.py
@@ -9,6 +9,7 @@ from connectors_sdk.utils import nested_get_from_dict
 
 from connectors.agent.logger import get_logger
 from connectors.config import add_defaults
+from connectors.fips import fips_mode_from_env
 
 logger = get_logger("config")
 
@@ -28,10 +29,13 @@ class ConnectorsAgentConfigurationWrapper:
         There's default config that allows us to run connectors service. When final
         configuration is reported these defaults will be merged with defaults from
         Connectors Service config and specific config coming from Agent.
+
+        Agent does not report FIPS mode, so it is read from the environment.
         """
         self._default_config = {
             "service": {
                 "log_level": "INFO",
+                "fips_mode": fips_mode_from_env(),
             },
             "connectors": [],
         }

--- a/app/connectors_service/connectors/agent/service_manager.py
+++ b/app/connectors_service/connectors/agent/service_manager.py
@@ -9,6 +9,10 @@ import connectors_sdk.logger
 
 import connectors.agent.logger
 from connectors.agent.logger import get_logger
+from connectors.fips import (
+    FIPSModeError,
+    apply_fips_mode,
+)
 from connectors.services.base import (
     ServiceAlreadyRunningError,
     get_services,
@@ -41,6 +45,32 @@ class ConnectorServiceManager:
         self._multi_service = None
         self._running = False
         self._sleeps = CancellableSleeps()
+        # Set when the run loop dies. The component reads it so that Agent sees a
+        # failure instead of a clean exit.
+        self.fatal_error = None
+
+    def _apply_fips_mode(self, config):
+        """Turn FIPS mode on when the configuration asks for it.
+
+        Thin wrapper over connectors.fips.apply_fips_mode that reports the failure
+        with the agent logger, which writes ECS logs that Agent can read.
+
+        Returns:
+            dict: The configuration to run with, with non-FIPS connectors removed
+                if FIPS mode is on. The input is left untouched.
+
+        Raises:
+            FIPSModeError: If FIPS mode is on but the system is not FIPS ready.
+        """
+        try:
+            return apply_fips_mode(config)
+        except FIPSModeError as e:
+            # Never fall back to non-FIPS crypto, failing to start is the safe outcome
+            logger.error(
+                f"FIPS mode is enabled but the system is not FIPS ready: {e} "
+                "Refusing to start connector services."
+            )
+            raise
 
     async def run(self):
         """Starts the running loop of the service.
@@ -62,10 +92,9 @@ class ConnectorServiceManager:
                 try:
                     logger.info("Starting connector services")
                     config = self._agent_config.get()
-                    self._multi_service = get_services(
-                        ["schedule", "sync_content", "sync_access_control", "cleanup"],
-                        config,
-                    )
+
+                    # Set the loggers up first, so that everything after this point
+                    # (FIPS messages included) is logged in the format Agent expects
                     log_level = config.get("service", {}).get(
                         "log_level", logging.INFO
                     )  # Log Level for connectors is managed like this
@@ -73,11 +102,20 @@ class ConnectorServiceManager:
                     # Log Level for agent connectors component itself
                     connectors.agent.logger.update_logger_level(log_level)
 
+                    config = self._apply_fips_mode(config)
+                    self._multi_service = get_services(
+                        ["schedule", "sync_content", "sync_access_control", "cleanup"],
+                        config,
+                    )
+
                     await self._multi_service.run()
                 except Exception as e:
                     logger.exception(
                         f"Error while running services in ConnectorServiceManager: {e}"
                     )
+                    # MultiService swallows the exception of the task that fails
+                    # first, so hand it over to the component explicitly
+                    self.fatal_error = e
                     raise
         finally:
             logger.info("Finished running, exiting")

--- a/app/connectors_service/connectors/fips.py
+++ b/app/connectors_service/connectors/fips.py
@@ -20,6 +20,9 @@ import ssl
 
 from connectors_sdk.logger import logger
 
+# Used to turn FIPS mode on when there is no config file, e.g. when running on Agent
+FIPS_MODE_ENV_VAR = "ELASTICSEARCH_CONNECTORS_FIPS_MODE"
+
 # Connectors that use NTLM or other non-FIPS-compliant algorithms
 NON_FIPS_COMPLIANT_CONNECTORS = frozenset(
     {
@@ -33,6 +36,36 @@ class FIPSModeError(Exception):
     """Raised when FIPS mode requirements are not met."""
 
     pass
+
+
+def fips_mode_from_env() -> bool:
+    """Read the FIPS mode setting from the environment.
+
+    The only accepted values are 'true' and 'false', case-insensitive. An unset
+    variable means FIPS mode is off.
+
+    Returns:
+        bool: True if the environment asks for FIPS mode, False otherwise.
+
+    Raises:
+        FIPSModeError: If the variable is set to anything else.
+    """
+    raw_value = os.environ.get(FIPS_MODE_ENV_VAR, "")
+    value = raw_value.strip().lower()
+
+    if value == "true":
+        return True
+
+    # Unset means off, which is the default everywhere else too
+    if value in ("", "false"):
+        return False
+
+    # A typo must not silently turn FIPS mode off on an image built for FIPS
+    msg = (
+        f"{FIPS_MODE_ENV_VAR} is set to '{raw_value}', which is not a valid value. "
+        "Use 'true' to turn FIPS mode on, or 'false' to turn it off."
+    )
+    raise FIPSModeError(msg)
 
 
 class FIPSConfig:
@@ -50,8 +83,7 @@ class FIPSConfig:
     def is_fips_mode_enabled(cls) -> bool:
         """Check if FIPS mode is enabled via configuration or environment."""
         if cls._fips_mode is None:
-            env_fips = os.environ.get("ELASTICSEARCH_CONNECTORS_FIPS_MODE", "").lower()
-            cls._fips_mode = env_fips == "true"
+            cls._fips_mode = fips_mode_from_env()
         return cls._fips_mode
 
     @classmethod
@@ -148,3 +180,42 @@ def validate_fips_mode():
         raise FIPSModeError(msg)
 
     logger.info(f"FIPS mode initialized. OpenSSL version: {ssl.OPENSSL_VERSION}")
+
+
+def apply_fips_mode(config: dict) -> dict:
+    """Turn FIPS mode on or off for this process, as the configuration asks.
+
+    This is the single place that puts FIPS mode into effect. Both entry points use
+    it: the standalone service (`connectors.service_cli`) and the service running
+    under Elastic Agent (`connectors.agent.service_manager`).
+
+    It does three things:
+    1. Store the requested mode, so the rest of the process can read it
+    2. Validate that the system's OpenSSL is in FIPS mode
+    3. Remove the connectors that cannot run under FIPS
+
+    Args:
+        config: The service configuration.
+
+    Returns:
+        dict: The configuration to run with. The input is left untouched. When FIPS
+            mode is on, the returned copy has the non-FIPS connectors removed.
+
+    Raises:
+        FIPSModeError: If FIPS mode is on but the system is not FIPS ready.
+    """
+    fips_enabled = config.get("service", {}).get("fips_mode", False)
+    FIPSConfig.set_fips_mode(fips_enabled)
+
+    # Always say which mode we are in. Silence here reads as "FIPS is on" to an
+    # operator who set the environment variable but got the value wrong.
+    logger.info(f"FIPS mode is {'enabled' if fips_enabled else 'disabled'}")
+
+    validate_fips_mode()
+
+    if not fips_enabled:
+        return config
+
+    return config | {
+        "sources": filter_fips_compliant_sources(config.get("sources", {}))
+    }

--- a/app/connectors_service/connectors/service_cli.py
+++ b/app/connectors_service/connectors/service_cli.py
@@ -27,10 +27,8 @@ from connectors import __version__
 from connectors.build_info import __build_info__
 from connectors.config import load_config
 from connectors.fips import (
-    FIPSConfig,
     FIPSModeError,
-    filter_fips_compliant_sources,
-    validate_fips_mode,
+    apply_fips_mode,
 )
 from connectors.preflight_check import PreflightCheck
 from connectors.services import get_services
@@ -133,16 +131,10 @@ def run(action, config_file, log_level, filebeat, service_type, uvloop):
         logger.exception(f"{msg}.\n{e}")
         raise ClickException(msg) from e
 
-    # Initialize FIPS mode from config
-    fips_enabled = config.get("service", {}).get("fips_mode", False)
-    FIPSConfig.set_fips_mode(fips_enabled)
-
-    # Enable FIPS mode if configured (validates OpenSSL)
+    # Enable FIPS mode if configured: validates OpenSSL and drops the connectors
+    # that cannot run under FIPS
     try:
-        validate_fips_mode()
-        if fips_enabled:
-            # Filter out non-FIPS-compliant connectors
-            config["sources"] = filter_fips_compliant_sources(config.get("sources", {}))
+        config = apply_fips_mode(config)
     except FIPSModeError as e:
         set_logger(logging.ERROR, filebeat=filebeat)
         msg = f"FIPS validation failed: {e}"

--- a/app/connectors_service/tests/agent/test_agent_config.py
+++ b/app/connectors_service/tests/agent/test_agent_config.py
@@ -3,15 +3,18 @@
 # or more contributor license agreements. Licensed under the Elastic License 2.0;
 # you may not use this file except in compliance with the Elastic License 2.0.
 #
+import os
 import warnings
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
+import pytest
 from elastic_transport import SecurityWarning
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Struct
 
 from connectors.agent.config import ConnectorsAgentConfigurationWrapper
 from connectors.es.client import ESClient
+from connectors.fips import FIPS_MODE_ENV_VAR, FIPSModeError
 
 CONNECTOR_ID = "test-connector"
 SERVICE_TYPE = "test-service-type"
@@ -430,3 +433,34 @@ def test_config_changed_when_connectors_did_not_change():
     }
 
     assert config_wrapper.config_changed(new_config) is False
+
+
+def test_fips_mode_is_off_when_env_var_is_not_set():
+    with patch.dict(os.environ, {}, clear=True):
+        config_wrapper = ConnectorsAgentConfigurationWrapper()
+
+    assert config_wrapper.get()["service"]["fips_mode"] is False
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", " true "])
+def test_fips_mode_is_on_when_env_var_is_true(value):
+    with patch.dict(os.environ, {FIPS_MODE_ENV_VAR: value}, clear=True):
+        config_wrapper = ConnectorsAgentConfigurationWrapper()
+
+    assert config_wrapper.get()["service"]["fips_mode"] is True
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", ""])
+def test_fips_mode_is_off_when_env_var_is_false(value):
+    with patch.dict(os.environ, {FIPS_MODE_ENV_VAR: value}, clear=True):
+        config_wrapper = ConnectorsAgentConfigurationWrapper()
+
+    assert config_wrapper.get()["service"]["fips_mode"] is False
+
+
+@pytest.mark.parametrize("value", ["ture", "enabled", "yes", "1"])
+def test_startup_fails_when_env_var_value_is_not_recognised(value):
+    """A typo must not silently turn FIPS mode off."""
+    with patch.dict(os.environ, {FIPS_MODE_ENV_VAR: value}, clear=True):
+        with pytest.raises(FIPSModeError):
+            ConnectorsAgentConfigurationWrapper()

--- a/app/connectors_service/tests/agent/test_cli.py
+++ b/app/connectors_service/tests/agent/test_cli.py
@@ -8,7 +8,8 @@ import os
 import signal
 from unittest.mock import AsyncMock, patch
 
-from connectors.agent.cli import main
+from connectors.agent.cli import FAILURE_EXIT_CODE, main
+from connectors.fips import FIPSModeError
 
 
 @patch("connectors.agent.cli.ConnectorsAgentComponent", return_value=AsyncMock())
@@ -26,3 +27,29 @@ def test_main_responds_to_sigterm(patch_component):
     main()
 
     loop.close()
+
+
+@patch("connectors.agent.cli.ConnectorsAgentComponent")
+def test_main_exits_with_failure_when_component_stops_with_an_error(patch_component):
+    component = AsyncMock()
+    component.run.side_effect = FIPSModeError("OpenSSL is not in FIPS mode")
+    patch_component.return_value = component
+
+    assert main() == FAILURE_EXIT_CODE
+
+
+@patch(
+    "connectors.agent.cli.ConnectorsAgentComponent",
+    side_effect=FIPSModeError("ELASTICSEARCH_CONNECTORS_FIPS_MODE is set to 'ture'"),
+)
+def test_main_exits_with_failure_when_fips_mode_cannot_be_read(patch_component):
+    assert main() == FAILURE_EXIT_CODE
+
+
+@patch("connectors.agent.cli.ConnectorsAgentComponent")
+def test_main_exits_with_failure_on_any_unexpected_error(patch_component):
+    component = AsyncMock()
+    component.run.side_effect = RuntimeError("something went wrong")
+    patch_component.return_value = component
+
+    assert main() == FAILURE_EXIT_CODE

--- a/app/connectors_service/tests/agent/test_component.py
+++ b/app/connectors_service/tests/agent/test_component.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from connectors.agent.component import ConnectorsAgentComponent
+from connectors.fips import FIPSModeError
 
 
 class StubMultiService:
@@ -43,3 +44,22 @@ async def test_try_update_without_auth_data(
 
     assert stub_multi_service.has_ran
     assert stub_multi_service.has_shutdown
+
+
+@pytest.mark.asyncio
+@patch("connectors.agent.component.MultiService", return_value=StubMultiService())
+@patch("connectors.agent.component.new_v2_from_reader", return_value=MagicMock())
+async def test_run_reraises_the_error_that_killed_the_connectors_service(
+    stub_multi_service, patch_new_v2_from_reader
+):
+    """MultiService swallows the first exception, the component must not."""
+    component = ConnectorsAgentComponent()
+    fatal_error = FIPSModeError("OpenSSL is not in FIPS mode")
+
+    async def fail_after_timeout():
+        await asyncio.sleep(0.1)
+        component.connector_service_manager.fatal_error = fatal_error
+        component.stop("SIGINT")
+
+    with pytest.raises(FIPSModeError):
+        await asyncio.gather(component.run(), fail_after_timeout())

--- a/app/connectors_service/tests/agent/test_service_manager.py
+++ b/app/connectors_service/tests/agent/test_service_manager.py
@@ -9,7 +9,16 @@ from unittest.mock import Mock, patch
 import pytest
 
 from connectors.agent.service_manager import ConnectorServiceManager
+from connectors.fips import FIPSConfig, FIPSModeError
 from connectors.services.base import ServiceAlreadyRunningError
+
+
+@pytest.fixture(autouse=True)
+def reset_fips_config():
+    """Reset FIPS config state before and after each test."""
+    FIPSConfig.reset()
+    yield
+    FIPSConfig.reset()
 
 
 @pytest.fixture(autouse=True)
@@ -23,6 +32,17 @@ def config_mock():
     }
 
     return config
+
+
+def _fips_config(fips_mode):
+    return {
+        "service": {"fips_mode": fips_mode},
+        "sources": {
+            "network_drive": "connectors.sources.network_drive:NetworkDriveDataSource",
+            "sharepoint_server": "connectors.sources.sharepoint.sharepoint_server:SharepointServerDataSource",
+            "slack": "connectors.sources.slack:SlackDataSource",
+        },
+    }
 
 
 class StubMultiService:
@@ -89,3 +109,81 @@ async def test_cannot_run_same_service_manager_twice(patch_get_services, config_
         # Execute task results to cause an exception to be raised if any
         for task in done:
             task.result()
+
+
+def test_apply_fips_mode_off_keeps_all_connectors(config_mock):
+    service_manager = ConnectorServiceManager(config_mock)
+
+    config = service_manager._apply_fips_mode(_fips_config(False))
+
+    assert FIPSConfig.is_fips_mode_enabled() is False
+    assert set(config["sources"]) == {"network_drive", "sharepoint_server", "slack"}
+
+
+@patch("connectors.fips.is_openssl_fips_mode", return_value=True)
+def test_apply_fips_mode_on_drops_non_fips_connectors(patch_openssl, config_mock):
+    service_manager = ConnectorServiceManager(config_mock)
+
+    config = service_manager._apply_fips_mode(_fips_config(True))
+
+    assert FIPSConfig.is_fips_mode_enabled() is True
+    assert set(config["sources"]) == {"slack"}
+
+
+@patch("connectors.fips.is_openssl_fips_mode", return_value=False)
+def test_apply_fips_mode_on_raises_when_system_is_not_fips_ready(
+    patch_openssl, config_mock
+):
+    service_manager = ConnectorServiceManager(config_mock)
+
+    with pytest.raises(FIPSModeError):
+        service_manager._apply_fips_mode(_fips_config(True))
+
+
+def test_apply_fips_mode_defaults_to_off_when_not_configured(config_mock):
+    service_manager = ConnectorServiceManager(config_mock)
+
+    config = service_manager._apply_fips_mode({"service": {}, "sources": {}})
+
+    assert FIPSConfig.is_fips_mode_enabled() is False
+    assert config["sources"] == {}
+
+
+@patch("connectors.fips.is_openssl_fips_mode", return_value=True)
+def test_apply_fips_mode_does_not_mutate_the_given_config(patch_openssl, config_mock):
+    service_manager = ConnectorServiceManager(config_mock)
+    original = _fips_config(True)
+
+    service_manager._apply_fips_mode(original)
+
+    assert set(original["sources"]) == {"network_drive", "sharepoint_server", "slack"}
+
+
+@pytest.mark.asyncio
+@patch("connectors.fips.is_openssl_fips_mode", return_value=False)
+@patch("connectors.agent.service_manager.get_services", return_value=StubMultiService())
+async def test_run_aborts_and_records_fatal_error_when_system_is_not_fips_ready(
+    patch_get_services, patch_openssl, config_mock
+):
+    config_mock.get.return_value = _fips_config(True)
+    service_manager = ConnectorServiceManager(config_mock)
+
+    with pytest.raises(FIPSModeError):
+        await service_manager.run()
+
+    assert isinstance(service_manager.fatal_error, FIPSModeError)
+    assert not patch_get_services.called
+
+
+@pytest.mark.asyncio
+@patch("connectors.agent.service_manager.get_services", return_value=StubMultiService())
+async def test_clean_shutdown_records_no_fatal_error(patch_get_services, config_mock):
+    service_manager = ConnectorServiceManager(config_mock)
+
+    async def stop_service_after_timeout():
+        await asyncio.sleep(0.1)
+        service_manager.stop()
+
+    await asyncio.gather(service_manager.run(), stop_service_after_timeout())
+
+    assert service_manager.fatal_error is None

--- a/app/connectors_service/tests/test_fips.py
+++ b/app/connectors_service/tests/test_fips.py
@@ -11,10 +11,13 @@ from unittest.mock import patch
 import pytest
 
 from connectors.fips import (
+    FIPS_MODE_ENV_VAR,
     NON_FIPS_COMPLIANT_CONNECTORS,
     FIPSConfig,
     FIPSModeError,
+    apply_fips_mode,
     filter_fips_compliant_sources,
+    fips_mode_from_env,
     is_connector_fips_compliant,
     is_openssl_fips_mode,
     validate_fips_mode,
@@ -272,3 +275,81 @@ class TestFIPSIntegration:
         FIPSConfig.set_fips_mode(False)
         # Should not raise any exception regardless of environment
         validate_fips_mode()
+
+
+class TestFIPSModeFromEnv:
+    """Tests for reading FIPS mode from the environment."""
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "True", "tRuE", " true "])
+    def test_true_turns_fips_mode_on(self, value):
+        with patch.dict(os.environ, {FIPS_MODE_ENV_VAR: value}):
+            assert fips_mode_from_env() is True
+
+    @pytest.mark.parametrize("value", ["false", "FALSE", "", "  "])
+    def test_false_and_empty_turn_fips_mode_off(self, value):
+        with patch.dict(os.environ, {FIPS_MODE_ENV_VAR: value}):
+            assert fips_mode_from_env() is False
+
+    def test_unset_variable_means_off(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert fips_mode_from_env() is False
+
+    @pytest.mark.parametrize("value", ["ture", "enabled", "yes", "1", "0"])
+    def test_unrecognised_value_raises(self, value):
+        """A typo must fail loudly instead of silently turning FIPS mode off."""
+        with patch.dict(os.environ, {FIPS_MODE_ENV_VAR: value}):
+            with pytest.raises(FIPSModeError) as exc_info:
+                fips_mode_from_env()
+            assert FIPS_MODE_ENV_VAR in str(exc_info.value)
+
+
+class TestApplyFIPSMode:
+    """Tests for apply_fips_mode, the shared entry point into FIPS mode."""
+
+    SOURCES = {
+        "github": "connectors.sources.github:GitHubDataSource",
+        "network_drive": "connectors.sources.network_drive:NASDataSource",
+        "sharepoint_server": "connectors.sources.sharepoint.sharepoint_server:SharepointServerDataSource",
+    }
+
+    def _config(self, fips_mode=None):
+        service = {} if fips_mode is None else {"fips_mode": fips_mode}
+        return {"service": service, "sources": dict(self.SOURCES)}
+
+    def test_fips_mode_off_keeps_all_sources(self):
+        config = apply_fips_mode(self._config(False))
+
+        assert FIPSConfig.is_fips_mode_enabled() is False
+        assert config["sources"] == self.SOURCES
+
+    def test_fips_mode_defaults_to_off_when_not_configured(self):
+        config = apply_fips_mode(self._config())
+
+        assert FIPSConfig.is_fips_mode_enabled() is False
+        assert config["sources"] == self.SOURCES
+
+    @patch("connectors.fips.is_openssl_fips_mode", return_value=True)
+    def test_fips_mode_on_drops_non_fips_sources(self, patch_openssl):
+        config = apply_fips_mode(self._config(True))
+
+        assert FIPSConfig.is_fips_mode_enabled() is True
+        assert set(config["sources"]) == {"github"}
+
+    @patch("connectors.fips.is_openssl_fips_mode", return_value=False)
+    def test_fips_mode_on_raises_when_openssl_is_not_fips(self, patch_openssl):
+        with pytest.raises(FIPSModeError):
+            apply_fips_mode(self._config(True))
+
+    @patch("connectors.fips.is_openssl_fips_mode", return_value=True)
+    def test_input_config_is_not_mutated(self, patch_openssl):
+        original = self._config(True)
+
+        apply_fips_mode(original)
+
+        assert original["sources"] == self.SOURCES
+
+    @patch("connectors.fips.is_openssl_fips_mode", return_value=True)
+    def test_missing_sources_key_is_tolerated(self, patch_openssl):
+        config = apply_fips_mode({"service": {"fips_mode": True}})
+
+        assert config["sources"] == {}


### PR DESCRIPTION
## Summary

<!--Provide a general description of the code changes in your pull request.
If the change relates to a specific issue, include the link at the top.

If this is an ad-hoc/trivial change and does not have a corresponding
issue, please describe your changes in enough details, so that reviewers
and other team members can understand the reasoning behind the pull request.-->

The service can already run in FIPS mode: it checks that OpenSSL is ready for FIPS and drops the two connectors that need NTLM (network drive and SharePoint Server). But that code lives in `service_cli.py`, which the agent does not use. The agent starts the service through `connectors/agent/`, and nothing there knows about FIPS.

We need it on elastic-agent for the new `elastic-agent-service-fips` image.

### What this changes

- `connectors/fips.py`: new `apply_fips_mode(config)`. Sets the mode, checks OpenSSL, drops the connectors that cannot run under FIPS. Both `service_cli.py` and `connectors/agent/service_manager.py` call it, so the rule lives in one place.
- The setting comes from `ELASTICSEARCH_CONNECTORS_FIPS_MODE`, because there is no config file on Agent and Agent does not report FIPS mode.
- Only `true` and `false` are accepted. A typo like `ture` stops the service instead of quietly turning FIPS mode off. Unset still means off.
- The mode is always logged at start: `FIPS mode is enabled` or `FIPS mode is disabled`.
- If FIPS mode is on but OpenSSL is not ready, the component now exits with code 1. Before, `MultiService` hid the error and it exited 0. This applies to any error that kills the service, not just FIPS.

Nothing changes when FIPS mode is off. All 31 connectors stay available.

## Checklists

<!--You can remove unrelated items from checklists below and/or add new
items that may help during the review.-->

#### Pre-Review Checklist
- [ ] this PR does NOT contain credentials of any kind, such as API keys or username/passwords (double check `config.yml.example`)
- [ ] this PR has a meaningful title
- [ ] this PR links to all relevant github issues that it fixes or partially addresses
- [ ] if there is no GH issue, please create it. Each PR should have a link to an issue
- [ ] this PR has a thorough description
- [ ] Covered the changes with automated tests
- [ ] Tested the changes locally
- [ ] Added a label for each target release version (example: `v7.13.2`, `v7.14.0`, `v8.0.0`)
- [ ] For bugfixes: backport safely to all minor branches still receiving patch releases
- [ ] Considered corresponding documentation changes
- [ ] Contributed any configuration settings changes to the configuration reference
- [ ] if you added or changed Rich Configurable Fields for a Native Connector, you made a corresponding PR in [Kibana](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts)

#### Changes Requiring Extra Attention

<!--Please call out any changes that require special attention from the
reviewers and/or increase the risk to availability or security of the
system after deployment. Remove the ones that don't apply.-->

- [ ] Security-related changes (encryption, TLS, SSRF, etc)
- [ ] New external service dependencies added.

## Related Pull Requests

<!--List any relevant PRs here or remove the section if this is a standalone PR.

* https://github.com/elastic/.../pull/123-->

## Release Note

<!--If you think this enhancement/fix should be included in the release notes,
please write a concise user-facing description of the change here.
You should also label the PR with `release_note` so the release notes
author(s) can easily look it up.-->
